### PR TITLE
D2: empty-state polish across sidebar, graph, trash

### DIFF
--- a/src/components/graph/GraphView.tsx
+++ b/src/components/graph/GraphView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { X } from 'lucide-react';
+import { EmptyGraphEmptyState } from '@/components/ui';
 import { safeInvoke } from '@/lib/ipc';
 import { useGraphStore, useNoteStore } from '@/stores';
 import { useNotes } from '@/hooks';
@@ -411,11 +412,8 @@ export function GraphView() {
           style={{ display: 'block', cursor: hoveredId ? 'pointer' : 'grab' }}
         />
         {graph && graph.nodes.length === 0 && !loading && (
-          <div
-            className="absolute inset-0 flex items-center justify-center text-sm"
-            style={{ color: 'var(--text-muted)' }}
-          >
-            No notes yet — create a note and add [[wiki-links]] to see the graph.
+          <div className="absolute inset-0 flex items-center justify-center">
+            <EmptyGraphEmptyState />
           </div>
         )}
       </div>

--- a/src/components/sidebar/BacklinksSection.tsx
+++ b/src/components/sidebar/BacklinksSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Link2, FileText, Calendar } from 'lucide-react';
 import { CollapsibleSection } from './CollapsibleSection';
+import { NoBacklinksEmptyState } from '@/components/ui';
 import { useNoteStore } from '@/stores';
 import { findBacklinks, readNote, type BacklinkInfo } from '@/lib';
 import type { NoteFile } from '@/types';
