### PR TITLE
fix: calendar grid shrinks instead of clipping in narrow right sidebar

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -84,13 +84,13 @@ export function Calendar() {
   };
 
   return (
-    <div className="select-none">
+    <div className="select-none min-w-0 w-full">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center justify-between mb-3 min-w-0 gap-1">
         <button
           onClick={handlePrevMonth}
           aria-label="Previous month"
-          className="p-1 transition-colors"
+          className="p-1 transition-colors flex-shrink-0"
           style={{ borderRadius: 'var(--radius-sm)', color: 'var(--text-secondary)' }}
           onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'var(--hover-overlay)'}
           onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
@@ -99,13 +99,16 @@ export function Calendar() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+        <span
+          className="text-sm font-medium truncate min-w-0 text-center"
+          style={{ color: 'var(--text-primary)' }}
+        >
           {format(viewDate, 'MMMM yyyy')}
         </span>
         <button
           onClick={handleNextMonth}
           aria-label="Next month"
-          className="p-1 transition-colors"
+          className="p-1 transition-colors flex-shrink-0"
           style={{ borderRadius: 'var(--radius-sm)', color: 'var(--text-secondary)' }}
           onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'var(--hover-overlay)'}
           onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
@@ -117,7 +120,7 @@ export function Calendar() {
       </div>
 
       {/* Day headers with week column */}
-      <div className="grid gap-0.5 mb-1" style={{ gridTemplateColumns: '24px repeat(7, 1fr)' }}>
+      <div className="grid gap-0.5 mb-1" style={{ gridTemplateColumns: '20px repeat(7, minmax(0, 1fr))' }}>
         {/* Week header */}
         <div
           className="text-center text-xs font-medium py-1"
@@ -148,7 +151,7 @@ export function Calendar() {
             <div
               key={weekIndex}
               className="grid gap-0.5"
-              style={{ gridTemplateColumns: '24px repeat(7, 1fr)' }}
+              style={{ gridTemplateColumns: '20px repeat(7, minmax(0, 1fr))' }}
             >
               {/* Week number */}
               <button

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -6,10 +6,13 @@ export function RightPanel() {
   const { showCalendarWidget, showTimelineWidget } = useSettingsStore();
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full min-w-0 overflow-hidden">
       {/* Calendar */}
       {showCalendarWidget && (
-        <div className="p-4" style={{ borderBottom: '1px solid var(--border-default)' }}>
+        <div
+          className="p-4 min-w-0 overflow-hidden"
+          style={{ borderBottom: '1px solid var(--border-default)' }}
+        >
           <Calendar />
         </div>
       )}


### PR DESCRIPTION
Bug: shrinking the right sidebar clipped the calendar; timeline + month-switch should remain visible.

Fix: `grid-cols` use `minmax(0, 1fr)`, add `min-w-0` to grid containers, mark month buttons `flex-shrink-0`, label `truncate`. Calendar now scales down gracefully.
