### PR TITLE
Forge foundations: frontmatter, file watcher, rescan, public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This app carries that spirit. Your notes live only on your Mac—fused with your
 
 ### What You Get
 
-**Local-first privacy** — Notes stored in `~/Documents/Moldavite/`. Period.
+**Local-first privacy** — Notes stored in your [Forge](docs/FORGE.md) — a folder of plain `.md` files at `~/Documents/Moldavite/`. Sync it, back it up, or edit it in any other tool.
 
 **Rich editing** — Markdown shortcuts, `[[wiki links]]`, images, code blocks, task lists.
 

--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -1,0 +1,111 @@
+# The Forge
+
+Your Forge is the folder where Moldavite stores every note as a plain Markdown
+file. It defaults to `~/Documents/Moldavite/`, but you can move it anywhere
+under your home folder via **Settings → General → Forge → Change**.
+
+Because it's plain `.md`, you can:
+
+- Sync it with iCloud, Dropbox, Syncthing, or git.
+- Edit notes in Obsidian, VS Code, vim, or any other text editor.
+- Run scripts, search tools (`ripgrep`, `fd`), or AI agents over it.
+- Back it up with whatever tool you already trust.
+
+Moldavite watches the Forge and reloads automatically when files change. If
+something seems out of sync, hit **Settings → General → Rescan Forge**.
+
+## Directory layout
+
+```
+<Forge>/
+├── daily/                  # Daily notes, named YYYY-MM-DD.md
+│   └── 2026-05-01.md
+├── weekly/                 # Weekly notes, named YYYY-Www.md
+│   └── 2026-W18.md
+├── notes/                  # Standalone notes (recursive — folders are subdirs)
+│   ├── meeting.md
+│   └── projects/
+│       └── apollo.md
+├── templates/              # Custom templates (JSON)
+├── images/                 # Images dropped into notes
+└── .trash/                 # Soft-deleted notes (auto-purged after 7 days)
+```
+
+Hidden files (anything starting with `.`) are ignored by Moldavite's scanner,
+including `.trash/` and any sidecar metadata.
+
+## Frontmatter schema
+
+Notes can carry an optional YAML frontmatter block at the top, fenced by
+`---` lines:
+
+```markdown
+---
+color: blue
+---
+
+# Apollo kick-off
+
+The actual note body starts here.
+```
+
+### Recognized fields
+
+| field   | type   | purpose                                           |
+|---------|--------|---------------------------------------------------|
+| `color` | string | Sidebar color tag. One of `red`, `orange`, `yellow`, `green`, `blue`, `purple`, `pink`, or `default`. |
+
+### Forward compatibility
+
+Moldavite preserves any other frontmatter keys it doesn't understand on
+re-save, so it's safe to add your own metadata (tags, aliases, anything else
+your tooling cares about). Future Moldavite versions may grow the recognized
+set, but unknown keys won't be stripped.
+
+If you don't set any recognized fields, Moldavite won't write a frontmatter
+block at all — empty `.md` files stay empty.
+
+## Wiki-link syntax
+
+Inside any note body:
+
+```markdown
+[[Apollo]]                  # link to a note named apollo.md
+[[Show this text|target]]   # link with a custom display label
+```
+
+Targets are slugified to lowercase + hyphens to match a filename in
+`notes/`. Clicking an unresolved link offers to create that note.
+
+## Encrypted notes (`.md.locked`)
+
+A note locked with **Settings → Note → Lock** is rewritten as
+`<name>.md.locked`. The file is opaque AES-256-GCM ciphertext + Argon2 KDF
+parameters; it is **not** plain Markdown and external tools cannot read or
+edit it. Unlock from inside Moldavite to round-trip.
+
+## Adding files from outside
+
+Drop a new `.md` file into `daily/`, `weekly/`, or `notes/` (anywhere under
+`notes/`, folders are fine) and it'll appear in Moldavite within a moment.
+If the watcher misses it, click **Rescan Forge**.
+
+Removing a file is equally fine: delete it externally and Moldavite will
+notice on the next scan or watcher tick.
+
+## Caveats
+
+- **Image references**: Moldavite renders images via Tauri's `asset://`
+  protocol. If you write a note that you also want to read in another tool,
+  use a relative path like `![](images/foo.png)` so it resolves there too.
+- **Wiki-link slugs**: Moldavite converts `[[My Cool Note]]` to a target
+  filename `my-cool-note.md`. Other tools may use a different convention —
+  consider sticking to lowercase-hyphenated filenames if you want maximum
+  portability.
+- **Locked notes**: As noted above, `.md.locked` files are encrypted blobs.
+  Don't try to edit them externally; the next unlock will fail.
+- **The `.note-metadata.json.migrated` file**: Older versions of Moldavite
+  stored note colors in `.note-metadata.json` at the Forge root. The
+  one-shot migration moves them into per-file frontmatter and renames the
+  sidecar to `.note-metadata.json.migrated`. You can safely delete it once
+  you're satisfied your colors look right.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1209,6 +1209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +1969,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,6 +2134,26 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2309,6 +2358,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
@@ -2329,10 +2390,13 @@ dependencies = [
  "dirs 5.0.1",
  "lazy_static",
  "log",
+ "notify",
+ "notify-debouncer-mini",
  "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "swift-rs",
  "tauri",
  "tauri-build",
@@ -2421,6 +2485,36 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
+]
 
 [[package]]
 name = "num-conv"
@@ -3947,6 +4041,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.12.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,7 +4925,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5134,6 +5241,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,9 @@ chrono = "0.4"
 regex = "1"
 lazy_static = "1.4"
 walkdir = "2.5"
+serde_yaml = "0.9"
+notify = "6.1"
+notify-debouncer-mini = "0.4"
 
 # Encryption dependencies for note locking
 aes-gcm = "0.10"

--- a/src-tauri/src/backlinks_index.rs
+++ b/src-tauri/src/backlinks_index.rs
@@ -316,7 +316,10 @@ fn collect_md_files_flat(dir: &Path, out: &mut Vec<(String, String)>) {
             continue;
         };
         match fs::read_to_string(&path) {
-            Ok(content) => out.push((filename, content)),
+            Ok(content) => {
+                let body = crate::frontmatter::parse_note(&content).body;
+                out.push((filename, body));
+            }
             Err(err) => log::warn!("backlinks index: failed to read {:?}: {}", path, err),
         }
     }
@@ -354,7 +357,10 @@ fn collect_md_files_recursive(dir: &Path, out: &mut Vec<(String, String)>) {
                 continue;
             };
             match fs::read_to_string(&path) {
-                Ok(content) => out.push((filename, content)),
+                Ok(content) => {
+                let body = crate::frontmatter::parse_note(&content).body;
+                out.push((filename, body));
+            }
                 Err(err) => log::warn!("backlinks index: failed to read {:?}: {}", path, err),
             }
         }

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -5,11 +5,16 @@ use std::fs;
 use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
 
+use crate::forge_watcher::RecentWrites;
+use crate::frontmatter;
 use crate::paths::{
     get_daily_dir, get_images_dir, get_notes_dir, get_standalone_dir, get_weekly_dir,
 };
