### PR TITLE
D3: QuickSwitcher upgrades (actions, recents, pins)

### DIFF
--- a/src/components/quick-switcher/QuickSwitcher.tsx
+++ b/src/components/quick-switcher/QuickSwitcher.tsx
@@ -644,9 +644,6 @@ export function QuickSwitcher() {
             <kbd>↵</kbd> open
           </span>
           <span>
-            <kbd>⇥</kbd> ??
-          </span>
-          <span>
             <kbd>esc</kbd> close
           </span>
         </div>

--- a/src/components/quick-switcher/QuickSwitcher.tsx
+++ b/src/components/quick-switcher/QuickSwitcher.tsx
@@ -1,15 +1,42 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
-import { Search, FileText, Calendar } from 'lucide-react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import {
+  Search,
+  FileText,
+  Calendar,
+  Star,
+  Settings as SettingsIcon,
+  Sun,
+  Plus,
+  FileStack,
+  Network,
+  Clock,
+  Keyboard,
+  History,
+  Pin,
+  Command as CommandIcon,
+} from 'lucide-react';
 import { useQuickSwitcherStore } from '@/stores/quickSwitcherStore';
 import { useNoteStore } from '@/stores/noteStore';
+import { useThemeStore } from '@/stores/themeStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useTimelineStore } from '@/stores/timelineStore';
+import { useGraphStore } from '@/stores/graphStore';
 import { useNotes } from '@/hooks/useNotes';
+import {
+  filterCommands,
+  commandCategoryLabel,
+  type QuickSwitcherCommand,
+} from './commands';
 import type { NoteFile } from '@/types';
 
 /**
  * Fuzzy match: checks if query characters appear in order within the title.
  * "mtg" matches "Meeting Notes"
  */
