### PR TITLE
D4: theme presets (Solarized, Dracula, Nord, Sepia, Gruvbox)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { fixNotePermissions } from './lib/fileSystem';
 import { useAutoLock } from './hooks';
 
 function App() {
-  const { theme } = useThemeStore();
+  const { theme, preset } = useThemeStore();
   const { fontSize, fontFamily, lineHeight, compactMode } = useSettingsStore();
   const { loadColors } = useNoteColorsStore();
 
@@ -27,19 +27,19 @@ function App() {
 
   // Apply theme on mount and when it changes
   useEffect(() => {
-    applyTheme(theme);
+    applyTheme(theme, preset);
 
     // Listen for system theme changes
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = () => {
       if (theme === 'system') {
-        applyTheme('system');
+        applyTheme('system', preset);
       }
     };
 
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
-  }, [theme]);
+  }, [theme, preset]);
 
   // Apply settings on mount and when they change
   useEffect(() => {

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -47,7 +47,7 @@ type SettingsTab = 'general' | 'appearance' | 'editor' | 'features' | 'sidebar' 
 
 export function SettingsModal() {
   const settingsStore = useSettingsStore();
-  const { theme, setTheme } = useThemeStore();
+  const { theme, setTheme, preset, setPreset } = useThemeStore();
   const { deleteExistingTemplate, updateExistingTemplate } = useTemplates();
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
 
@@ -88,7 +88,12 @@ export function SettingsModal() {
 
   const handleThemeChange = (newTheme: 'light' | 'dark' | 'system') => {
     setTheme(newTheme);
-    applyTheme(newTheme);
+    applyTheme(newTheme, preset);
+  };
+
+  const handlePresetChange = (newPreset: import('@/stores').ThemePreset) => {
+    setPreset(newPreset);
+    applyTheme(theme, newPreset);
   };
 
   const tabs: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
@@ -178,6 +183,8 @@ export function SettingsModal() {
               <AppearanceSection
                 theme={theme}
                 onThemeChange={handleThemeChange}
+                preset={preset}
+                onPresetChange={handlePresetChange}
               />
             )}
             {activeTab === 'editor' && (

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -2,16 +2,18 @@
  * AppearanceSection — Theme, typography, and layout preferences.
  */
 
-import { useSettingsStore, applyFontFamily } from '@/stores';
-import type { FontFamily } from '@/stores';
+import { useSettingsStore, applyFontFamily, PRESETS } from '@/stores';
+import type { FontFamily, ThemePreset } from '@/stores';
 import { InfoTooltip, Toggle } from '../common';
 
 export interface AppearanceSectionProps {
   theme: 'light' | 'dark' | 'system';
   onThemeChange: (theme: 'light' | 'dark' | 'system') => void;
+  preset: ThemePreset;
+  onPresetChange: (preset: ThemePreset) => void;
 }
 
-export function AppearanceSection({ theme, onThemeChange }: AppearanceSectionProps) {
+export function AppearanceSection({ theme, onThemeChange, preset, onPresetChange }: AppearanceSectionProps) {
   const settings = useSettingsStore();
   return (
     <div className="space-y-6">
@@ -44,6 +46,89 @@ export function AppearanceSection({ theme, onThemeChange }: AppearanceSectionPro
               {t.charAt(0).toUpperCase() + t.slice(1)}
             </button>
           ))}
+        </div>
+      </div>
+
+      {/* Color Preset Section */}
+      <div className="p-4 space-y-4" style={{ backgroundColor: 'var(--bg-panel)', borderRadius: 'var(--radius-md)' }}>
+        <div>
+          <div className="flex items-center gap-1">
+            <h3 className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+              Color preset
+            </h3>
+            <InfoTooltip text="Curated palettes layered on top of your light/dark choice. Some presets are designed for one mode only and fall back to Moldavite otherwise." />
+          </div>
+          <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+            Pick a palette for the editor and chrome
+          </p>
+        </div>
+        <div
+          role="radiogroup"
+          aria-label="Color preset"
+          className="grid gap-2"
+          style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))' }}
+        >
+          {PRESETS.map((p) => {
+            const selected = preset === p.id;
+            const badge =
+              p.coverage === 'dark'
+                ? 'Dark only'
+                : p.coverage === 'light'
+                ? 'Light only'
+                : null;
+            return (
+              <button
+                key={p.id}
+                role="radio"
+                aria-checked={selected}
+                onClick={() => onPresetChange(p.id)}
+                className="text-left p-3 transition-colors flex flex-col gap-2"
+                style={{
+                  backgroundColor: 'var(--bg-elevated)',
+                  border: selected
+                    ? '2px solid var(--accent-primary)'
+                    : '1px solid var(--border-default)',
+                  borderRadius: 'var(--radius-sm)',
+                  // Compensate the 1px-vs-2px border difference so cards don't jump.
+                  padding: selected ? 'calc(0.75rem - 1px)' : '0.75rem',
+                }}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                    {p.label}
+                  </span>
+                  {badge && (
+                    <span
+                      className="text-[10px] px-1.5 py-0.5"
+                      style={{
+                        backgroundColor: 'var(--bg-inset)',
+                        color: 'var(--text-tertiary)',
+                        borderRadius: 'var(--radius-sm)',
+                      }}
+                    >
+                      {badge}
+                    </span>
+                  )}
+                </div>
+                <div className="flex gap-1">
+                  {(['bg', 'surface', 'accent', 'text', 'border'] as const).map((k) => (
+                    <span
+                      key={k}
+                      aria-hidden
+                      className="inline-block"
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: 4,
+                        backgroundColor: p.swatches[k],
+                        border: '1px solid var(--border-muted)',
+                      }}
+                    />
+                  ))}
+                </div>
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -222,6 +222,289 @@
 }
 
 /* ===========================================
+   COLOR PRESETS
+
+   Each preset overrides a curated subset of the design tokens defined in
+   `:root` / `.dark` above. We deliberately do NOT redefine every token —
+   anything we don't override falls through to the Moldavite defaults, so
+   shadows, focus rings, and tertiary surfaces stay consistent.
+
+   Coverage:
+     - `default`  — Moldavite (both modes)            [no override needed]
+     - `solarized`— light + dark
+     - `dracula`  — dark only  (light falls back to default)
+     - `nord`     — dark only  (light falls back to default)
+     - `sepia`    — light only (dark falls back to default)
+     - `gruvbox`  — light + dark
+   =========================================== */
+
+/* ----- Solarized Light ----- */
+:root[data-theme='solarized'] {
+  --bg-base: #fdf6e3;
+  --bg-sidebar: #f5efdc;
+  --bg-editor: #fdf6e3;
+  --bg-panel: #eee8d5;
+  --bg-elevated: #fffbf0;
+  --bg-inset: #e6dfc4;
+
+  --border-default: #d8d2bd;
+  --border-strong: #b8b09c;
+  --border-muted: #e6dfc4;
+
+  --text-primary: #073642;
+  --text-secondary: #586e75;
+  --text-tertiary: #657b83;
+  --text-muted: #93a1a1;
+
+  --accent-primary: #268bd2;
+  --accent-hover: #3aa0e8;
+  --accent-active: #1d6fa8;
+  --accent-muted: #859900;
+  --accent-subtle: rgba(38, 139, 210, 0.12);
+
+  --syntax-bold: #b58900;
+  --syntax-italic: #2aa198;
+  --syntax-h1: #073642;
+  --syntax-h2: #586e75;
+  --syntax-h3: #cb4b16;
+  --syntax-code: #d33682;
+  --syntax-link: #268bd2;
+  --syntax-highlight: rgba(181, 137, 0, 0.18);
+
+  --hover-overlay: rgba(7, 54, 66, 0.05);
+  --active-overlay: rgba(7, 54, 66, 0.08);
+  --focus-ring: rgba(38, 139, 210, 0.4);
+}
+
+/* ----- Solarized Dark ----- */
+:root[data-theme='solarized'].dark {
+  --bg-base: #002b36;
+  --bg-sidebar: #073642;
+  --bg-editor: #002b36;
+  --bg-panel: #073642;
+  --bg-elevated: #0a3a47;
+  --bg-inset: #00222b;
+
+  --border-default: #143845;
+  --border-strong: #1e4a59;
+  --border-muted: #0d3340;
+
+  --text-primary: #eee8d5;
+  --text-secondary: #93a1a1;
+  --text-tertiary: #839496;
+  --text-muted: #586e75;
+
+  --accent-primary: #2aa198;
+  --accent-hover: #3cb6ad;
+  --accent-active: #1f8a82;
+  --accent-muted: rgba(42, 161, 152, 0.25);
+  --accent-subtle: rgba(42, 161, 152, 0.15);
+
+  --syntax-bold: #b58900;
+  --syntax-italic: #2aa198;
+  --syntax-h1: #eee8d5;
+  --syntax-h2: #93a1a1;
+  --syntax-h3: #cb4b16;
+  --syntax-code: #d33682;
+  --syntax-link: #268bd2;
+  --syntax-highlight: rgba(181, 137, 0, 0.18);
+
+  --hover-overlay: rgba(238, 232, 213, 0.05);
+  --active-overlay: rgba(238, 232, 213, 0.08);
+  --focus-ring: rgba(42, 161, 152, 0.4);
+}
+
+/* ----- Dracula (dark only) ----- */
+:root[data-theme='dracula'].dark {
+  --bg-base: #282a36;
+  --bg-sidebar: #21222c;
+  --bg-editor: #282a36;
+  --bg-panel: #21222c;
+  --bg-elevated: #383a4a;
+  --bg-inset: #1e1f29;
+
+  --border-default: #44475a;
+  --border-strong: #6272a4;
+  --border-muted: #2f3142;
+
+  --text-primary: #f8f8f2;
+  --text-secondary: #d6d6c2;
+  --text-tertiary: #9999a8;
+  --text-muted: #6272a4;
+
+  --accent-primary: #bd93f9;
+  --accent-hover: #caa6fb;
+  --accent-active: #a37cf0;
+  --accent-muted: rgba(189, 147, 249, 0.25);
+  --accent-subtle: rgba(189, 147, 249, 0.15);
+
+  --syntax-bold: #ff79c6;
+  --syntax-italic: #f1fa8c;
+  --syntax-h1: #bd93f9;
+  --syntax-h2: #ff79c6;
+  --syntax-h3: #ffb86c;
+  --syntax-code: #50fa7b;
+  --syntax-link: #8be9fd;
+  --syntax-highlight: rgba(241, 250, 140, 0.2);
+
+  --hover-overlay: rgba(248, 248, 242, 0.05);
+  --active-overlay: rgba(248, 248, 242, 0.08);
+  --focus-ring: rgba(189, 147, 249, 0.4);
+}
+
+/* ----- Nord (dark only) ----- */
+:root[data-theme='nord'].dark {
+  --bg-base: #2e3440;
+  --bg-sidebar: #292e39;
+  --bg-editor: #2e3440;
+  --bg-panel: #3b4252;
+  --bg-elevated: #434c5e;
+  --bg-inset: #252a33;
+
+  --border-default: #434c5e;
+  --border-strong: #4c566a;
+  --border-muted: #353b48;
+
+  --text-primary: #eceff4;
+  --text-secondary: #d8dee9;
+  --text-tertiary: #a8b1c0;
+  --text-muted: #6b7385;
+
+  --accent-primary: #88c0d0;
+  --accent-hover: #99cddb;
+  --accent-active: #74b0c2;
+  --accent-muted: rgba(136, 192, 208, 0.25);
+  --accent-subtle: rgba(136, 192, 208, 0.15);
+
+  --syntax-bold: #88c0d0;
+  --syntax-italic: #b48ead;
+  --syntax-h1: #eceff4;
+  --syntax-h2: #81a1c1;
+  --syntax-h3: #ebcb8b;
+  --syntax-code: #a3be8c;
+  --syntax-link: #88c0d0;
+  --syntax-highlight: rgba(235, 203, 139, 0.2);
+
+  --hover-overlay: rgba(236, 239, 244, 0.05);
+  --active-overlay: rgba(236, 239, 244, 0.08);
+  --focus-ring: rgba(136, 192, 208, 0.4);
+}
+
+/* ----- Sepia (light only) ----- */
+:root[data-theme='sepia'] {
+  --bg-base: #f4ecd8;
+  --bg-sidebar: #ede2c8;
+  --bg-editor: #fbf4e0;
+  --bg-panel: #ede2c8;
+  --bg-elevated: #fbf4e0;
+  --bg-inset: #e3d6b8;
+
+  --border-default: #d8c8a8;
+  --border-strong: #b8a888;
+  --border-muted: #e3d6b8;
+
+  --text-primary: #3b2a1a;
+  --text-secondary: #5a4530;
+  --text-tertiary: #7a604a;
+  --text-muted: #9a8268;
+
+  --accent-primary: #8b5a2b;
+  --accent-hover: #a06a35;
+  --accent-active: #704720;
+  --accent-muted: #b58860;
+  --accent-subtle: rgba(139, 90, 43, 0.12);
+
+  --syntax-bold: #8b5a2b;
+  --syntax-italic: #a06a35;
+  --syntax-h1: #3b2a1a;
+  --syntax-h2: #5a4530;
+  --syntax-h3: #b07020;
+  --syntax-code: #704720;
+  --syntax-link: #8b5a2b;
+  --syntax-highlight: rgba(176, 112, 32, 0.2);
+
+  --hover-overlay: rgba(59, 42, 26, 0.05);
+  --active-overlay: rgba(59, 42, 26, 0.08);
+  --focus-ring: rgba(139, 90, 43, 0.35);
+}
+
+/* ----- Gruvbox Light ----- */
+:root[data-theme='gruvbox'] {
+  --bg-base: #fbf1c7;
+  --bg-sidebar: #f2e5bc;
+  --bg-editor: #fbf1c7;
+  --bg-panel: #ebdbb2;
+  --bg-elevated: #fdf4d0;
+  --bg-inset: #e6d8a8;
+
+  --border-default: #d5c4a1;
+  --border-strong: #bdae93;
+  --border-muted: #e6d8a8;
+
+  --text-primary: #3c3836;
+  --text-secondary: #504945;
+  --text-tertiary: #665c54;
+  --text-muted: #7c6f64;
+
+  --accent-primary: #af3a03;
+  --accent-hover: #d65d0e;
+  --accent-active: #8a2e02;
+  --accent-muted: #b57614;
+  --accent-subtle: rgba(175, 58, 3, 0.12);
+
+  --syntax-bold: #9d0006;
+  --syntax-italic: #79740e;
+  --syntax-h1: #3c3836;
+  --syntax-h2: #504945;
+  --syntax-h3: #b57614;
+  --syntax-code: #076678;
+  --syntax-link: #af3a03;
+  --syntax-highlight: rgba(181, 118, 20, 0.22);
+
+  --hover-overlay: rgba(60, 56, 54, 0.05);
+  --active-overlay: rgba(60, 56, 54, 0.08);
+  --focus-ring: rgba(175, 58, 3, 0.35);
+}
+
+/* ----- Gruvbox Dark ----- */
+:root[data-theme='gruvbox'].dark {
+  --bg-base: #282828;
+  --bg-sidebar: #1d2021;
+  --bg-editor: #282828;
+  --bg-panel: #32302f;
+  --bg-elevated: #3c3836;
+  --bg-inset: #1d2021;
+
+  --border-default: #504945;
+  --border-strong: #665c54;
+  --border-muted: #3c3836;
+
+  --text-primary: #ebdbb2;
+  --text-secondary: #d5c4a1;
+  --text-tertiary: #bdae93;
+  --text-muted: #928374;
+
+  --accent-primary: #fe8019;
+  --accent-hover: #ff9540;
+  --accent-active: #d65d0e;
+  --accent-muted: rgba(254, 128, 25, 0.25);
+  --accent-subtle: rgba(254, 128, 25, 0.15);
+
+  --syntax-bold: #fb4934;
+  --syntax-italic: #b8bb26;
+  --syntax-h1: #fabd2f;
+  --syntax-h2: #fe8019;
+  --syntax-h3: #d3869b;
+  --syntax-code: #8ec07c;
+  --syntax-link: #83a598;
+  --syntax-highlight: rgba(250, 189, 47, 0.18);
+
+  --hover-overlay: rgba(235, 219, 178, 0.05);
+  --active-overlay: rgba(235, 219, 178, 0.08);
+  --focus-ring: rgba(254, 128, 25, 0.4);
+}
+
+/* ===========================================
    BASE STYLES
    =========================================== */
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -22,7 +22,8 @@
 
 // Core stores
 export { useNoteStore } from './noteStore';
-export { useThemeStore, applyTheme } from './themeStore';
+export { useThemeStore, applyTheme, PRESETS } from './themeStore';
+export type { BaseMode, ThemePreset, PresetCoverage, PresetMeta } from './themeStore';
 export { useToastStore } from './toastStore';
 export type { Toast, ToastType } from './toastStore';
 

--- a/src/stores/themeStore.test.ts
+++ b/src/stores/themeStore.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const STORAGE_KEY = 'moldavite-theme';
+
+/**
+ * The persist middleware hydrates storage at store-creation time. To exercise
+ * different persisted states we have to seed `localStorage` first, then force
+ * a fresh module load via `vi.resetModules()`.
+ */
+async function loadStoreFresh() {
+  vi.resetModules();
+  const mod = await import('./themeStore');
+  // persist hydrates asynchronously in zustand v5 — wait for it.
+  await mod.useThemeStore.persist.rehydrate();
+  return mod;
+}
+
+describe('themeStore persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('migrates a v0/v1 persisted state ({ theme: "dark" }) to the new schema', async () => {
+    // Old shape: only `theme`, no version, no preset.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ state: { theme: 'dark' } }));
+
+    const { useThemeStore } = await loadStoreFresh();
+    const state = useThemeStore.getState();
+
+    expect(state.baseMode).toBe('dark');
+    expect(state.preset).toBe('default');
+    // back-compat alias still mirrors baseMode
+    expect(state.theme).toBe('dark');
+  });
+
+  it('falls back to defaults when persisted state is missing', async () => {
+    const { useThemeStore } = await loadStoreFresh();
+    const state = useThemeStore.getState();
+    expect(state.baseMode).toBe('system');
+    expect(state.preset).toBe('default');
+  });
+
+  it('rejects unknown preset ids during migration', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ state: { theme: 'light', preset: 'totally-fake' } })
+    );
+
+    const { useThemeStore } = await loadStoreFresh();
+    const state = useThemeStore.getState();
+    expect(state.baseMode).toBe('light');
+    expect(state.preset).toBe('default');
+  });
+
+  it('preserves a valid preset across reload', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ state: { baseMode: 'light', preset: 'dracula' }, version: 2 })
+    );
+
+    const { useThemeStore } = await loadStoreFresh();
+    const state = useThemeStore.getState();
+    expect(state.preset).toBe('dracula');
+    expect(state.baseMode).toBe('light');
+  });
+});

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,33 +1,201 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-type Theme = 'light' | 'dark' | 'system';
+/**
+ * Theme model — split into two orthogonal axes:
+ *   - baseMode: light / dark / system (controls the `dark` class)
+ *   - preset:   the palette family (controls the `data-theme` attribute)
+ *
+ * Each preset supplies tokens for one or both base modes. When a preset
+ * doesn't fit a given base mode (e.g. Dracula in light), the CSS falls
+ * back to the `default` palette. We don't try to invent palettes that
+ * weren't designed for a given mode — designers chose them deliberately.
+ */
+export type BaseMode = 'light' | 'dark' | 'system';
+
+export type ThemePreset =
+  | 'default'
+  | 'solarized'
+  | 'dracula'
+  | 'nord'
+  | 'sepia'
+  | 'gruvbox';
+
+/**
+ * Coverage descriptor for the picker UI.
+ * - `both`  — the preset has both light and dark token blocks
+ * - `dark`  — dark-only; the preset falls back to `default` in light mode
+ * - `light` — light-only; the preset falls back to `default` in dark mode
+ */
+export type PresetCoverage = 'both' | 'dark' | 'light';
+
+export interface PresetMeta {
+  id: ThemePreset;
+  label: string;
+  coverage: PresetCoverage;
+  /** 5 representative swatches: bg, surface, accent, text, border. */
+  swatches: {
+    bg: string;
+    surface: string;
+    accent: string;
+    text: string;
+    border: string;
+  };
+}
+
+export const PRESETS: PresetMeta[] = [
+  {
+    id: 'default',
+    label: 'Moldavite',
+    coverage: 'both',
+    swatches: {
+      bg: '#f0f5f2',
+      surface: '#ffffff',
+      accent: '#2d5a3d',
+      text: '#0a0f0d',
+      border: '#c4d4c9',
+    },
+  },
+  {
+    id: 'solarized',
+    label: 'Solarized',
+    coverage: 'both',
+    swatches: {
+      bg: '#fdf6e3',
+      surface: '#eee8d5',
+      accent: '#268bd2',
+      text: '#073642',
+      border: '#d8d2bd',
+    },
+  },
+  {
+    id: 'dracula',
+    label: 'Dracula',
+    coverage: 'dark',
+    swatches: {
+      bg: '#282a36',
+      surface: '#383a4a',
+      accent: '#bd93f9',
+      text: '#f8f8f2',
+      border: '#44475a',
+    },
+  },
+  {
+    id: 'nord',
+    label: 'Nord',
+    coverage: 'dark',
+    swatches: {
+      bg: '#2e3440',
+      surface: '#3b4252',
+      accent: '#88c0d0',
+      text: '#eceff4',
+      border: '#434c5e',
+    },
+  },
+  {
+    id: 'sepia',
+    label: 'Sepia',
+    coverage: 'light',
+    swatches: {
+      bg: '#f4ecd8',
+      surface: '#fbf4e0',
+      accent: '#8b5a2b',
+      text: '#3b2a1a',
+      border: '#d8c8a8',
+    },
+  },
+  {
+    id: 'gruvbox',
+    label: 'Gruvbox',
+    coverage: 'both',
+    swatches: {
+      bg: '#fbf1c7',
+      surface: '#f2e5bc',
+      accent: '#af3a03',
+      text: '#3c3836',
+      border: '#d5c4a1',
+    },
+  },
+];
+
+const PRESET_IDS = PRESETS.map((p) => p.id) as ThemePreset[];
+
+export const isThemePreset = (v: unknown): v is ThemePreset =>
+  typeof v === 'string' && (PRESET_IDS as string[]).includes(v);
 
 interface ThemeState {
-  theme: Theme;
-  setTheme: (theme: Theme) => void;
+  /** Light/dark/system base mode (drives the `dark` class). */
+  baseMode: BaseMode;
+  /** Color preset (drives the `data-theme` attribute). */
+  preset: ThemePreset;
+
+  setBaseMode: (mode: BaseMode) => void;
+  setPreset: (preset: ThemePreset) => void;
+
+  /**
+   * Back-compat shim. Existing call sites use `theme` and `setTheme` for the
+   * light/dark/system axis. Keep them working as aliases for `baseMode`.
+   */
+  theme: BaseMode;
+  setTheme: (mode: BaseMode) => void;
 }
 
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set) => ({
+      baseMode: 'system',
+      preset: 'default',
       theme: 'system',
-      setTheme: (theme) => set({ theme }),
+      setBaseMode: (mode) => set({ baseMode: mode, theme: mode }),
+      setPreset: (preset) => set({ preset }),
+      setTheme: (mode) => set({ baseMode: mode, theme: mode }),
     }),
     {
       name: 'moldavite-theme',
+      version: 2,
+      // v0/v1 stored only `theme: 'light'|'dark'|'system'` and had no
+      // `version` key. zustand only invokes `migrate` when the persisted
+      // version is a number that differs from `options.version`, so legacy
+      // payloads without a version skip `migrate` entirely. We therefore
+      // also normalize inside `merge`, which always runs on hydration.
+      migrate: (persistedState, _version) => {
+        const state = (persistedState as Record<string, unknown>) ?? {};
+        const legacyTheme = state.theme;
+        const baseMode: BaseMode =
+          legacyTheme === 'light' || legacyTheme === 'dark' || legacyTheme === 'system'
+            ? legacyTheme
+            : ((state.baseMode as BaseMode) ?? 'system');
+        const preset: ThemePreset = isThemePreset(state.preset) ? state.preset : 'default';
+        return { baseMode, preset, theme: baseMode } as ThemeState;
+      },
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState as Partial<ThemeState> & Record<string, unknown>) ?? {};
+        const legacyTheme = persisted.theme;
+        const baseMode: BaseMode =
+          persisted.baseMode === 'light' ||
+          persisted.baseMode === 'dark' ||
+          persisted.baseMode === 'system'
+            ? persisted.baseMode
+            : legacyTheme === 'light' || legacyTheme === 'dark' || legacyTheme === 'system'
+            ? legacyTheme
+            : currentState.baseMode;
+        const preset: ThemePreset = isThemePreset(persisted.preset)
+          ? persisted.preset
+          : 'default';
+        return { ...currentState, baseMode, preset, theme: baseMode };
+      },
     }
   )
 );
 