@@ -103,9 +104,7 @@ export function BacklinksSection({
             Scanning notes...
           </div>
         ) : backlinks.length === 0 ? (
-          <div className="py-2 text-xs" style={{ color: 'var(--text-muted)' }}>
-            No notes link to this note yet.
-          </div>
+          <NoBacklinksEmptyState />
         ) : (
           backlinks.map((backlink) => (
             <button

--- a/src/components/sidebar/MoveToFolderModal.tsx
+++ b/src/components/sidebar/MoveToFolderModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { X, Folder, FolderOpen, ChevronRight, Home } from 'lucide-react';
+import { EmptyState } from '@/components/ui';
 import type { FolderInfo } from '@/types';
 
 interface MoveToFolderModalProps {
@@ -169,9 +170,13 @@ export function MoveToFolderModal({
             ))}
 
             {folders.length === 0 && (
-              <div className="px-3 py-4 text-sm text-gray-500 dark:text-gray-400 text-center">
-                No folders yet. Create one first.
-              </div>
+              <EmptyState
+                icon={Folder}
+                heading="No folders yet"
+                message="Create a folder in the sidebar first, then move notes here."
+                variant="compact"
+                iconColor="text-gray-400 dark:text-gray-500"
+              />
             )}
           </div>
         </div>

--- a/src/components/sidebar/SidebarDailyList.tsx
+++ b/src/components/sidebar/SidebarDailyList.tsx
@@ -1,5 +1,7 @@
+import { Calendar } from 'lucide-react';
 import { SidebarSection } from './SidebarSection';
 import { DraggableNoteItem } from './DraggableNoteItem';
+import { EmptyState } from '@/components/ui';
 import type { NoteFile } from '@/types';
 
 interface SidebarDailyListProps {
@@ -54,9 +56,13 @@ export function SidebarDailyList({
     >
       <div className="px-3 space-y-1 min-h-[20px]">
         {sorted.length === 0 ? (
-          <p className="px-3 py-2 text-sm" style={{ color: 'var(--text-muted)' }}>
-            No daily notes yet
-          </p>
+          <EmptyState
+            icon={Calendar}
+            heading="No daily notes yet"
+            message="Click Today to start journaling."
+            variant="compact"
+            iconColor="text-gray-400 dark:text-gray-500"
+          />
         ) : (
           sorted.map((note) => (
             <DraggableNoteItem

--- a/src/components/sidebar/SidebarFolderTree.tsx
+++ b/src/components/sidebar/SidebarFolderTree.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { FolderPlus } from 'lucide-react';
+import { FolderPlus, Folder } from 'lucide-react';
 import { SidebarSection } from './SidebarSection';
 import { FolderTree } from './FolderTree';
+import { EmptyState } from '@/components/ui';
 import type { FolderInfo, NoteFile } from '@/types';
 
 interface SidebarFolderTreeProps {
@@ -105,9 +106,21 @@ export function SidebarFolderTree({
             getNoteTags={getNoteTags}
           />
         ) : (
-          <p className="px-3 py-2 text-sm" style={{ color: 'var(--text-muted)' }}>
-            No folders yet
-          </p>
+          <EmptyState
+            icon={Folder}
+            heading="No folders yet"
+            message="Create a folder to organize your notes."
+            actions={[
+              {
+                label: 'New Folder',
+                onClick: onNewFolder,
+                variant: 'secondary',
+                icon: FolderPlus,
+              },
+            ]}
+            variant="compact"
+            iconColor="text-gray-400 dark:text-gray-500"
+          />
         )}
       </div>
     </SidebarSection>

--- a/src/components/sidebar/TrashPopover.tsx
+++ b/src/components/sidebar/TrashPopover.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Trash2, Undo2, FileText, Calendar, Folder, X, GripHorizontal } from 'lucide-react';
+import { EmptyTrashEmptyState } from '@/components/ui';
 import type { TrashedNote } from '@/types';
 
 const POPOVER_WIDTH = 380;
@@ -209,12 +210,7 @@ export function TrashPopover({
 
       <div className="flex-1 overflow-y-auto">
         {trashedNotes.length === 0 ? (
-          <div className="px-4 py-8 text-center">
-            <Trash2 className="w-10 h-10 mx-auto mb-2" style={{ color: 'var(--text-muted)', opacity: 0.4 }} />
-            <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
-              Trash is empty
-            </p>
-          </div>
+          <EmptyTrashEmptyState />
         ) : (
           <ul className="divide-y" style={{ borderColor: 'var(--border-muted)' }}>
             {trashedNotes.map((note) => (

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,5 +1,5 @@
 import React, { RefAttributes } from 'react';
-import { LucideIcon, LucideProps } from 'lucide-react';
+import { LucideIcon, LucideProps, Link2, Trash2, Share2 } from 'lucide-react';
 
 interface EmptyStateAction {
   label: string;
@@ -289,6 +289,42 @@ export function ConnectCalendarEmptyState({
       ]}
       variant="card"
       iconColor="text-blue-400 dark:text-blue-500"
+    />
+  );
+}
+
+export function NoBacklinksEmptyState() {
+  return (
+    <EmptyState
+      icon={Link2}
+      heading="No backlinks yet"
+      message="When another note links to this one with [[wiki links]], it will show up here."
+      variant="compact"
+      iconColor="text-gray-400 dark:text-gray-500"
+    />
+  );
+}
+
+export function EmptyTrashEmptyState() {
+  return (
+    <EmptyState
+      icon={Trash2}
+      heading="Trash is empty"
+      message="Deleted notes and folders appear here for 7 days before being removed permanently."
+      variant="compact"
+      iconColor="text-gray-400 dark:text-gray-500"
+    />
+  );
+}
+
+export function EmptyGraphEmptyState() {
+  return (
+    <EmptyState
+      icon={Share2}
+      heading="Your graph is empty"
+      message="Create notes and connect them with [[wiki links]] to see your knowledge graph take shape."
+      variant="compact"
+      iconColor="text-gray-400 dark:text-gray-500"
     />
   );
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,6 +6,9 @@ export {
   NoEventsEmptyState,
   ConnectCalendarEmptyState,
   NoNotesEmptyState,
+  NoBacklinksEmptyState,
+  EmptyTrashEmptyState,
+  EmptyGraphEmptyState,
 } from './EmptyState';
 export {
   Skeleton,


### PR DESCRIPTION
## Summary
- Add `NoBacklinks`, `EmptyTrash`, `EmptyGraph` variants to the shared `EmptyState` component family
- Replace ad-hoc empty UI in sidebar (daily, folders, backlinks, move modal), trash popover, and graph view with consistent `EmptyState` variants

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (17/17)
- [x] `npm run build`
- [x] `npm run check:size` (app 393.6 KB / 103.2 KB gz, within 420/120 budget)
- [x] `cargo clippy --lib --all-targets -- -D warnings`
- [x] `cargo test --lib` (58/58)