-function fuzzyMatch(query: string, title: string): { matches: boolean; indices: number[] } {
+function fuzzyMatch(
+  query: string,
+  title: string,
+): { matches: boolean; indices: number[] } {
   const indices: number[] = [];
   let queryIndex = 0;
   const lowerQuery = query.toLowerCase();
@@ -28,30 +55,25 @@ function fuzzyMatch(query: string, title: string): { matches: boolean; indices: 
   };
 }
 
-/**
- * Get display title from note file name
- */
 function getNoteTitle(noteFile: NoteFile): string {
-  // Strip .md extension
   return noteFile.name.replace(/\.md$/, '');
 }
 
-/**
- * Get note type label
- */
 function getNoteTypeLabel(noteFile: NoteFile): string {
   if (noteFile.isDaily) return 'Daily';
   if (noteFile.isWeekly) return 'Weekly';
   return 'Note';
 }
 
-/**
- * Highlight matched characters in the title
- */
-function HighlightedTitle({ title, indices }: { title: string; indices: number[] }) {
+function HighlightedTitle({
+  title,
+  indices,
+}: {
+  title: string;
+  indices: number[];
+}) {
   const chars = title.split('');
   const indexSet = new Set(indices);
-
   return (
     <span>
       {chars.map((char, i) => (
@@ -66,21 +88,47 @@ function HighlightedTitle({ title, indices }: { title: string; indices: number[]
   );
 }
 
-interface QuickSwitcherItemProps {
+/**
+ * Dispatch a synthetic Cmd+key event so we can reuse the existing global
+ * keyboard handlers (e.g. ShortcutHelpHost / template picker) without
+ * duplicating their state plumbing here.
+ */
+function dispatchModKey(key: string) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    metaKey: true,
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+}
+
+/** Discriminated union for unified keyboard navigation across rows. */
+type Row =
+  | { kind: 'note'; note: NoteFile; indices: number[]; isPinned?: boolean }
+  | { kind: 'command'; command: QuickSwitcherCommand; titleIndices: number[] }
+  | { kind: 'recent-search'; query: string };
+
+interface NoteRowProps {
   note: NoteFile;
   isSelected: boolean;
   matchIndices: number[];
+  isPinned: boolean;
   onClick: () => void;
   onMouseEnter: () => void;
+  onTogglePin: (e: React.MouseEvent) => void;
 }
 
-function QuickSwitcherItem({
+function NoteRow({
   note,
   isSelected,
   matchIndices,
+  isPinned,
   onClick,
   onMouseEnter,
-}: QuickSwitcherItemProps) {
+  onTogglePin,
+}: NoteRowProps) {
   const title = getNoteTitle(note);
   const typeLabel = getNoteTypeLabel(note);
 
@@ -101,69 +149,280 @@ function QuickSwitcherItem({
         <div className="quick-switcher-item-title">
           <HighlightedTitle title={title} indices={matchIndices} />
         </div>
+        <div className="quick-switcher-item-meta">{typeLabel}</div>
+      </div>
+      <button
+        type="button"
+        aria-label={isPinned ? 'Unpin note' : 'Pin note'}
+        className={`quick-switcher-pin ${isPinned ? 'quick-switcher-pin-active' : ''}`}
+        onClick={onTogglePin}
+        // Stop the parent button onClick handler firing when pin is clicked.
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <Star className="w-4 h-4" fill={isPinned ? 'currentColor' : 'none'} />
+      </button>
+    </button>
+  );
+}
+
+interface CommandRowProps {
+  command: QuickSwitcherCommand;
+  isSelected: boolean;
+  titleIndices: number[];
+  onClick: () => void;
+  onMouseEnter: () => void;
+}
+
+function commandIcon(id: string) {
+  switch (id) {
+    case 'open-settings':
+      return <SettingsIcon className="w-4 h-4" />;
+    case 'open-today':
+      return <Calendar className="w-4 h-4" />;
+    case 'new-note':
+      return <Plus className="w-4 h-4" />;
+    case 'new-note-from-template':
+      return <FileStack className="w-4 h-4" />;
+    case 'open-graph':
+      return <Network className="w-4 h-4" />;
+    case 'toggle-timeline':
+      return <Clock className="w-4 h-4" />;
+    case 'toggle-theme':
+      return <Sun className="w-4 h-4" />;
+    case 'shortcut-help':
+      return <Keyboard className="w-4 h-4" />;
+    default:
+      return <CommandIcon className="w-4 h-4" />;
+  }
+}
+
+function CommandRow({
+  command,
+  isSelected,
+  titleIndices,
+  onClick,
+  onMouseEnter,
+}: CommandRowProps) {
+  return (
+    <button
+      className={`quick-switcher-item quick-switcher-item-command ${isSelected ? 'quick-switcher-item-selected' : ''}`}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+    >
+      <div className="quick-switcher-item-icon quick-switcher-item-icon-command">
+        {commandIcon(command.id)}
+      </div>
+      <div className="quick-switcher-item-content">
+        <div className="quick-switcher-item-title">
+          <HighlightedTitle title={command.title} indices={titleIndices} />
+        </div>
         <div className="quick-switcher-item-meta">
-          {typeLabel}
+          {commandCategoryLabel(command.category)}
         </div>
       </div>
     </button>
   );
 }
 
+interface RecentSearchRowProps {
+  query: string;
+  isSelected: boolean;
+  onClick: () => void;
+  onMouseEnter: () => void;
+}
+
+function RecentSearchRow({
+  query,
+  isSelected,
+  onClick,
+  onMouseEnter,
+}: RecentSearchRowProps) {
+  return (
+    <button
+      className={`quick-switcher-item ${isSelected ? 'quick-switcher-item-selected' : ''}`}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+    >
+      <div className="quick-switcher-item-icon">
+        <History className="w-4 h-4" />
+      </div>
+      <div className="quick-switcher-item-content">
+        <div className="quick-switcher-item-title">{query}</div>
+        <div className="quick-switcher-item-meta">Recent search</div>
+      </div>
+    </button>
+  );
+}
+
+function SectionHeader({
+  label,
+  icon,
+}: {
+  label: string;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className="quick-switcher-section-header">
+      {icon}
+      <span>{label}</span>
+    </div>
+  );
+}
+
 export function QuickSwitcher() {
-  const { isOpen, close } = useQuickSwitcherStore();
+  const {
+    isOpen,
+    close,
+    recentSearches,
+    pinnedNoteIds,
+    addRecentSearch,
+    togglePinned,
+  } = useQuickSwitcherStore();
   const { recentNoteIds } = useNoteStore();
-  const { notes, loadNote } = useNotes();
+  const { notes, loadNote, loadDailyNote, createNote } = useNotes();
+  const { theme, setTheme } = useThemeStore();
+  const { setIsSettingsOpen } = useSettingsStore();
+  const { toggle: toggleTimeline } = useTimelineStore();
+  const { open: openGraph } = useGraphStore();
 
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Filter and sort notes based on query
-  const filteredNotes = useCallback(() => {
-    if (!query.trim()) {
-      // Show recent notes when query is empty
-      const recentNotes: NoteFile[] = [];
-      for (const id of recentNoteIds) {
-        const note = notes.find((n) => n.path === id);
-        if (note) recentNotes.push(note);
+  /**
+   * Compute the rendered rows + the section breakpoints used to inject
+   * headers between groups. Rows are kept flat so up/down navigation is a
+   * trivial index walk.
+   */
+  const { rows, headers } = useMemo(() => {
+    const rows: Row[] = [];
+    /** Map from row index → header to render BEFORE that row. */
+    const headers = new Map<number, { label: string; icon?: React.ReactNode }>();
+
+    const noteByPath = new Map(notes.map((n) => [n.path, n] as const));
+    const trimmed = query.trim();
+
+    if (!trimmed) {
+      // Empty input: pinned → recent notes → recent searches → quick actions.
+      const pinned = pinnedNoteIds
+        .map((id) => noteByPath.get(id))
+        .filter((n): n is NoteFile => Boolean(n));
+
+      if (pinned.length > 0) {
+        headers.set(rows.length, {
+          label: 'Pinned',
+          icon: <Pin className="w-3 h-3" />,
+        });
+        for (const note of pinned) {
+          rows.push({ kind: 'note', note, indices: [], isPinned: true });
+        }
       }
-      // Fill remaining slots with other notes
-      const remaining = notes
-        .filter((n) => !recentNoteIds.includes(n.path))
-        .slice(0, 7 - recentNotes.length);
-      return [...recentNotes, ...remaining].map((note) => ({
-        note,
-        indices: [] as number[],
-      }));
+
+      const pinnedSet = new Set(pinnedNoteIds);
+      const recents: NoteFile[] = [];
+      for (const id of recentNoteIds) {
+        if (pinnedSet.has(id)) continue;
+        const note = noteByPath.get(id);
+        if (note) recents.push(note);
+      }
+      // Pad up to 7 with "other" notes (excluding pinned + recents already shown).
+      const shown = new Set([
+        ...pinnedNoteIds,
+        ...recents.map((n) => n.path),
+      ]);
+      const padding = notes
+        .filter((n) => !shown.has(n.path))
+        .slice(0, Math.max(0, 7 - recents.length));
+      const recentRows = [...recents, ...padding];
+
+      if (recentRows.length > 0) {
+        headers.set(rows.length, { label: 'Recent notes' });
+        for (const note of recentRows) {
+          rows.push({
+            kind: 'note',
+            note,
+            indices: [],
+            isPinned: pinnedSet.has(note.path),
+          });
+        }
+      }
+
+      if (recentSearches.length > 0) {
+        headers.set(rows.length, {
+          label: 'Recent searches',
+          icon: <History className="w-3 h-3" />,
+        });
+        for (const q of recentSearches) {
+          rows.push({ kind: 'recent-search', query: q });
+        }
+      }
+
+      // Quick actions catalog (full list, in canonical order).
+      const allCommands = filterCommands('');
+      if (allCommands.length > 0) {
+        headers.set(rows.length, {
+          label: 'Quick actions',
+          icon: <CommandIcon className="w-3 h-3" />,
+        });
+        for (const c of allCommands) {
+          rows.push({
+            kind: 'command',
+            command: c.command,
+            titleIndices: c.titleIndices,
+          });
+        }
+      }
+    } else {
+      // Non-empty input: matching notes first, then matching commands.
+      const pinnedSet = new Set(pinnedNoteIds);
+      const noteMatches = notes
+        .map((note) => {
+          const title = getNoteTitle(note);
+          const m = fuzzyMatch(trimmed, title);
+          return { note, ...m };
+        })
+        .filter((r) => r.matches)
+        .sort((a, b) => {
+          const aStart = a.indices[0] === 0 ? 0 : 1;
+          const bStart = b.indices[0] === 0 ? 0 : 1;
+          return aStart - bStart;
+        });
+
+      for (const r of noteMatches) {
+        rows.push({
+          kind: 'note',
+          note: r.note,
+          indices: r.indices,
+          isPinned: pinnedSet.has(r.note.path),
+        });
+      }
+
+      const commandMatches = filterCommands(trimmed);
+      if (commandMatches.length > 0) {
+        headers.set(rows.length, {
+          label: 'Actions',
+          icon: <CommandIcon className="w-3 h-3" />,
+        });
+        for (const c of commandMatches) {
+          rows.push({
+            kind: 'command',
+            command: c.command,
+            titleIndices: c.titleIndices,
+          });
+        }
+      }
     }
 
-    // Fuzzy search by title (derived from name)
-    const matches = notes
-      .map((note) => {
-        const title = getNoteTitle(note);
-        const { matches, indices } = fuzzyMatch(query, title);
-        return { note, matches, indices };
-      })
-      .filter((item) => item.matches)
-      .sort((a, b) => {
-        // Prioritize matches at the start
-        const aStartMatch = a.indices[0] === 0 ? 0 : 1;
-        const bStartMatch = b.indices[0] === 0 ? 0 : 1;
-        return aStartMatch - bStartMatch;
-      });
+    return { rows, headers };
+  }, [query, notes, recentNoteIds, recentSearches, pinnedNoteIds]);
 
-    return matches.map(({ note, indices }) => ({ note, indices }));
-  }, [query, notes, recentNoteIds]);
-
-  const results = filteredNotes();
-
-  // Reset selection when query changes
+  // Reset selection when the visible result set changes.
   useEffect(() => {
     setSelectedIndex(0);
   }, [query]);
 
-  // Auto-focus input when opened
+  // Auto-focus input when opened.
   useEffect(() => {
     if (isOpen) {
       setQuery('');
@@ -172,15 +431,103 @@ export function QuickSwitcher() {
     }
   }, [isOpen]);
 
-  // Handle keyboard navigation
+  const runCommand = useCallback(
+    (id: string) => {
+      switch (id) {
+        case 'open-settings':
+          setIsSettingsOpen(true);
+          return;
+        case 'open-today': {
+          const today = new Date();
+          useNoteStore.getState().setSelectedDate(today);
+          loadDailyNote(today).catch((e) =>
+            console.error('[QuickSwitcher] loadDailyNote failed', e),
+          );
+          return;
+        }
+        case 'new-note':
+          createNote('Untitled').catch((e) =>
+            console.error('[QuickSwitcher] createNote failed', e),
+          );
+          return;
+        case 'new-note-from-template':
+          // Re-trigger the existing Cmd+T handler so the template picker
+          // (owned by Editor scope) opens without us having to duplicate it.
+          dispatchModKey('t');
+          return;
+        case 'toggle-timeline':
+          toggleTimeline();
+          return;
+        case 'toggle-theme': {
+          const next =
+            theme === 'light' ? 'dark' : theme === 'dark' ? 'system' : 'light';
+          setTheme(next);
+          return;
+        }
+        case 'shortcut-help':
+          dispatchModKey('/');
+          return;
+        case 'open-graph':
+          openGraph();
+          return;
+        default:
+          console.warn('[QuickSwitcher] unknown command', id);
+      }
+    },
+    [
+      setIsSettingsOpen,
+      loadDailyNote,
+      createNote,
+      toggleTimeline,
+      theme,
+      setTheme,
+      openGraph,
+    ],
+  );
+
+  const selectNote = useCallback(
+    async (note: NoteFile) => {
+      close();
+      try {
+        await loadNote(note);
+      } catch (error) {
+        console.error('[QuickSwitcher] Failed to load note:', error);
+      }
+    },
+    [close, loadNote],
+  );
+
+  const activate = useCallback(
+    (row: Row) => {
+      const trimmed = query.trim();
+      if (trimmed) addRecentSearch(trimmed);
+
+      switch (row.kind) {
+        case 'note':
+          void selectNote(row.note);
+          return;
+        case 'command':
+          close();
+          runCommand(row.command.id);
+          return;
+        case 'recent-search':
+          setQuery(row.query);
+          // Move focus back to the input so the user can keep typing.
+          setTimeout(() => inputRef.current?.focus(), 0);
+          return;
+      }
+    },
+    [query, addRecentSearch, selectNote, close, runCommand],
+  );
+
+  // Keyboard navigation.
   useEffect(() => {
     if (!isOpen) return;
-
     const handleKeyDown = (e: KeyboardEvent) => {
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
-          setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+          setSelectedIndex((i) => Math.min(i + 1, Math.max(rows.length - 1, 0)));
           break;
         case 'ArrowUp':
           e.preventDefault();
@@ -188,9 +535,7 @@ export function QuickSwitcher() {
           break;
         case 'Enter':
           e.preventDefault();
-          if (results[selectedIndex]) {
-            selectNote(results[selectedIndex].note);
-          }
+          if (rows[selectedIndex]) activate(rows[selectedIndex]);
           break;
         case 'Escape':
           e.preventDefault();
@@ -198,37 +543,26 @@ export function QuickSwitcher() {
           break;
       }
     };
-
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, results, selectedIndex, close]);
+  }, [isOpen, rows, selectedIndex, close, activate]);
 
-  // Click outside to close
+  // Click outside to close.
   useEffect(() => {
     if (!isOpen) return;
-
     const handleClickOutside = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
         close();
       }
     };
-
-    // Delay to avoid closing on the same click that opened
     setTimeout(() => {
       document.addEventListener('mousedown', handleClickOutside);
     }, 0);
-
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isOpen, close]);
-
-  const selectNote = async (noteFile: NoteFile) => {
-    close();
-    try {
-      await loadNote(noteFile);
-    } catch (_error) {
-      console.error('[QuickSwitcher] Failed to load note:', _error);
-    }
-  };
 
   if (!isOpen) return null;
 
@@ -241,35 +575,80 @@ export function QuickSwitcher() {
             ref={inputRef}
             type="text"
             className="quick-switcher-input"
-            placeholder="Search notes..."
+            placeholder="Search notes or run a command…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
         </div>
 
         <div className="quick-switcher-results">
-          {results.length === 0 ? (
-            <div className="quick-switcher-empty">
-              No notes found
-            </div>
+          {rows.length === 0 ? (
+            <div className="quick-switcher-empty">No matches</div>
           ) : (
-            results.map((result, index) => (
-              <QuickSwitcherItem
-                key={result.note.path}
-                note={result.note}
-                isSelected={index === selectedIndex}
-                matchIndices={result.indices}
-                onClick={() => selectNote(result.note)}
-                onMouseEnter={() => setSelectedIndex(index)}
-              />
-            ))
+            rows.map((row, index) => {
+              const header = headers.get(index);
+              const key =
+                row.kind === 'note'
+                  ? `note:${row.note.path}`
+                  : row.kind === 'command'
+                    ? `cmd:${row.command.id}`
+                    : `recent:${row.query}`;
+              return (
+                <div key={key}>
+                  {header && (
+                    <SectionHeader label={header.label} icon={header.icon} />
+                  )}
+                  {row.kind === 'note' && (
+                    <NoteRow
+                      note={row.note}
+                      isSelected={index === selectedIndex}
+                      matchIndices={row.indices}
+                      isPinned={!!row.isPinned}
+                      onClick={() => activate(row)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                      onTogglePin={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        togglePinned(row.note.path);
+                      }}
+                    />
+                  )}
+                  {row.kind === 'command' && (
+                    <CommandRow
+                      command={row.command}
+                      isSelected={index === selectedIndex}
+                      titleIndices={row.titleIndices}
+                      onClick={() => activate(row)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                    />
+                  )}
+                  {row.kind === 'recent-search' && (
+                    <RecentSearchRow
+                      query={row.query}
+                      isSelected={index === selectedIndex}
+                      onClick={() => activate(row)}
+                      onMouseEnter={() => setSelectedIndex(index)}
+                    />
+                  )}
+                </div>
+              );
+            })
           )}
         </div>
 
         <div className="quick-switcher-footer">
-          <span><kbd>↑↓</kbd> navigate</span>
-          <span><kbd>↵</kbd> open</span>
-          <span><kbd>esc</kbd> close</span>
+          <span>
+            <kbd>↑↓</kbd> navigate
+          </span>
+          <span>
+            <kbd>↵</kbd> open
+          </span>
+          <span>
+            <kbd>⇥</kbd> ??
+          </span>
+          <span>
+            <kbd>esc</kbd> close
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/quick-switcher/commands.test.ts
+++ b/src/components/quick-switcher/commands.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterCommands,
+  matchCommand,
+  QUICK_SWITCHER_COMMANDS,
+} from './commands';
+
+describe('QuickSwitcher command filter', () => {
+  it('returns the full catalog when the query is empty', () => {
+    const results = filterCommands('');
+    expect(results).toHaveLength(QUICK_SWITCHER_COMMANDS.length);
+    expect(results[0].command.id).toBe(QUICK_SWITCHER_COMMANDS[0].id);
+  });
+
+  it('filters by fuzzy match on the title and reports highlight indices', () => {
+    const results = filterCommands('settings');
+    const ids = results.map((r) => r.command.id);
+    expect(ids).toContain('open-settings');
+    const settings = results.find((r) => r.command.id === 'open-settings')!;
+    // "settings" appears verbatim in "Open Settings", so we expect indices for
+    // each matched character.
+    expect(settings.titleIndices.length).toBe('settings'.length);
+  });
+
+  it('matches via keywords without highlighting the title', () => {
+    // "dark" is a keyword for Toggle Theme but does not appear in the title.
+    const result = matchCommand('dark', {
+      id: 'toggle-theme',
+      title: 'Toggle Theme',
+      category: 'preferences',
+      keywords: ['theme', 'light', 'dark', 'appearance'],
+    });
+    expect(result.matches).toBe(true);
+    expect(result.titleIndices).toEqual([]);
+  });
+
+  it('rejects queries that do not appear in title or keywords', () => {
+    const results = filterCommands('zzzqqqxxx');
+    expect(results).toEqual([]);
+  });
+
+  it('preserves catalog order in filtered results', () => {
+    // Both "Open Today's Note" and "Open Settings" match a fuzzy "open".
+    const results = filterCommands('open');
+    const matchedOpenItems = results
+      .map((r) => r.command.id)
+      .filter((id) => id.startsWith('open-'));
+    // Catalog order has 'open-today' before 'open-settings'.
+    const todayIdx = matchedOpenItems.indexOf('open-today');
+    const settingsIdx = matchedOpenItems.indexOf('open-settings');
+    expect(todayIdx).toBeGreaterThanOrEqual(0);
+    expect(settingsIdx).toBeGreaterThanOrEqual(0);
+    expect(todayIdx).toBeLessThan(settingsIdx);
+  });
+});

--- a/src/components/quick-switcher/commands.ts
+++ b/src/components/quick-switcher/commands.ts
@@ -1,0 +1,161 @@
+/**
+ * Action command catalog for the QuickSwitcher.
+ *
+ * These are the typed commands the user can invoke from the same `⌘P` palette
+ * as note search. Keeping the data here (separate from the React component)
+ * lets us unit-test the filter logic without rendering anything.
+ */
+
+export type QuickSwitcherCommandCategory =
+  | 'navigation'
+  | 'notes'
+  | 'view'
+  | 'preferences'
+  | 'help'
+  | 'system';
+
+export interface QuickSwitcherCommand {
+  id: string;
+  title: string;
+  /** One-line description / keyboard hint shown on the right. */
+  category: QuickSwitcherCommandCategory;
+  /** Lower-cased haystack used by the fuzzy matcher. */
+  keywords?: string[];
+}
+
+/**
+ * Static command catalog. The handler for each id lives in QuickSwitcher.tsx
+ * (it needs hooks/stores), but the metadata is colocated here so it's easy to
+ * audit at a glance and to test the filtering rules in isolation.
+ *
+ * Order here is the canonical order shown when the input is empty.
+ */
+export const QUICK_SWITCHER_COMMANDS: readonly QuickSwitcherCommand[] = [
+  {
+    id: 'open-today',
+    title: "Open Today's Note",
+    category: 'notes',
+    keywords: ['today', 'daily', 'journal'],
+  },
+  {
+    id: 'new-note',
+    title: 'New Note',
+    category: 'notes',
+    keywords: ['create', 'new', 'note'],
+  },
+  {
+    id: 'new-note-from-template',
+    title: 'New Note from Template…',
+    category: 'notes',
+    keywords: ['template', 'new', 'create'],
+  },
+  {
+    id: 'open-graph',
+    title: 'Open Graph View',
+    category: 'view',
+    keywords: ['graph', 'connections', 'view'],
+  },
+  {
+    id: 'toggle-timeline',
+    title: 'Toggle Timeline',
+    category: 'view',
+    keywords: ['timeline', 'history', 'right panel'],
+  },
+  {
+    id: 'toggle-theme',
+    title: 'Toggle Theme',
+    category: 'preferences',
+    keywords: ['theme', 'light', 'dark', 'appearance'],
+  },
+  {
+    id: 'open-settings',
+    title: 'Open Settings',
+    category: 'preferences',
+    keywords: ['settings', 'preferences', 'config'],
+  },
+  {
+    id: 'shortcut-help',
+    title: 'Show Keyboard Shortcuts',
+    category: 'help',
+    keywords: ['shortcuts', 'help', 'keys'],
+  },
+];
+
+const CATEGORY_LABEL: Record<QuickSwitcherCommandCategory, string> = {
+  navigation: 'Navigation',
+  notes: 'Notes',
+  view: 'View',
+  preferences: 'Preferences',
+  help: 'Help',
+  system: 'System',
+};
+
+export function commandCategoryLabel(
+  cat: QuickSwitcherCommandCategory,
+): string {
+  return CATEGORY_LABEL[cat];
+}
+
+/**
+ * Fuzzy-match a query against a command. A command matches if every character
+ * in the query appears (in order) in either the title or any keyword token.
+ * Returns the indices of the matched characters within the title for
+ * highlighting; if the match came purely from keywords, the title is shown
+ * un-highlighted.
+ */
+export function matchCommand(
+  query: string,
+  command: QuickSwitcherCommand,
+): { matches: boolean; titleIndices: number[] } {
+  const trimmed = query.trim();
+  if (!trimmed) return { matches: true, titleIndices: [] };
+
+  const lowerQuery = trimmed.toLowerCase();
+  const titleResult = fuzzyChars(lowerQuery, command.title.toLowerCase());
+  if (titleResult.matches) {
+    return { matches: true, titleIndices: titleResult.indices };
+  }
+
+  // Fall back to keyword haystack — title indices stay empty so we don't
+  // pretend characters matched the visible title.
+  const keywordHaystack = (command.keywords ?? []).join(' ').toLowerCase();
+  if (keywordHaystack && fuzzyChars(lowerQuery, keywordHaystack).matches) {
+    return { matches: true, titleIndices: [] };
+  }
+
+  return { matches: false, titleIndices: [] };
+}
+
+function fuzzyChars(
+  query: string,
+  haystack: string,
+): { matches: boolean; indices: number[] } {
+  const indices: number[] = [];
+  let qi = 0;
+  for (let i = 0; i < haystack.length && qi < query.length; i++) {
+    if (haystack[i] === query[qi]) {
+      indices.push(i);
+      qi++;
+    }
+  }
+  return { matches: qi === query.length, indices };
+}
+
+/**
+ * Filter the command catalog by query. When the query is empty, every command
+ * is returned in its canonical order (caller decides whether to render them
+ * under a "Quick actions" header). When non-empty, matched commands are
+ * returned in catalog order — they always appear AFTER any matching notes in
+ * the final result list.
+ */
+export function filterCommands(
+  query: string,
+  commands: readonly QuickSwitcherCommand[] = QUICK_SWITCHER_COMMANDS,
+): { command: QuickSwitcherCommand; titleIndices: number[] }[] {
+  const out: { command: QuickSwitcherCommand; titleIndices: number[] }[] = [];
+  for (const command of commands) {
+    const { matches, titleIndices } = matchCommand(query, command);
+    if (matches) out.push({ command, titleIndices });
+  }
+  return out;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2569,6 +2569,66 @@ body {
   border-color: var(--border-primary, #3a404c);
 }
 
+/* Section headers between groups (Pinned / Recent notes / Quick actions / etc.) */
+.quick-switcher-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted, #7c8494);
+}
+
+/* Pin (star) button on note rows. Hidden until hover/focus/active. */
+.quick-switcher-pin {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  color: var(--text-muted, #7c8494);
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0;
+}
+
+.quick-switcher-item:hover .quick-switcher-pin,
+.quick-switcher-item-selected .quick-switcher-pin,
+.quick-switcher-pin-active {
+  opacity: 1;
+}
+
+.quick-switcher-pin-active {
+  color: var(--accent-primary, #5a7aa8);
+}
+
+.quick-switcher-pin:hover {
+  background: var(--bg-tertiary, #f6f7f9);
+  color: var(--accent-primary, #5a7aa8);
+}
+
+.dark .quick-switcher-pin:hover {
+  background: var(--bg-tertiary, #1a1d23);
+  color: var(--accent-light, #7090bc);
+}
+
+/* Distinct icon tint for action commands */
+.quick-switcher-item-icon-command {
+  background: color-mix(in srgb, var(--accent-primary, #5a7aa8) 10%, transparent);
+  color: var(--accent-primary, #5a7aa8);
+}
+
+.dark .quick-switcher-item-icon-command {
+  background: color-mix(in srgb, var(--accent-light, #7090bc) 18%, transparent);
+  color: var(--accent-light, #7090bc);
+}
+
 /* ==========================================================================
    Visual Polish - Premium Micro-interactions
    ========================================================================== */

--- a/src/stores/quickSwitcherStore.test.ts
+++ b/src/stores/quickSwitcherStore.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useQuickSwitcherStore,
+  QUICK_SWITCHER_RECENT_SEARCH_LIMIT,
+} from './quickSwitcherStore';
+
+describe('quickSwitcherStore', () => {
+  beforeEach(() => {
+    // Reset to a known clean slate. localStorage is jsdom-backed in tests,
+    // so we wipe the persisted slice too for hermetic runs.
+    localStorage.removeItem('moldavite-quick-switcher');
+    useQuickSwitcherStore.setState({
+      isOpen: false,
+      recentSearches: [],
+      pinnedNoteIds: [],
+    });
+  });
+
+  describe('recent searches', () => {
+    it('adds queries newest-first and deduplicates case-insensitively', () => {
+      const { addRecentSearch } = useQuickSwitcherStore.getState();
+      addRecentSearch('alpha');
+      addRecentSearch('beta');
+      addRecentSearch('Alpha'); // same as 'alpha'
+      expect(useQuickSwitcherStore.getState().recentSearches).toEqual([
+        'Alpha',
+        'beta',
+      ]);
+    });
+
+    it('caps the list at the configured limit', () => {
+      const { addRecentSearch } = useQuickSwitcherStore.getState();
+      const limit = QUICK_SWITCHER_RECENT_SEARCH_LIMIT;
+      // Push limit+2 distinct queries.
+      for (let i = 0; i < limit + 2; i++) addRecentSearch(`q-${i}`);
+      const recents = useQuickSwitcherStore.getState().recentSearches;
+      expect(recents).toHaveLength(limit);
+      // Most recent first.
+      expect(recents[0]).toBe(`q-${limit + 1}`);
+    });
+
+    it('persists recent searches to localStorage', () => {
+      useQuickSwitcherStore.getState().addRecentSearch('persisted');
+      const raw = localStorage.getItem('moldavite-quick-switcher');
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw ?? '{}');
+      expect(parsed.state.recentSearches).toContain('persisted');
+    });
+
+    it('ignores empty / whitespace queries', () => {
+      const { addRecentSearch } = useQuickSwitcherStore.getState();
+      addRecentSearch('');
+      addRecentSearch('   ');
+      expect(useQuickSwitcherStore.getState().recentSearches).toEqual([]);
+    });
+  });
+
+  describe('pinned notes', () => {
+    it('toggles a note id on and off', () => {
+      const { togglePinned, isPinned } = useQuickSwitcherStore.getState();
+
+      togglePinned('notes/foo.md');
+      expect(useQuickSwitcherStore.getState().pinnedNoteIds).toEqual([
+        'notes/foo.md',
+      ]);
+      expect(isPinned('notes/foo.md')).toBe(true);
+
+      togglePinned('notes/foo.md');
+      expect(useQuickSwitcherStore.getState().pinnedNoteIds).toEqual([]);
+      // `isPinned` is bound to a snapshot, so re-read from getState.
+      expect(useQuickSwitcherStore.getState().isPinned('notes/foo.md')).toBe(
+        false,
+      );
+    });
+
+    it('appends new pins without disturbing existing ones', () => {
+      const { togglePinned } = useQuickSwitcherStore.getState();
+      togglePinned('a.md');
+      togglePinned('b.md');
+      togglePinned('c.md');
+      expect(useQuickSwitcherStore.getState().pinnedNoteIds).toEqual([
+        'a.md',
+        'b.md',
+        'c.md',
+      ]);
+    });
+  });
+});

--- a/src/stores/quickSwitcherStore.ts
+++ b/src/stores/quickSwitcherStore.ts
@@ -1,15 +1,77 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+const MAX_RECENT_SEARCHES = 5;
 
 interface QuickSwitcherState {
   isOpen: boolean;
+  /** Last successful queries the user actually executed (most-recent first). */
+  recentSearches: string[];
+  /** Note ids the user has pinned for quick access. */
+  pinnedNoteIds: string[];
+
   open: () => void;
   close: () => void;
   toggle: () => void;
+
+  /** Push a query onto the recent-searches stack (dedup, capped at 5). */
+  addRecentSearch: (query: string) => void;
+  /** Forget every remembered search. */
+  clearRecentSearches: () => void;
+
+  /** Add or remove a note id from the pinned list. */
+  togglePinned: (noteId: string) => void;
+  isPinned: (noteId: string) => boolean;
 }
 
-export const useQuickSwitcherStore = create<QuickSwitcherState>((set) => ({
-  isOpen: false,
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
-  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
-}));
+export const useQuickSwitcherStore = create<QuickSwitcherState>()(
+  persist(
+    (set, get) => ({
+      isOpen: false,
+      recentSearches: [],
+      pinnedNoteIds: [],
+
+      open: () => set({ isOpen: true }),
+      close: () => set({ isOpen: false }),
+      toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+
+      addRecentSearch: (query) => {
+        const trimmed = query.trim();
+        if (!trimmed) return;
+        set((state) => {
+          const without = state.recentSearches.filter(
+            (q) => q.toLowerCase() !== trimmed.toLowerCase(),
+          );
+          return {
+            recentSearches: [trimmed, ...without].slice(0, MAX_RECENT_SEARCHES),
+          };
+        });
+      },
+
+      clearRecentSearches: () => set({ recentSearches: [] }),
+
+      togglePinned: (noteId) =>
+        set((state) => {
+          if (state.pinnedNoteIds.includes(noteId)) {
+            return {
+              pinnedNoteIds: state.pinnedNoteIds.filter((id) => id !== noteId),
+            };
+          }
+          return { pinnedNoteIds: [...state.pinnedNoteIds, noteId] };
+        }),
+
+      isPinned: (noteId) => get().pinnedNoteIds.includes(noteId),
+    }),
+    {
+      name: 'moldavite-quick-switcher',
+      storage: createJSONStorage(() => localStorage),
+      // Don't persist transient UI state.
+      partialize: (state) => ({
+        recentSearches: state.recentSearches,
+        pinnedNoteIds: state.pinnedNoteIds,
+      }),
+    },
+  ),
+);
+
+export const QUICK_SWITCHER_RECENT_SEARCH_LIMIT = MAX_RECENT_SEARCHES;


### PR DESCRIPTION
## Summary
- Action commands in the palette: Today, New Note, From Template, Graph, Timeline, Theme cycle, Settings, Shortcut help
- Recent searches section (last 5, persisted, deduped, ignores whitespace)
- Pinned notes section (hover-revealed star button on each row)
- Section headers: Pinned / Recent notes / Recent searches / Quick actions / Actions
- Updated keyboard footer: \`↑↓ navigate · ↵ open · esc close\`

Existing fuzzy match, ↑↓/Enter/Esc nav, recent notes, click-outside, daily/weekly/note category icons all preserved.

\"Rescan Forge\" command intentionally not added — that's coming with the Forge foundations PR; will append to the catalog there.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` (0 errors, 23 pre-existing warnings unchanged)
- [x] \`npm test\` 28/28 (+9 new tests across store + commands)
- [x] \`npm run build\` succeeds
- [x] \`npm run check:size\` app JS 401.7 KB / 105.5 KB gz (under 420/120 budget)