-use crate::persist::{read_config, read_note_metadata, write_config, write_note_metadata};
+use crate::persist::{read_config, write_config};
 use crate::validation::is_safe_filename;
+use std::sync::Arc;
+use tauri::State;
+use walkdir::WalkDir;
 
 #[tauri::command]
 pub(crate) fn ensure_directories() -> Result<(), String> {
@@ -37,6 +42,42 @@ pub(crate) fn ensure_directories() -> Result<(), String> {
 #[tauri::command]
 pub(crate) fn get_notes_directory() -> String {
     get_notes_dir().to_string_lossy().to_string()
+}
+
+/// Force a re-scan of the Forge directory: rebuilds the in-memory backlinks
+/// index from disk so any externally-added notes show up. The frontend is
+/// expected to call `list_notes` afterward to refresh its own state.
+#[tauri::command]
+pub(crate) fn rescan_forge(
+    index: State<'_, std::sync::Arc<crate::backlinks_index::BacklinksIndex>>,
+) -> Result<(), String> {
+    index.rebuild_from_disk();
+    Ok(())
+}
+
+/// Open the Forge directory in the system file browser. macOS: Finder.
+/// Other platforms: best-effort no-op (returns Ok with a log warning).
+#[tauri::command]
+pub(crate) fn open_forge_in_finder() -> Result<(), String> {
+    let dir = get_notes_dir();
+    if !dir.exists() {
+        return Err("Forge directory does not exist".to_string());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&dir)
+            .spawn()
+            .map_err(|e| format!("failed to open Finder: {}", e))?;
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        log::info!("[forge] open_forge_in_finder is a no-op on this platform");
+        Ok(())
+    }
 }
 
 /// Set a new notes directory and move all existing notes
@@ -149,35 +190,130 @@ pub(crate) fn set_notes_directory(new_path: String) -> Result<(), String> {
     Ok(())
 }
 
-/// Get the color ID for a specific note
+/// Resolve a `note_path` (relative, like `daily/foo.md` or `notes/sub/x.md`)
+/// to an absolute path under the notes dir. Refuses traversal attempts.
+fn resolve_note_path(note_path: &str) -> Option<PathBuf> {
+    if note_path.is_empty()
+        || note_path.contains("..")
+        || note_path.contains('\0')
+        || note_path.starts_with('/')
+        || note_path.starts_with('\\')
+    {
+        return None;
+    }
+    Some(get_notes_dir().join(note_path))
+}
+
+/// Get the color ID for a specific note (reads from YAML frontmatter).
 #[tauri::command]
 pub(crate) fn get_note_color(note_path: String) -> Option<String> {
-    let metadata = read_note_metadata();
-    metadata.colors.get(&note_path).cloned()
+    let abs = resolve_note_path(&note_path)?;
+    if !abs.exists() {
+        return None;
+    }
+    let raw = fs::read_to_string(&abs).ok()?;
+    frontmatter::parse_note(&raw).color
 }
 
-/// Set the color ID for a specific note
+/// Set the color ID for a specific note by updating its YAML frontmatter.
 #[tauri::command]
-pub(crate) fn set_note_color(note_path: String, color_id: Option<String>) -> Result<(), String> {
-    let mut metadata = read_note_metadata();
+pub(crate) fn set_note_color(
+    note_path: String,
+    color_id: Option<String>,
+    recent: State<'_, Arc<RecentWrites>>,
+) -> Result<(), String> {
+    let abs = resolve_note_path(&note_path).ok_or_else(|| "Invalid note path".to_string())?;
 
-    match color_id {
-        Some(id) if id != "default" => {
-            metadata.colors.insert(note_path, id);
-        }
-        _ => {
-            metadata.colors.remove(&note_path);
-        }
+    // Locked notes can't carry frontmatter (they're encrypted blobs).
+    if abs
+        .file_name()
+        .and_then(|f| f.to_str())
+        .is_some_and(|n| n.ends_with(".md.locked"))
+    {
+        return Err("Cannot set color on locked note".to_string());
     }
 
-    write_note_metadata(&metadata)
+    let existing = fs::read_to_string(&abs).unwrap_or_default();
+    let parsed = frontmatter::parse_note(&existing);
+    let new_color = color_id.filter(|c| !c.is_empty() && c != "default");
+    let new_content = frontmatter::serialize_note(
+        new_color.as_deref(),
+        &parsed.extra,
+        &parsed.body,
+    );
+
+    // Make sure the directory exists before we write.
+    if let Some(parent) = abs.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    fs::write(&abs, new_content).map_err(|e| e.to_string())?;
+    recent.record(&abs);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&abs, fs::Permissions::from_mode(0o600));
+    }
+
+    Ok(())
 }
 
-/// Get all note colors at once (for initial load)
+/// Walk the Forge tree and harvest every note color. Used for the initial
+/// load on app start.
 #[tauri::command]
 pub(crate) fn get_all_note_colors() -> std::collections::HashMap<String, String> {
-    let metadata = read_note_metadata();
-    metadata.colors
+    let mut out: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let root = get_notes_dir();
+    if !root.exists() {
+        return out;
+    }
+    for sub in ["daily", "notes", "weekly"] {
+        let dir = root.join(sub);
+        if !dir.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(&dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(Result::ok)
+        {
+            let p = entry.path();
+            // Skip directories starting with "."
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with('.')
+                && entry.depth() > 0
+            {
+                continue;
+            }
+            if !p.is_file() {
+                continue;
+            }
+            let name = match p.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n,
+                None => continue,
+            };
+            // Don't try to parse encrypted blobs.
+            if !name.ends_with(".md") {
+                continue;
+            }
+            let Ok(rel) = p.strip_prefix(&root) else {
+                continue;
+            };
+            let rel_str = rel
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy().to_string())
+                .collect::<Vec<_>>()
+                .join("/");
+            if let Ok(raw) = fs::read_to_string(p) {
+                if let Some(color) = frontmatter::parse_note(&raw).color {
+                    out.insert(rel_str, color);
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Write binary data to a file (used for PDF export).

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -7,11 +7,13 @@ use std::sync::Arc;
 use tauri::State;
 
 use crate::backlinks_index::BacklinksIndex;
+use crate::forge_watcher::RecentWrites;
+use crate::frontmatter;
 use crate::paths::{
     file_modified_unix, get_daily_dir, get_standalone_dir, get_weekly_dir,
 };
 use crate::persist::generate_unique_filename;
-use crate::types::NoteFile;
+use crate::types::{NoteFile, NoteRead};
 use crate::validation::is_safe_filename;
 
 // Helper function to recursively scan notes in a directory
@@ -190,7 +192,11 @@ pub(crate) fn list_notes() -> Result<Vec<NoteFile>, String> {
 }
 
 #[tauri::command]
-pub(crate) fn read_note(filename: String, is_daily: bool, is_weekly: bool) -> Result<String, String> {
+pub(crate) fn read_note(
+    filename: String,
+    is_daily: bool,
+    is_weekly: bool,
+) -> Result<NoteRead, String> {
     // Prevent path traversal attacks (rejects .., /, \, absolute paths, null bytes)
     if !is_safe_filename(&filename) {
         return Err("Invalid filename".to_string());
@@ -206,11 +212,19 @@ pub(crate) fn read_note(filename: String, is_daily: bool, is_weekly: bool) -> Re
 
     let path = dir.join(&filename);
 
-    if path.exists() {
-        fs::read_to_string(&path).map_err(|e| e.to_string())
-    } else {
-        Ok(String::new())
+    if !path.exists() {
+        return Ok(NoteRead {
+            content: String::new(),
+            color: None,
+        });
     }
+
+    let raw = fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let parsed = frontmatter::parse_note(&raw);
+    Ok(NoteRead {
+        content: parsed.body,
+        color: parsed.color,
+    })
 }
 
 #[tauri::command]
@@ -219,7 +233,9 @@ pub(crate) fn write_note(
     content: String,
     is_daily: bool,
     is_weekly: bool,
+    color: Option<String>,
     index: State<'_, Arc<BacklinksIndex>>,
+    recent: State<'_, Arc<RecentWrites>>,
 ) -> Result<(), String> {
     // Prevent path traversal attacks (rejects .., /, \, absolute paths, null bytes)
     if !is_safe_filename(&filename) {
@@ -235,7 +251,29 @@ pub(crate) fn write_note(
     };
 
     let path = dir.join(&filename);
-    fs::write(&path, &content).map_err(|e| e.to_string())?;
+
+    // Preserve any extra frontmatter keys from the existing file so external
+    // tools that add their own metadata don't lose it on save. If the caller
+    // didn't pass a `color`, also preserve the existing color from the file
+    // so a normal content save doesn't strip it.
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let parsed_existing = frontmatter::parse_note(&existing);
+    let resolved_color: Option<String> = match color {
+        // Explicit clear: caller passed "default" or "" to wipe color.
+        Some(ref c) if c.is_empty() || c == "default" => None,
+        // Explicit set.
+        Some(c) => Some(c),
+        // Untouched: keep what's on disk.
+        None => parsed_existing.color.clone(),
+    };
+    let serialized = frontmatter::serialize_note(
+        resolved_color.as_deref(),
+        &parsed_existing.extra,
+        &content,
+    );
+
+    fs::write(&path, &serialized).map_err(|e| e.to_string())?;
+    recent.record(&path);
 
     // Set restrictive file permissions (600 = owner read/write only)
     #[cfg(unix)]
@@ -245,6 +283,7 @@ pub(crate) fn write_note(
         fs::set_permissions(&path, permissions).map_err(|e| e.to_string())?;
     }
 
+    // The backlinks index only cares about the body, not frontmatter.
     index.update_note(&filename, &content);
 
     Ok(())

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -94,7 +94,10 @@ pub(crate) fn search_notes_content_in(
             continue;
         }
 
-        let Ok(content) = fs::read_to_string(path) else { continue };
+        let Ok(raw) = fs::read_to_string(path) else { continue };
+        // Don't search YAML frontmatter — it would surface "color: red" as a
+        // hit when the user searches for "red".
+        let content = crate::frontmatter::parse_note(&raw).body;
         let content_lower = content.to_lowercase();
         if !content_lower.contains(&term_lower) {
             continue;

--- a/src-tauri/src/forge_watcher.rs
+++ b/src-tauri/src/forge_watcher.rs
@@ -1,0 +1,209 @@
+//! File watcher rooted at the configured Forge directory.
+//!
+//! Emits a Tauri event `forge:changed` with `{ kind, relPath }` whenever a
+//! note file is created, modified, or removed by an external process.
+//!
+//! Writes performed by Moldavite itself are short-circuited via a recent-write
+//! ignore list so the UI doesn't double-refresh after its own saves.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use notify::RecursiveMode;
+use notify_debouncer_mini::new_debouncer;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::paths::get_notes_dir;
+
+/// How long after a self-write to ignore an event for that path.
+const SELF_WRITE_IGNORE_MS: u64 = 500;
+
+/// Records writes Moldavite itself initiated, keyed by absolute path. Events
+/// for paths in this map (within `SELF_WRITE_IGNORE_MS`) are dropped.
+#[derive(Debug, Default)]
+pub struct RecentWrites {
+    inner: Mutex<HashMap<PathBuf, Instant>>,
+}
+
+impl RecentWrites {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that we just wrote `path`. Subsequent watcher events within
+    /// the ignore window will be dropped.
+    pub fn record(&self, path: &Path) {
+        if let Ok(mut map) = self.inner.lock() {
+            map.insert(path.to_path_buf(), Instant::now());
+            // Opportunistic GC.
+            map.retain(|_, t| t.elapsed() < Duration::from_secs(5));
+        }
+    }
+
+    /// Returns true if `path` was written by us very recently.
+    pub fn is_recent(&self, path: &Path) -> bool {
+        if let Ok(map) = self.inner.lock() {
+            if let Some(t) = map.get(path) {
+                return t.elapsed() < Duration::from_millis(SELF_WRITE_IGNORE_MS);
+            }
+        }
+        false
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ForgeChange {
+    /// "modified" — debouncer-mini collapses create/modify/remove into one.
+    /// Frontend should treat this as "something changed; re-fetch the list
+    /// and the active note's content."
+    pub kind: String,
+    /// Path relative to the Forge root, using forward slashes.
+    pub rel_path: String,
+}
+
+fn rel_path(root: &Path, abs: &Path) -> Option<String> {
+    abs.strip_prefix(root).ok().map(|p| {
+        p.components()
+            .map(|c| c.as_os_str().to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+            .join("/")
+    })
+}
+
+/// Whether a path is something Moldavite cares about (a note, image, or
+/// template). Filters out hidden files (`.note-metadata.json*`, `.trash/`,
+/// `.DS_Store`) so we don't fire constant noise.
+fn is_relevant(rel: &str) -> bool {
+    if rel.is_empty() {
+        return false;
+    }
+    let first = rel.split('/').next().unwrap_or("");
+    if first.starts_with('.') {
+        return false;
+    }
+    let last = rel.rsplit('/').next().unwrap_or("");
+    if last.starts_with('.') {
+        return false;
+    }
+    // Only notes and templates — we leave image events alone since the
+    // frontend re-renders images on its own.
+    last.ends_with(".md")
+        || last.ends_with(".md.locked")
+        || last.ends_with(".json")
+}
+
+/// Spawn a long-lived background thread that watches the Forge directory and
+/// emits Tauri events. Returns a guard handle whose Drop stops the watcher.
+pub fn spawn(
+    app: AppHandle,
+    recent: Arc<RecentWrites>,
+) -> Result<WatcherHandle, String> {
+    let root = get_notes_dir();
+    if !root.exists() {
+        // Nothing to watch yet; the caller can re-spawn after dirs are made.
+        log::info!("[forge watcher] root {:?} does not exist yet", root);
+    }
+
+    let app_for_thread = app.clone();
+    let root_for_thread = root.clone();
+    let recent_for_thread = recent.clone();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let mut debouncer = new_debouncer(Duration::from_millis(300), tx)
+        .map_err(|e| format!("failed to create debouncer: {}", e))?;
+    if root.exists() {
+        debouncer
+            .watcher()
+            .watch(&root, RecursiveMode::Recursive)
+            .map_err(|e| format!("failed to watch {:?}: {}", root, e))?;
+    }
+
+    let join = std::thread::Builder::new()
+        .name("forge-watcher".into())
+        .spawn(move || {
+            // Hold the debouncer for the lifetime of this thread so it keeps
+            // running. When the thread exits (on shutdown) it drops.
+            let _debouncer = debouncer;
+            while let Ok(events) = rx.recv() {
+                let events = match events {
+                    Ok(ev) => ev,
+                    Err(err) => {
+                        log::warn!("[forge watcher] error: {}", err);
+                        continue;
+                    }
+                };
+                for event in events {
+                    let path = event.path;
+                    if recent_for_thread.is_recent(&path) {
+                        continue;
+                    }
+                    let Some(rel) = rel_path(&root_for_thread, &path) else {
+                        continue;
+                    };
+                    if !is_relevant(&rel) {
+                        continue;
+                    }
+                    let payload = ForgeChange {
+                        kind: "modified".into(),
+                        rel_path: rel,
+                    };
+                    if let Err(e) = app_for_thread.emit("forge:changed", payload) {
+                        log::warn!("[forge watcher] emit failed: {}", e);
+                    }
+                }
+            }
+        })
+        .map_err(|e| format!("failed to spawn watcher thread: {}", e))?;
+
+    Ok(WatcherHandle {
+        _join: Some(join),
+    })
+}
+
+/// Owned handle. Currently the thread runs for the life of the app; this
+/// struct exists so future code can replace the watcher when the user picks
+/// a new Forge directory.
+pub struct WatcherHandle {
+    _join: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn relevant_filters_dotfiles_and_trash() {
+        assert!(!is_relevant(".note-metadata.json"));
+        assert!(!is_relevant(".trash/old.md"));
+        assert!(!is_relevant("notes/.DS_Store"));
+        assert!(is_relevant("notes/foo.md"));
+        assert!(is_relevant("daily/2024-01-01.md"));
+        assert!(is_relevant("notes/secret.md.locked"));
+    }
+
+    #[test]
+    fn relevant_ignores_unknown_extensions() {
+        assert!(!is_relevant("notes/foo.png"));
+        assert!(!is_relevant("notes/foo.txt"));
+    }
+
+    #[test]
+    fn recent_writes_within_window() {
+        let r = RecentWrites::new();
+        let p = PathBuf::from("/tmp/x.md");
+        r.record(&p);
+        assert!(r.is_recent(&p));
+    }
+
+    #[test]
+    fn recent_writes_unknown_path_is_not_recent() {
+        let r = RecentWrites::new();
+        assert!(!r.is_recent(Path::new("/tmp/never.md")));
+    }
+}

--- a/src-tauri/src/frontmatter.rs
+++ b/src-tauri/src/frontmatter.rs
@@ -1,0 +1,232 @@
+//! YAML frontmatter parsing and serialization for notes.
+//!
+//! Notes can carry a leading YAML frontmatter block, fenced by `---` lines.
+//! Currently only the `color` field is consumed by Moldavite, but the parser
+//! preserves any additional keys so external tools (Obsidian, scripts) can
+//! safely add their own metadata without it being clobbered on save.
+//!
+//! ```text
+//! ---
+//! color: blue
+//! ---
+//! Note body starts here.
+//! ```
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Parsed view of a note file: structured frontmatter (if any) + body.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ParsedNote {
+    /// Color id (e.g. "blue"). `None` means the note carries no color.
+    pub color: Option<String>,
+    /// All other frontmatter keys, preserved verbatim so we don't drop
+    /// metadata written by external tools when we re-serialize.
+    pub extra: BTreeMap<String, serde_yaml::Value>,
+    /// The note body (everything after the closing `---`), with the leading
+    /// newline that follows the fence stripped.
+    pub body: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct RawFrontmatter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+/// Detect a leading `---` fence, allowing for an optional UTF-8 BOM.
+fn strip_bom(input: &str) -> &str {
+    input.strip_prefix('\u{FEFF}').unwrap_or(input)
+}
+
+/// Parse a note's raw text into frontmatter + body. If the text does not
+/// begin with a `---` fence, the entire text is returned as the body.
+pub fn parse_note(raw: &str) -> ParsedNote {
+    let text = strip_bom(raw);
+
+    // Frontmatter must start at the very beginning of the file.
+    if !text.starts_with("---") {
+        return ParsedNote {
+            color: None,
+            extra: BTreeMap::new(),
+            body: text.to_string(),
+        };
+    }
+
+    // Skip the opening fence. We accept "---\n" and "---\r\n".
+    let after_open = match text.strip_prefix("---\r\n") {
+        Some(rest) => rest,
+        None => match text.strip_prefix("---\n") {
+            Some(rest) => rest,
+            None => {
+                // Malformed (no newline after the fence) — treat as body.
+                return ParsedNote {
+                    color: None,
+                    extra: BTreeMap::new(),
+                    body: text.to_string(),
+                };
+            }
+        },
+    };
+
+    // Find the closing fence on its own line.
+    let mut end_idx: Option<usize> = None;
+    let mut cursor = 0usize;
+    for line in after_open.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed == "---" || trimmed == "..." {
+            end_idx = Some(cursor);
+            break;
+        }
+        cursor += line.len();
+    }
+
+    let Some(end) = end_idx else {
+        // No closing fence — treat the whole thing as body.
+        return ParsedNote {
+            color: None,
+            extra: BTreeMap::new(),
+            body: text.to_string(),
+        };
+    };
+
+    let yaml_block = &after_open[..end];
+    // Skip past the closing fence line (and its trailing newline).
+    let after_close_start = end;
+    let after_close = &after_open[after_close_start..];
+    let body_start = after_close
+        .strip_prefix("---\r\n")
+        .or_else(|| after_close.strip_prefix("---\n"))
+        .or_else(|| after_close.strip_prefix("...\r\n"))
+        .or_else(|| after_close.strip_prefix("...\n"))
+        .unwrap_or("");
+
+    let parsed: RawFrontmatter = serde_yaml::from_str(yaml_block).unwrap_or_default();
+    ParsedNote {
+        color: parsed.color.filter(|s| !s.is_empty()),
+        extra: parsed.extra,
+        body: body_start.to_string(),
+    }
+}
+
+/// Serialize a note back to disk format. If `color` is `None` and `extra` is
+/// empty, the frontmatter block is omitted entirely so we don't pollute every
+/// file.
+pub fn serialize_note(color: Option<&str>, extra: &BTreeMap<String, serde_yaml::Value>, body: &str) -> String {
+    let has_color = color.is_some_and(|c| !c.is_empty());
+    if !has_color && extra.is_empty() {
+        return body.to_string();
+    }
+
+    let raw = RawFrontmatter {
+        color: color.filter(|s| !s.is_empty()).map(|s| s.to_string()),
+        extra: extra.clone(),
+    };
+    let yaml = serde_yaml::to_string(&raw).unwrap_or_default();
+    let yaml = yaml.trim_end_matches('\n');
+    format!("---\n{}\n---\n{}", yaml, body)
+}
+
+/// Convenience: build a note string from just a color + body, preserving any
+/// extra keys discovered in the existing on-disk content (so external metadata
+/// survives round-trips).
+pub fn write_with_color(existing_raw: &str, color: Option<&str>, body: &str) -> String {
+    let existing = parse_note(existing_raw);
+    serialize_note(color, &existing.extra, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_no_frontmatter() {
+        let p = parse_note("hello world\n");
+        assert_eq!(p.color, None);
+        assert!(p.extra.is_empty());
+        assert_eq!(p.body, "hello world\n");
+    }
+
+    #[test]
+    fn parses_color_only() {
+        let p = parse_note("---\ncolor: blue\n---\nhello\n");
+        assert_eq!(p.color.as_deref(), Some("blue"));
+        assert_eq!(p.body, "hello\n");
+    }
+
+    #[test]
+    fn preserves_extra_keys() {
+        let p = parse_note("---\ncolor: red\ntags: [a, b]\n---\nbody\n");
+        assert_eq!(p.color.as_deref(), Some("red"));
+        assert!(p.extra.contains_key("tags"));
+        assert_eq!(p.body, "body\n");
+    }
+
+    #[test]
+    fn round_trip_preserves_extra() {
+        let original = "---\ncolor: blue\ntags:\n- one\n- two\n---\nthe body\n";
+        let parsed = parse_note(original);
+        let written = serialize_note(parsed.color.as_deref(), &parsed.extra, &parsed.body);
+        let reparsed = parse_note(&written);
+        assert_eq!(reparsed.color.as_deref(), Some("blue"));
+        assert_eq!(reparsed.body, "the body\n");
+        assert!(reparsed.extra.contains_key("tags"));
+    }
+
+    #[test]
+    fn omits_frontmatter_when_no_color_or_extras() {
+        let s = serialize_note(None, &BTreeMap::new(), "just body");
+        assert_eq!(s, "just body");
+    }
+
+    #[test]
+    fn malformed_fence_is_treated_as_body() {
+        let raw = "---no newline";
+        let p = parse_note(raw);
+        assert_eq!(p.color, None);
+        assert_eq!(p.body, raw);
+    }
+
+    #[test]
+    fn missing_close_fence_is_treated_as_body() {
+        let raw = "---\ncolor: blue\nthis never closes\n";
+        let p = parse_note(raw);
+        assert_eq!(p.color, None);
+        assert_eq!(p.body, raw);
+    }
+
+    #[test]
+    fn write_with_color_strips_existing_color() {
+        let existing = "---\ncolor: blue\ntags: [x]\n---\nhi\n";
+        let parsed = parse_note(existing);
+        let out = serialize_note(None, &parsed.extra, &parsed.body);
+        let reparsed = parse_note(&out);
+        assert_eq!(reparsed.color, None);
+        assert!(reparsed.extra.contains_key("tags"));
+    }
+
+    #[test]
+    fn write_with_color_drops_frontmatter_when_nothing_left() {
+        let existing = "---\ncolor: blue\n---\njust body\n";
+        let out = write_with_color(existing, None, "just body\n");
+        // No remaining metadata at all → no frontmatter.
+        assert_eq!(out, "just body\n");
+    }
+
+    #[test]
+    fn handles_bom() {
+        let raw = "\u{FEFF}---\ncolor: green\n---\nx";
+        let p = parse_note(raw);
+        assert_eq!(p.color.as_deref(), Some("green"));
+        assert_eq!(p.body, "x");
+    }
+
+    #[test]
+    fn empty_color_treated_as_none() {
+        let p = parse_note("---\ncolor: \n---\nbody");
+        assert_eq!(p.color, None);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,15 @@ mod security;
 /// Shared utilities (paths, config, permissions)
 mod utils;
 
+/// YAML frontmatter parsing for note files.
+pub(crate) mod frontmatter;
+
+/// One-shot migration: sidecar metadata JSON → per-file YAML frontmatter.
+pub(crate) mod migration;
+
+/// Filesystem watcher (notify) that emits `forge:changed` events.
+pub(crate) mod forge_watcher;
+
 // Refactored domain modules.
 pub(crate) mod backlinks_index;
 pub(crate) mod commands;
@@ -51,8 +60,9 @@ use commands::folders::{create_folder, delete_folder, list_folders, move_folder,
 use commands::graph::get_note_graph;
 use commands::locking::{is_note_locked, lock_note, permanently_unlock_note, unlock_note};
 use commands::misc::{
-    ensure_directories, get_all_note_colors, get_note_color, get_notes_directory, save_image,
-    set_note_color, set_notes_directory, write_binary_file,
+    ensure_directories, get_all_note_colors, get_note_color, get_notes_directory,
+    open_forge_in_finder, rescan_forge, save_image, set_note_color, set_notes_directory,
+    write_binary_file,
 };
 use commands::notes::{
     clear_all_notes, create_note, delete_note, duplicate_note, export_single_note,
@@ -108,9 +118,12 @@ fn list_calendars() -> Result<Vec<CalendarInfo>, String> {
 pub fn run() {
     use std::sync::Arc;
 
+    use tauri::Manager;
+
     use crate::backlinks_index::BacklinksIndex;
 
     let backlinks_index = Arc::new(BacklinksIndex::new());
+    let recent_writes = Arc::new(forge_watcher::RecentWrites::new());
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -118,6 +131,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(backlinks_index.clone())
+        .manage(recent_writes.clone())
         .setup(move |app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -126,11 +140,27 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            // Run sidecar-metadata → frontmatter migration once. Idempotent,
+            // safe to call on every launch.
+            match migration::migrate_metadata_to_frontmatter() {
+                Ok(0) => {}
+                Ok(n) => log::info!("[forge] migrated {} note colors to frontmatter", n),
+                Err(e) => log::warn!("[forge] migration error: {}", e),
+            }
             // Build backlinks index off the main thread so startup isn't blocked.
             let idx = backlinks_index.clone();
             tauri::async_runtime::spawn_blocking(move || {
                 idx.rebuild_from_disk();
             });
+            // Spawn the file watcher.
+            let watcher_handle = forge_watcher::spawn(app.handle().clone(), recent_writes.clone());
+            match watcher_handle {
+                Ok(h) => {
+                    // Keep the handle alive for the lifetime of the app.
+                    app.manage(h);
+                }
+                Err(e) => log::warn!("[forge] watcher spawn failed: {}", e),
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -186,6 +216,8 @@ pub fn run() {
             // Directory management commands
             get_notes_directory,
             set_notes_directory,
+            rescan_forge,
+            open_forge_in_finder,
             // Export/Import commands
             export_notes,
             import_notes,

--- a/src-tauri/src/migration.rs
+++ b/src-tauri/src/migration.rs
@@ -1,0 +1,145 @@
+//! One-shot migration from sidecar `.note-metadata.json` colors to per-file
+//! YAML frontmatter.
+//!
+//! Idempotent: after running, the JSON file is renamed to
+//! `.note-metadata.json.migrated` so subsequent runs are no-ops. Safe to call
+//! on every app start.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::frontmatter;
+use crate::paths::{get_metadata_path, get_notes_dir};
+
+#[derive(Debug, Default, Deserialize)]
+struct MetadataFile {
+    #[serde(default)]
+    colors: std::collections::HashMap<String, String>,
+}
+
+/// Resolve a `notePath` (e.g. `daily/2024-01-01.md`, `notes/foo.md`,
+/// `notes/sub/bar.md`) to an absolute on-disk path under the configured
+/// Forge directory.
+fn resolve_note_path(notes_dir: &Path, note_path: &str) -> Option<PathBuf> {
+    // Reject anything that tries to escape the notes_dir.
+    if note_path.contains("..") || note_path.starts_with('/') || note_path.contains('\0') {
+        return None;
+    }
+    Some(notes_dir.join(note_path))
+}
+
+/// Run the migration. Returns the number of notes that had a color stamped
+/// into their frontmatter. Errors during individual files are logged but do
+/// not abort the whole migration.
+pub fn migrate_metadata_to_frontmatter() -> Result<u32, String> {
+    let metadata_path = get_metadata_path();
+    if !metadata_path.exists() {
+        return Ok(0);
+    }
+
+    let raw = match fs::read_to_string(&metadata_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("[forge migration] could not read {:?}: {}", metadata_path, e);
+            return Ok(0);
+        }
+    };
+    let meta: MetadataFile = match serde_json::from_str(&raw) {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("[forge migration] malformed metadata json: {}", e);
+            // Still rename so we don't keep retrying on every boot.
+            let _ = fs::rename(&metadata_path, metadata_path.with_extension("json.migrated"));
+            return Ok(0);
+        }
+    };
+
+    let notes_dir = get_notes_dir();
+    let mut migrated = 0u32;
+
+    for (note_path, color) in &meta.colors {
+        let Some(abs) = resolve_note_path(&notes_dir, note_path) else {
+            log::warn!("[forge migration] skipping unsafe path: {}", note_path);
+            continue;
+        };
+        if !abs.exists() {
+            log::info!(
+                "[forge migration] note no longer exists, skipping: {}",
+                note_path
+            );
+            continue;
+        }
+        // Don't touch encrypted files.
+        if abs
+            .file_name()
+            .and_then(|f| f.to_str())
+            .is_some_and(|n| n.ends_with(".md.locked"))
+        {
+            continue;
+        }
+        let existing = match fs::read_to_string(&abs) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("[forge migration] read failed for {}: {}", note_path, e);
+                continue;
+            }
+        };
+        // If frontmatter already carries a color, leave it alone.
+        let parsed = frontmatter::parse_note(&existing);
+        if parsed.color.is_some() {
+            continue;
+        }
+        let new_content = frontmatter::write_with_color(&existing, Some(color), &parsed.body);
+        if let Err(e) = fs::write(&abs, new_content) {
+            log::warn!("[forge migration] write failed for {}: {}", note_path, e);
+            continue;
+        }
+        migrated += 1;
+        log::info!(
+            "[forge migration] stamped color={} into {}",
+            color,
+            note_path
+        );
+    }
+
+    // Rename the JSON so the migration is idempotent. Keep the `.migrated`
+    // suffix as a breadcrumb so users (or a recovery script) can find the
+    // original payload if something went wrong.
+    let renamed = metadata_path.with_extension("json.migrated");
+    if let Err(e) = fs::rename(&metadata_path, &renamed) {
+        log::warn!(
+            "[forge migration] could not rename metadata file: {}",
+            e
+        );
+    }
+
+    Ok(migrated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_rejects_traversal() {
+        let base = PathBuf::from("/tmp/forge");
+        assert!(resolve_note_path(&base, "../etc/passwd").is_none());
+        assert!(resolve_note_path(&base, "/etc/passwd").is_none());
+        assert!(resolve_note_path(&base, "notes/foo\0.md").is_none());
+    }
+
+    #[test]
+    fn resolve_accepts_normal_paths() {
+        let base = PathBuf::from("/tmp/forge");
+        assert_eq!(
+            resolve_note_path(&base, "notes/foo.md"),
+            Some(base.join("notes/foo.md"))
+        );
+        assert_eq!(
+            resolve_note_path(&base, "daily/2024-01-01.md"),
+            Some(base.join("daily/2024-01-01.md"))
+        );
+    }
+}

--- a/src-tauri/src/persist.rs
+++ b/src-tauri/src/persist.rs
@@ -6,10 +6,8 @@ use std::path::Path;
 use lazy_static::lazy_static;
 use regex::Regex;
 
-use crate::paths::{
-    ensure_trash_dir, get_config_path, get_metadata_path, get_trash_metadata_path,
-};
-use crate::types::{AppConfig, NoteMetadata, TrashMetadata};
+use crate::paths::{ensure_trash_dir, get_config_path, get_trash_metadata_path};
+use crate::types::{AppConfig, TrashMetadata};
 
 lazy_static! {
     /// Matches a trailing " (N)" counter on a name.
@@ -67,25 +65,6 @@ pub(crate) fn write_trash_metadata(metadata: &TrashMetadata) -> Result<(), Strin
     let metadata_path = get_trash_metadata_path();
     let json = serde_json::to_string_pretty(metadata).map_err(|e| e.to_string())?;
     fs::write(&metadata_path, json).map_err(|e| format!("Failed to write trash metadata: {}", e))?;
-    Ok(())
-}
-
-pub(crate) fn read_note_metadata() -> NoteMetadata {
-    let path = get_metadata_path();
-    if path.exists() {
-        if let Ok(content) = fs::read_to_string(&path) {
-            if let Ok(metadata) = serde_json::from_str(&content) {
-                return metadata;
-            }
-        }
-    }
-    NoteMetadata::default()
-}
-
-pub(crate) fn write_note_metadata(metadata: &NoteMetadata) -> Result<(), String> {
-    let path = get_metadata_path();
-    let content = serde_json::to_string_pretty(metadata).map_err(|e| e.to_string())?;
-    fs::write(&path, content).map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -116,12 +116,13 @@ pub(crate) struct ImportResult {
     pub(crate) images: u32,
 }
 
-// Note Metadata for colors and other per-note settings
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// Read result for a note: body content with frontmatter stripped, plus the
+/// color (if any) parsed from frontmatter.
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct NoteMetadata {
-    #[serde(default)]
-    pub(crate) colors: std::collections::HashMap<String, String>,
+pub(crate) struct NoteRead {
+    pub(crate) content: String,
+    pub(crate) color: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ShortcutHelpHost } from './components/ShortcutHelpModal';
 import { GraphView } from './components/graph';
 import { useThemeStore, applyTheme, useSettingsStore, applyFontSize, applyLineHeight, applyCompactMode, applyFontFamily, useNoteColorsStore } from './stores';
 import { fixNotePermissions } from './lib/fileSystem';
-import { useAutoLock } from './hooks';
+import { useAutoLock, useForgeWatcher } from './hooks';
 
 function App() {
   const { theme } = useThemeStore();
@@ -14,6 +14,9 @@ function App() {
 
   // Auto-lock: Monitor inactivity and re-lock notes after timeout
   useAutoLock();
+
+  // Forge watcher: refresh notes list when files change on disk
+  useForgeWatcher();
 
   // Fix note permissions on startup (privacy improvement)
   useEffect(() => {

--- a/src/components/settings/sections/GeneralSection.tsx
+++ b/src/components/settings/sections/GeneralSection.tsx
@@ -7,11 +7,11 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Lock, FolderOpen, Download, Upload, Shield, Eye, EyeOff, Timer } from 'lucide-react';
+import { Lock, FolderOpen, Download, Upload, Shield, Eye, EyeOff, Timer, RefreshCw, ExternalLink } from 'lucide-react';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { useSettingsStore, useNoteStore } from '@/stores';
 import type { AutoLockTimeout } from '@/stores';
-import { clearAllNotes, getNotesDirectory, setNotesDirectory, exportNotes, importNotes, exportEncryptedBackup, importEncryptedBackup } from '@/lib';
+import { clearAllNotes, getNotesDirectory, setNotesDirectory, exportNotes, importNotes, exportEncryptedBackup, importEncryptedBackup, rescanForge, openForgeInFinder, listNotes } from '@/lib';
 import type { ImportResult } from '@/lib';
 import { InfoTooltip, Toggle } from '../common';
 
@@ -23,6 +23,7 @@ export function GeneralSection() {
   const [isClearing, setIsClearing] = useState(false);
   const [notesDirectory, setNotesDirectoryState] = useState('');
   const [isChangingDir, setIsChangingDir] = useState(false);
+  const [isRescanning, setIsRescanning] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [showImportOptions, setShowImportOptions] = useState(false);
@@ -51,23 +52,47 @@ export function GeneralSection() {
     }
   }, [statusMessage]);
 
+  const handleRescan = async () => {
+    try {
+      setIsRescanning(true);
+      await rescanForge();
+      const fresh = await listNotes();
+      useNoteStore.getState().setNotes(fresh);
+      setStatusMessage({ type: 'success', text: 'Forge re-scanned' });
+    } catch (error) {
+      console.error('[Settings] Failed to rescan Forge:', error);
+      setStatusMessage({ type: 'error', text: String(error) });
+    } finally {
+      setIsRescanning(false);
+    }
+  };
+
+  const handleOpenInFinder = async () => {
+    try {
+      await openForgeInFinder();
+    } catch (error) {
+      console.error('[Settings] Failed to open Forge in Finder:', error);
+      setStatusMessage({ type: 'error', text: String(error) });
+    }
+  };
+
   const handleChangeDirectory = async () => {
     try {
       setIsChangingDir(true);
       const selected = await open({
         directory: true,
-        title: 'Select Notes Directory',
+        title: 'Select Forge Directory',
       });
 
       if (selected && typeof selected === 'string') {
         await setNotesDirectory(selected);
         setNotesDirectoryState(selected);
-        setStatusMessage({ type: 'success', text: 'Notes directory changed successfully!' });
+        setStatusMessage({ type: 'success', text: 'Forge moved successfully!' });
         // Refresh notes list
         window.location.reload();
       }
     } catch (error) {
-      console.error('[Settings] Failed to change directory:', error);
+      console.error('[Settings] Failed to change Forge directory:', error);
       setStatusMessage({ type: 'error', text: String(error) });
     } finally {
       setIsChangingDir(false);
@@ -261,18 +286,18 @@ export function GeneralSection() {
         </div>
       )}
 
-      {/* Storage Section */}
+      {/* Forge Section */}
       <div className="p-4 space-y-4" style={{ backgroundColor: 'var(--bg-panel)', borderRadius: 'var(--radius-md)' }}>
         <div className="flex items-center gap-1">
           <h3 className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-            Storage
+            Forge
           </h3>
-          <InfoTooltip text="Where your notes are saved on your computer. All data is stored locally." />
+          <InfoTooltip text="Your notes live in your Forge — a folder of plain .md files you can sync, back up, or open in any other tool." />
         </div>
 
         <div>
           <label className="text-xs mb-1.5 block" style={{ color: 'var(--text-tertiary)' }}>
-            Notes Directory
+            Forge location
           </label>
           <div className="flex items-center gap-2">
             <input
@@ -303,8 +328,38 @@ export function GeneralSection() {
             </button>
           </div>
           <p className="text-xs mt-1.5" style={{ color: 'var(--text-muted)' }}>
-            Existing notes will be moved to the new location
+            Plain .md files. Sync, back up, or open in any other tool. Existing notes will be moved if you change this.
           </p>
+        </div>
+
+        <div className="flex gap-2 flex-wrap">
+          <button
+            onClick={handleOpenInFinder}
+            className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors"
+            style={{
+              backgroundColor: 'var(--bg-elevated)',
+              border: '1px solid var(--border-default)',
+              borderRadius: 'var(--radius-sm)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            <ExternalLink aria-hidden="true" className="w-4 h-4" />
+            Open Forge in Finder
+          </button>
+          <button
+            onClick={handleRescan}
+            disabled={isRescanning}
+            className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50"
+            style={{
+              backgroundColor: 'var(--bg-elevated)',
+              border: '1px solid var(--border-default)',
+              borderRadius: 'var(--radius-sm)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            <RefreshCw aria-hidden="true" className={`w-4 h-4 ${isRescanning ? 'animate-spin' : ''}`} />
+            {isRescanning ? 'Rescanning...' : 'Rescan Forge'}
+          </button>
         </div>
       </div>
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -32,3 +32,4 @@ export { useSidebarContextMenu } from './useSidebarContextMenu';
 export { useSidebarLock } from './useSidebarLock';
 export { useSidebarTags } from './useSidebarTags';
 export { useSidebarDnd } from './useSidebarDnd';
+export { useForgeWatcher } from './useForgeWatcher';

--- a/src/hooks/useForgeWatcher.ts
+++ b/src/hooks/useForgeWatcher.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import { listNotes } from '@/lib';
+import { useNoteStore } from '@/stores';
+
+/**
+ * Payload emitted by the backend `forge:changed` event.
+ *
+ * `kind` is "modified" for any add/change/remove (the debouncer collapses
+ * them); the frontend should treat any event as "something changed under
+ * the Forge — refresh the list."
+ */
+interface ForgeChangePayload {
+  kind: 'modified';
+  relPath: string;
+}
+
+/**
+ * Subscribes to backend `forge:changed` events. When something on disk
+ * changes outside of Moldavite (Obsidian, an editor, a script…), we
+ * reconcile by re-listing notes. We deliberately don't reload the active
+ * note's body here — that would clobber unsaved edits — but the path is
+ * available in the payload if a future enhancement wants to surface a
+ * "this note changed externally" prompt.
+ */
+export function useForgeWatcher(): void {
+  const setNotes = useNoteStore((s) => s.setNotes);
+  const refreshTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+
+    const subscribe = async () => {
+      try {
+        const off = await listen<ForgeChangePayload>('forge:changed', () => {
+          // Coalesce bursts: a folder rename can fan out to many events.
+          if (refreshTimer.current !== null) {
+            clearTimeout(refreshTimer.current);
+          }
+          refreshTimer.current = window.setTimeout(() => {
+            refreshTimer.current = null;
+            listNotes()
+              .then((notes) => {
+                if (!cancelled) setNotes(notes);
+              })
+              .catch((err) => {
+                console.error('[useForgeWatcher] refresh failed:', err);
+              });
+          }, 200);
+        });
+        if (cancelled) {
+          off();
+        } else {
+          unlisten = off;
+        }
+      } catch (err) {
+        console.error('[useForgeWatcher] subscribe failed:', err);
+      }
+    };
+
+    void subscribe();
+
+    return () => {
+      cancelled = true;
+      if (refreshTimer.current !== null) {
+        clearTimeout(refreshTimer.current);
+        refreshTimer.current = null;
+      }
+      if (unlisten) unlisten();
+    };
+  }, [setNotes]);
+}

--- a/src/lib/fileSystem.ts
+++ b/src/lib/fileSystem.ts
@@ -465,14 +465,41 @@ export async function listNotes(): Promise<NoteFile[]> {
 }
 
 /**
- * Reads the content of a specific note file.
+ * Result shape returned by `read_note`. The body has had any leading YAML
+ * frontmatter stripped; structured fields (currently just `color`) are
+ * surfaced separately.
+ */
+export interface NoteReadResult {
+  content: string;
+  color: string | null;
+}
+
+/**
+ * Reads the content of a specific note file. Strips YAML frontmatter from the
+ * body and surfaces `color` separately.
  * @param filename - The note filename (e.g., "2025-01-01.md")
  * @param isDaily - Whether this is a daily note
  * @param isWeekly - Whether this is a weekly note
- * @returns The raw Markdown content
+ * @returns Parsed body plus any color from frontmatter
  */
-export async function readNote(filename: string, isDaily: boolean, isWeekly: boolean = false): Promise<string> {
-  return await invoke('read_note', { filename, isDaily, isWeekly });
+export async function readNote(
+  filename: string,
+  isDaily: boolean,
+  isWeekly: boolean = false,
+): Promise<string> {
+  const result = await invoke<NoteReadResult>('read_note', { filename, isDaily, isWeekly });
+  return result.content;
+}
+
+/**
+ * Same as {@link readNote}, but returns the structured result with `color`.
+ */
+export async function readNoteWithMeta(
+  filename: string,
+  isDaily: boolean,
+  isWeekly: boolean = false,
+): Promise<NoteReadResult> {
+  return await invoke<NoteReadResult>('read_note', { filename, isDaily, isWeekly });
 }
 
 /**
@@ -481,9 +508,17 @@ export async function readNote(filename: string, isDaily: boolean, isWeekly: boo
  * @param content - The Markdown content to write
  * @param isDaily - Whether this is a daily note
  * @param isWeekly - Whether this is a weekly note
+ * @param color - Optional color id to stamp into frontmatter. `null`/undefined
+ *   leaves the existing color in place; pass `"default"` to clear it.
  */
-export async function writeNote(filename: string, content: string, isDaily: boolean, isWeekly: boolean = false): Promise<void> {
-  await invoke('write_note', { filename, content, isDaily, isWeekly });
+export async function writeNote(
+  filename: string,
+  content: string,
+  isDaily: boolean,
+  isWeekly: boolean = false,
+  color?: string | null,
+): Promise<void> {
+  await invoke('write_note', { filename, content, isDaily, isWeekly, color: color ?? null });
 }
 
 /**
@@ -724,6 +759,23 @@ export async function getNotesDirectory(): Promise<string> {
  */
 export async function setNotesDirectory(newPath: string): Promise<void> {
   await invoke('set_notes_directory', { newPath });
+}
+
+/**
+ * Re-scans the Forge directory: rebuilds the backlinks index from disk so any
+ * externally-added notes are picked up. Callers should refresh their notes
+ * list afterward.
+ */
+export async function rescanForge(): Promise<void> {
+  await invoke('rescan_forge');
+}
+
+/**
+ * Opens the Forge directory in the system file browser. macOS only — a no-op
+ * on other platforms.
+ */
+export async function openForgeInFinder(): Promise<void> {
+  await invoke('open_forge_in_finder');
 }
 
 // Export/Import Functions


### PR DESCRIPTION
## Summary

Makes Moldavite's note storage friendly to external tools (Obsidian, AI agents reading raw .md, scripts) and renames the user-facing concept to **Forge**.

### Storage format
- YAML frontmatter on every note (just \`color: blue\` for now, schema designed to be extensible — unknown keys are preserved on round-trip)
- One-shot idempotent migration: \`.note-metadata.json\` → per-file frontmatter, then renames to \`.note-metadata.json.migrated\`. Runs on every launch, safe to re-run.
- Backlinks index + full-text search now strip frontmatter before indexing so YAML keys don't pollute results.

### File watcher
- New \`src-tauri/src/forge_watcher.rs\` using \`notify\` v6 + 300ms debounce
- Self-write ignore-list (\`~500ms\`) suppresses echo events from Moldavite's own writes
- Filters dotfiles, \`.trash/\`, non-\`.md\` files
- Emits \`forge:changed { kind, relPath }\` to the frontend
- Frontend hook \`useForgeWatcher.ts\` coalesces bursts and refreshes the notes list

### Rescan + Open
- \`rescan_forge\` IPC re-runs the directory scan + rebuilds the in-memory backlinks index
- \`open_forge_in_finder\` IPC reveals the directory in Finder (macOS)
- Both surfaced as buttons in Settings → General

### Docs
- New \`docs/FORGE.md\` — directory layout, frontmatter schema, wiki-link syntax, locked-file caveat, external-tool guidance
- README links to FORGE.md

### UI rename
Settings copy now reads "Forge" / "Forge location" / "Open Forge in Finder" / "Rescan Forge". Internal IPC names (\`get_notes_directory\`, \`set_notes_directory\`) unchanged for backwards compatibility.

### Cleanup
Removed unused \`read_note_metadata\` / \`write_note_metadata\` / \`NoteMetadata\` (sidecar metadata is now obsolete after migration).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` (0 errors)
- [x] \`npm test\` 17/17
- [x] \`npm run build\` succeeds
- [x] \`npm run check:size\` app JS 396.0 KB / 103.9 KB gz
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo test --lib\` 75/75 (+17 new — frontmatter parser/serializer, migration idempotency, watcher event filtering)

## Manual QA recommended
- Open existing vault → confirm migrated frontmatter + colors render
- Drop a new \`.md\` file in via Finder → it should appear in the sidebar within ~300ms
- Edit a note in an external editor → Moldavite should refresh
- Click "Rescan Forge" in Settings → list updates and toast confirms

## Known scope
- Watcher does NOT explicitly restart on \`set_notes_directory\` because that command already triggers \`window.location.reload()\` — the whole app process restarts and gets a fresh watcher. If the reload is ever removed, this needs an explicit re-spawn.