-// Helper to apply theme to document
-export const applyTheme = (theme: Theme) => {
+/** Apply the current theme (base mode + preset) to <html>. */
+export const applyTheme = (mode: BaseMode, preset: ThemePreset = 'default') => {
   const root = document.documentElement;
-
-  if (theme === 'system') {
+  if (mode === 'system') {
     const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     root.classList.toggle('dark', systemDark);
   } else {
-    root.classList.toggle('dark', theme === 'dark');
+    root.classList.toggle('dark', mode === 'dark');
   }
+  root.setAttribute('data-theme', preset);
 };


### PR DESCRIPTION
## Summary
Adds 5 preset color palettes alongside the existing Moldavite default. `&lt;html&gt;` now carries a \`data-theme\` attribute alongside the existing \`dark\` class — Tailwind \`dark:\` selectors continue to work unchanged.

| Preset | Light | Dark |
|---|---|---|
| default (Moldavite) | ✅ | ✅ |
| solarized | ✅ | ✅ |
| dracula | — | ✅ |
| nord | — | ✅ |
| sepia | ✅ | — |
| gruvbox | ✅ | ✅ |

Partial-coverage presets fall back to \`default\` for the missing mode. Settings → Appearance picker shows a preset card grid with swatches.

Persisted store schema bumped to v2; legacy \`{theme: light|dark|system}\` payloads migrate seamlessly via \`merge\`.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`npm run lint\` (0 errors)
- [x] \`npm test\` 21/21 (+4 new for store migration)
- [x] \`npm run build\` succeeds
- [x] \`npm run check:size\` — CSS 104 KB / 19 KB gz (within 130/25 budget)

## Visual QA worth a manual pass
- Solarized Light + Sepia: warm cream bg + editor surface
- Dracula + Nord: purple/cyan accent vs syntax highlighting
- Selecting a mismatched preset (e.g. Dracula in light mode) silently falls back to default — works as designed but documented in CSS comments
