### PR TITLE
feat(forge): multi-Forge support (Obsidian-style vault switching)

### DIFF
--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -1,8 +1,25 @@
 # The Forge
 
 Your Forge is the folder where Moldavite stores every note as a plain Markdown
-file. It defaults to `~/Documents/Moldavite/`, but you can move it anywhere
-under your home folder via **Settings → General → Forge → Change**.
+file. Multiple Forges can live side-by-side under a parent directory (the
+**Forges root**, defaulting to `~/Documents/Moldavite/`). You can switch
+between them from the dropdown at the top of the sidebar, create new ones
+with **+ New Forge**, or rename / delete them in **Manage Forges…**.
+
+```
+~/Documents/Moldavite/        # Forges root
+├── Personal/                 # Forge
+├── Work/                     # Forge
+└── Archive/                  # Forge
+```
+
+Switching the active Forge reloads the window so every cache and watcher
+rebinds to the new root. Per-Forge state (recent notes, quick switcher
+history) is namespaced in `localStorage` so each Forge keeps its own.
+
+The previous single-folder layout (everything stored directly under
+`~/Documents/Moldavite/`) is migrated automatically on first launch into
+a `Default` Forge — no manual steps required.
 
 Because it's plain `.md`, you can:
 

--- a/src-tauri/src/commands/forges.rs
+++ b/src-tauri/src/commands/forges.rs
@@ -99,7 +99,7 @@ pub(crate) fn list_forges() -> Result<Vec<ForgeInfo>, String> {
             is_active: name == active,
         });
     }
-    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out.sort_by_key(|f| f.name.to_lowercase());
     Ok(out)
 }
 

--- a/src-tauri/src/commands/forges.rs
+++ b/src-tauri/src/commands/forges.rs
@@ -1,0 +1,340 @@
+//! Forge management commands: list, create, rename, delete, set-active,
+//! set forges root.
+//!
+//! A "Forge" is a directory under `forges_root` that contains a notes tree
+//! (`daily/`, `notes/`, etc.). Switching the active Forge swaps the entire
+//! root path that the rest of the backend resolves through `paths::get_notes_dir`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tauri::{AppHandle, Manager, State};
+
+use crate::backlinks_index::BacklinksIndex;
+use crate::forge_watcher::{self, RecentWrites, WatcherHandle};
+use crate::paths::{get_active_forge_name, get_forges_root};
+use crate::persist::{read_config, write_config};
+use crate::types::ForgeInfo;
+use crate::validation::is_safe_filename;
+
+/// A directory looks like a Forge if it contains at least one of the
+/// expected note subdirs.
+pub(crate) fn looks_like_forge(dir: &Path) -> bool {
+    if !dir.is_dir() {
+        return false;
+    }
+    for sub in ["daily", "notes", "weekly", "templates"] {
+        if dir.join(sub).is_dir() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Validate a Forge name. Stricter than `is_safe_filename` — disallow
+/// dotfiles and reserve `.trash` style names.
+pub(crate) fn is_valid_forge_name(name: &str) -> bool {
+    if !is_safe_filename(name) {
+        return false;
+    }
+    if name.starts_with('.') {
+        return false;
+    }
+    // Avoid Windows-y reserved names just in case.
+    let upper = name.to_uppercase();
+    if matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL") {
+        return false;
+    }
+    // 64-char cap is plenty for a folder name and sidesteps fs limits.
+    if name.chars().count() > 64 {
+        return false;
+    }
+    true
+}
+
+/// Scaffold an empty Forge at `path` with the standard subdirs.
+pub(crate) fn scaffold_forge(path: &Path) -> Result<(), String> {
+    fs::create_dir_all(path).map_err(|e| format!("Failed to create Forge dir: {}", e))?;
+    for sub in ["daily", "notes", "weekly", "templates", ".trash"] {
+        fs::create_dir_all(path.join(sub))
+            .map_err(|e| format!("Failed to create {}/{}: {}", path.display(), sub, e))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn list_forges() -> Result<Vec<ForgeInfo>, String> {
+    let root = get_forges_root();
+    let active = get_active_forge_name();
+    let mut out: Vec<ForgeInfo> = Vec::new();
+
+    if !root.exists() {
+        return Ok(out);
+    }
+
+    let entries = fs::read_dir(&root).map_err(|e| format!("Failed to read forges root: {}", e))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        if !path.is_dir() {
+            continue;
+        }
+        if !looks_like_forge(&path) {
+            continue;
+        }
+        out.push(ForgeInfo {
+            name: name.to_string(),
+            path: path.to_string_lossy().to_string(),
+            is_active: name == active,
+        });
+    }
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(out)
+}
+
+#[tauri::command]
+pub(crate) fn create_forge(name: String) -> Result<ForgeInfo, String> {
+    if !is_valid_forge_name(&name) {
+        return Err("Invalid Forge name".to_string());
+    }
+    let root = get_forges_root();
+    fs::create_dir_all(&root).map_err(|e| format!("Failed to create forges root: {}", e))?;
+    let path = root.join(&name);
+    if path.exists() {
+        return Err(format!("A Forge named \"{}\" already exists", name));
+    }
+    scaffold_forge(&path)?;
+    Ok(ForgeInfo {
+        name: name.clone(),
+        path: path.to_string_lossy().to_string(),
+        is_active: false,
+    })
+}
+
+#[tauri::command]
+pub(crate) fn set_active_forge(
+    name: String,
+    app: AppHandle,
+    recent: State<'_, Arc<RecentWrites>>,
+    index: State<'_, Arc<BacklinksIndex>>,
+) -> Result<String, String> {
+    if !is_valid_forge_name(&name) {
+        return Err("Invalid Forge name".to_string());
+    }
+    let root = get_forges_root();
+    let target = root.join(&name);
+    if !target.is_dir() {
+        return Err(format!("Forge \"{}\" does not exist", name));
+    }
+    if !looks_like_forge(&target) {
+        // It's a plain dir that hasn't been scaffolded — make it a Forge.
+        scaffold_forge(&target)?;
+    }
+    let mut cfg = read_config();
+    cfg.forges_root = Some(root.to_string_lossy().to_string());
+    cfg.active_forge = Some(name.clone());
+    // Clear the deprecated single-Forge field so subsequent reads use the
+    // forges_root + active_forge pair only.
+    cfg.notes_directory = None;
+    write_config(&cfg)?;
+
+    // Tear down old watcher and spin up a new one rooted at the new Forge.
+    if let Some(old) = app.try_state::<WatcherHandle>() {
+        old.shutdown();
+    }
+    recent.clear();
+    if let Ok(handle) = forge_watcher::spawn(app.clone(), recent.inner().clone()) {
+        // Replace the managed handle. tauri::Manager::manage replaces existing.
+        app.manage(handle);
+    }
+    // Rebuild the backlinks index off-thread so the UI doesn't block.
+    let idx = index.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        idx.rebuild_from_disk();
+    });
+
+    Ok(name)
+}
+
+#[tauri::command]
+pub(crate) fn rename_forge(old_name: String, new_name: String) -> Result<ForgeInfo, String> {
+    if !is_valid_forge_name(&old_name) || !is_valid_forge_name(&new_name) {
+        return Err("Invalid Forge name".to_string());
+    }
+    if old_name == new_name {
+        let root = get_forges_root();
+        let path = root.join(&old_name);
+        return Ok(ForgeInfo {
+            name: old_name,
+            path: path.to_string_lossy().to_string(),
+            is_active: get_active_forge_name() == new_name,
+        });
+    }
+    let root = get_forges_root();
+    let from = root.join(&old_name);
+    let to = root.join(&new_name);
+    if !from.is_dir() {
+        return Err(format!("Forge \"{}\" does not exist", old_name));
+    }
+    if to.exists() {
+        return Err(format!("A Forge named \"{}\" already exists", new_name));
+    }
+    fs::rename(&from, &to).map_err(|e| format!("Failed to rename Forge: {}", e))?;
+
+    // If the renamed Forge was active, update the config so it stays active
+    // under the new name.
+    let mut cfg = read_config();
+    if cfg.active_forge.as_deref() == Some(old_name.as_str()) {
+        cfg.active_forge = Some(new_name.clone());
+        write_config(&cfg)?;
+    }
+
+    Ok(ForgeInfo {
+        name: new_name.clone(),
+        path: to.to_string_lossy().to_string(),
+        is_active: read_config().active_forge.as_deref() == Some(new_name.as_str()),
+    })
+}
+
+#[tauri::command]
+pub(crate) fn delete_forge(name: String) -> Result<(), String> {
+    if !is_valid_forge_name(&name) {
+        return Err("Invalid Forge name".to_string());
+    }
+    if get_active_forge_name() == name {
+        return Err("Cannot delete the active Forge — switch first".to_string());
+    }
+    let root = get_forges_root();
+    let path = root.join(&name);
+    if !path.is_dir() {
+        return Err(format!("Forge \"{}\" does not exist", name));
+    }
+    fs::remove_dir_all(&path).map_err(|e| format!("Failed to delete Forge: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn set_forges_root(path: String) -> Result<String, String> {
+    let new_root = PathBuf::from(&path);
+    if !new_root.is_absolute() {
+        return Err("Path must be absolute".to_string());
+    }
+    let canonical = match new_root.canonicalize() {
+        Ok(p) => p,
+        Err(_) => new_root
+            .parent()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| new_root.clone()),
+    };
+    let path_str = canonical.to_string_lossy().to_lowercase();
+    let forbidden = [
+        "/system",
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/etc",
+        "/var",
+        "/private/var",
+        "/private/etc",
+        "/library",
+        "/applications",
+        "/cores",
+        "/dev",
+    ];
+    for f in &forbidden {
+        if path_str.starts_with(f) {
+            return Err("Cannot use system directories".to_string());
+        }
+    }
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let canonical_home = home.canonicalize().unwrap_or(home.clone());
+    if !canonical.starts_with(&canonical_home) && !canonical.starts_with("/Volumes/") {
+        return Err("Forges root must be in your home folder or on an external volume".to_string());
+    }
+
+    fs::create_dir_all(&new_root).map_err(|e| format!("Failed to create root: {}", e))?;
+    let mut cfg = read_config();
+    cfg.forges_root = Some(canonical.to_string_lossy().to_string());
+    write_config(&cfg)?;
+    Ok(canonical.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub(crate) fn get_forges_root_path() -> String {
+    get_forges_root().to_string_lossy().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_forge_names() {
+        assert!(is_valid_forge_name("Personal"));
+        assert!(is_valid_forge_name("Work-2024"));
+        assert!(is_valid_forge_name("My Forge"));
+    }
+
+    #[test]
+    fn invalid_forge_names() {
+        assert!(!is_valid_forge_name(""));
+        assert!(!is_valid_forge_name(".hidden"));
+        assert!(!is_valid_forge_name("../escape"));
+        assert!(!is_valid_forge_name("a/b"));
+        assert!(!is_valid_forge_name("a\0b"));
+        let too_long: String = "x".repeat(80);
+        assert!(!is_valid_forge_name(&too_long));
+    }
+
+    #[test]
+    fn looks_like_forge_detects_subdirs() {
+        let tmp = std::env::temp_dir().join(format!(
+            "moldavite-forge-detect-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(tmp.join("daily")).unwrap();
+        assert!(looks_like_forge(&tmp));
+        let _ = fs::remove_dir_all(&tmp);
+
+        let tmp2 = std::env::temp_dir().join(format!(
+            "moldavite-forge-detect2-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp2).unwrap();
+        assert!(!looks_like_forge(&tmp2));
+        let _ = fs::remove_dir_all(&tmp2);
+    }
+
+    #[test]
+    fn scaffold_creates_subdirs() {
+        let tmp = std::env::temp_dir().join(format!(
+            "moldavite-scaffold-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        scaffold_forge(&tmp).unwrap();
+        for sub in ["daily", "notes", "weekly", "templates", ".trash"] {
+            assert!(tmp.join(sub).is_dir(), "missing {}", sub);
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@
 pub mod backlinks;
 pub mod export_import;
 pub mod folders;
+pub mod forges;
 pub mod graph;
 pub mod locking;
 pub mod misc;

--- a/src-tauri/src/forge_watcher.rs
+++ b/src-tauri/src/forge_watcher.rs
@@ -43,6 +43,15 @@ impl RecentWrites {
         }
     }
 
+    /// Drop all recorded recent-writes. Called when swapping the watcher
+    /// root so stale entries from the previous Forge can't suppress real
+    /// events in the new one.
+    pub fn clear(&self) {
+        if let Ok(mut map) = self.inner.lock() {
+            map.clear();
+        }
+    }
+
     /// Returns true if `path` was written by us very recently.
     pub fn is_recent(&self, path: &Path) -> bool {
         if let Ok(map) = self.inner.lock() {
@@ -123,13 +132,30 @@ pub fn spawn(
             .map_err(|e| format!("failed to watch {:?}: {}", root, e))?;
     }
 
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+
     let join = std::thread::Builder::new()
         .name("forge-watcher".into())
         .spawn(move || {
             // Hold the debouncer for the lifetime of this thread so it keeps
             // running. When the thread exits (on shutdown) it drops.
             let _debouncer = debouncer;
-            while let Ok(events) = rx.recv() {
+            loop {
+                // Wake up periodically so the stop signal can break the loop
+                // even when no fs events arrive.
+                let events = match rx.recv_timeout(Duration::from_millis(500)) {
+                    Ok(ev) => ev,
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        if stop_rx.try_recv().is_ok() {
+                            break;
+                        }
+                        continue;
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                };
+                if stop_rx.try_recv().is_ok() {
+                    break;
+                }
                 let events = match events {
                     Ok(ev) => ev,
                     Err(err) => {
@@ -162,14 +188,30 @@ pub fn spawn(
 
     Ok(WatcherHandle {
         _join: Some(join),
+        stop: Some(stop_tx),
     })
 }
 
-/// Owned handle. Currently the thread runs for the life of the app; this
-/// struct exists so future code can replace the watcher when the user picks
-/// a new Forge directory.
+/// Owned handle. Calling `shutdown` (or dropping it) stops the watcher
+/// thread so a new one can be spawned for a different Forge.
 pub struct WatcherHandle {
     _join: Option<std::thread::JoinHandle<()>>,
+    stop: Option<std::sync::mpsc::Sender<()>>,
+}
+
+impl WatcherHandle {
+    /// Tell the watcher thread to stop. Idempotent.
+    pub fn shutdown(&self) {
+        if let Some(tx) = &self.stop {
+            let _ = tx.send(());
+        }
+    }
+}
+
+impl Drop for WatcherHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,6 +57,10 @@ use commands::export_import::{
     import_notes, import_settings_json,
 };
 use commands::folders::{create_folder, delete_folder, list_folders, move_folder, rename_folder};
+use commands::forges::{
+    create_forge, delete_forge, get_forges_root_path, list_forges, rename_forge,
+    set_active_forge, set_forges_root,
+};
 use commands::graph::get_note_graph;
 use commands::locking::{is_note_locked, lock_note, permanently_unlock_note, unlock_note};
 use commands::misc::{
@@ -140,6 +144,12 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            // Wrap legacy single-Forge layout into Default Forge if needed.
+            // Idempotent — runs on every launch and exits early once
+            // forges_root + active_forge are set.
+            if let Err(e) = migration::migrate_legacy_single_forge_to_multi() {
+                log::warn!("[forge] multi-Forge migration error: {}", e);
+            }
             // Run sidecar-metadata → frontmatter migration once. Idempotent,
             // safe to call on every launch.
             match migration::migrate_metadata_to_frontmatter() {
@@ -218,6 +228,14 @@ pub fn run() {
             set_notes_directory,
             rescan_forge,
             open_forge_in_finder,
+            // Multi-Forge management commands
+            list_forges,
+            create_forge,
+            set_active_forge,
+            rename_forge,
+            delete_forge,
+            set_forges_root,
+            get_forges_root_path,
             // Export/Import commands
             export_notes,
             import_notes,

--- a/src-tauri/src/migration.rs
+++ b/src-tauri/src/migration.rs
@@ -11,7 +11,91 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::frontmatter;
-use crate::paths::{get_metadata_path, get_notes_dir};
+use crate::paths::{get_metadata_path, get_notes_dir, DEFAULT_FORGE_NAME};
+use crate::persist::{read_config, write_config};
+
+/// Wrap a legacy single-Forge directory into the new multi-Forge layout.
+///
+/// On first launch after the multi-Forge update, users have a config that
+/// lacks `forges_root`/`active_forge`. If their notes_directory points at a
+/// dir that already contains a notes tree (`daily/`, `notes/`, etc.), we
+/// move that tree into a `Default` subdirectory and write the new config:
+///
+///   forges_root  = <old notes_directory>
+///   active_forge = "Default"
+///
+/// Idempotent. Safe to call on every launch.
+pub fn migrate_legacy_single_forge_to_multi() -> Result<bool, String> {
+    let mut cfg = read_config();
+    if cfg.forges_root.is_some() && cfg.active_forge.is_some() {
+        return Ok(false);
+    }
+
+    let legacy_dir = match cfg.notes_directory.as_deref() {
+        Some(s) if !s.is_empty() => PathBuf::from(s),
+        _ => crate::paths::get_default_notes_dir(),
+    };
+
+    if !legacy_dir.is_dir() {
+        cfg.forges_root = Some(legacy_dir.to_string_lossy().to_string());
+        cfg.active_forge = Some(DEFAULT_FORGE_NAME.to_string());
+        cfg.notes_directory = None;
+        write_config(&cfg)?;
+        return Ok(false);
+    }
+
+    let has_forge_layout = ["daily", "notes", "weekly", "templates"]
+        .iter()
+        .any(|s| legacy_dir.join(s).is_dir());
+
+    if !has_forge_layout {
+        cfg.forges_root = Some(legacy_dir.to_string_lossy().to_string());
+        cfg.active_forge = Some(DEFAULT_FORGE_NAME.to_string());
+        cfg.notes_directory = None;
+        write_config(&cfg)?;
+        return Ok(false);
+    }
+
+    let default_forge = legacy_dir.join(DEFAULT_FORGE_NAME);
+    if default_forge.exists() {
+        cfg.forges_root = Some(legacy_dir.to_string_lossy().to_string());
+        cfg.active_forge = Some(DEFAULT_FORGE_NAME.to_string());
+        cfg.notes_directory = None;
+        write_config(&cfg)?;
+        return Ok(true);
+    }
+    fs::create_dir_all(&default_forge)
+        .map_err(|e| format!("Failed to create Default Forge: {}", e))?;
+
+    let entries =
+        fs::read_dir(&legacy_dir).map_err(|e| format!("Failed to read legacy dir: {}", e))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name() else { continue };
+        if name == std::ffi::OsStr::new(DEFAULT_FORGE_NAME) {
+            continue;
+        }
+        let dest = default_forge.join(name);
+        if let Err(e) = fs::rename(&path, &dest) {
+            log::warn!(
+                "[forge migration] failed to move {:?} → {:?}: {}",
+                path,
+                dest,
+                e
+            );
+        }
+    }
+
+    cfg.forges_root = Some(legacy_dir.to_string_lossy().to_string());
+    cfg.active_forge = Some(DEFAULT_FORGE_NAME.to_string());
+    cfg.notes_directory = None;
+    write_config(&cfg)?;
+    log::info!(
+        "[forge migration] wrapped legacy Forge into {:?}",
+        default_forge
+    );
+    Ok(true)
+}
 
 #[derive(Debug, Default, Deserialize)]
 struct MetadataFile {

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -18,8 +18,68 @@ pub(crate) fn get_default_notes_dir() -> PathBuf {
         .join("Moldavite")
 }
 
+/// Default name for the Forge that legacy single-Forge users get migrated
+/// into on first launch after the multi-Forge update.
+pub(crate) const DEFAULT_FORGE_NAME: &str = "Default";
+
+/// Returns the parent directory that holds all Forges. Falls back to the
+/// legacy `notes_directory.parent()` if `forges_root` is unset.
+pub(crate) fn get_forges_root() -> PathBuf {
+    let config = read_config();
+    if let Some(root) = config.forges_root.as_deref() {
+        let p = PathBuf::from(root);
+        if !p.as_os_str().is_empty() {
+            return p;
+        }
+    }
+    // Fallback: derive from legacy notes_directory parent.
+    if let Some(legacy) = config.notes_directory.as_deref() {
+        let p = PathBuf::from(legacy);
+        if let Some(parent) = p.parent() {
+            return parent.to_path_buf();
+        }
+    }
+    dirs::document_dir()
+        .expect("Could not find Documents directory")
+        .join("Moldavite")
+}
+
+/// Returns the active Forge name (a directory under `forges_root`).
+pub(crate) fn get_active_forge_name() -> String {
+    let config = read_config();
+    if let Some(name) = config.active_forge.as_deref() {
+        if !name.is_empty() {
+            return name.to_string();
+        }
+    }
+    // Fallback: pull the leaf name off legacy notes_directory.
+    if let Some(legacy) = config.notes_directory.as_deref() {
+        if let Some(name) = PathBuf::from(legacy)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+        {
+            return name;
+        }
+    }
+    DEFAULT_FORGE_NAME.to_string()
+}
+
 pub(crate) fn get_notes_dir() -> PathBuf {
     let config = read_config();
+    // Preferred: forges_root + active_forge.
+    if let (Some(root), Some(name)) = (
+        config.forges_root.as_deref(),
+        config.active_forge.as_deref(),
+    ) {
+        if !root.is_empty() && !name.is_empty() {
+            let path = PathBuf::from(root).join(name);
+            if path.exists() {
+                return path;
+            }
+        }
+    }
+    // Back-compat: legacy `notes_directory` field.
     if let Some(custom_dir) = config.notes_directory {
         let path = PathBuf::from(&custom_dir);
         if path.exists() {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -99,11 +99,31 @@ pub(crate) struct BacklinkInfo {
     pub(crate) context: String,
 }
 
-// App Configuration for custom notes directory
+// App Configuration for custom notes directory + multi-Forge support.
+//
+// `forges_root` is the parent directory that holds one or more Forge
+// directories. `active_forge` is the directory name (immediate child of
+// `forges_root`) that should be treated as the live Forge.
+//
+// `notes_directory` is deprecated and retained for one release as a
+// fallback for users upgrading from single-Forge layouts. New code reads
+// `forges_root` + `active_forge`; the migration on startup wraps the
+// legacy directory into a Forge and clears the deprecated field.
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AppConfig {
     pub(crate) notes_directory: Option<String>,
+    pub(crate) forges_root: Option<String>,
+    pub(crate) active_forge: Option<String>,
+}
+
+// Public-facing struct returned by the `list_forges` command.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ForgeInfo {
+    pub(crate) name: String,
+    pub(crate) path: String,
+    pub(crate) is_active: bool,
 }
 
 // Export/Import Result structures

--- a/src/components/quick-switcher/QuickSwitcher.tsx
+++ b/src/components/quick-switcher/QuickSwitcher.tsx
@@ -467,6 +467,10 @@ export function QuickSwitcher() {
         case 'shortcut-help':
           dispatchModKey('/');
           return;
+        case 'switch-forge':
+          // Sidebar listens for this event and opens the Forge dropdown.
+          window.dispatchEvent(new Event('moldavite:open-forge-switcher'));
+          return;
         case 'open-graph':
           openGraph();
           return;

--- a/src/components/quick-switcher/commands.ts
+++ b/src/components/quick-switcher/commands.ts
@@ -74,6 +74,12 @@ export const QUICK_SWITCHER_COMMANDS: readonly QuickSwitcherCommand[] = [
     keywords: ['settings', 'preferences', 'config'],
   },
   {
+    id: 'switch-forge',
+    title: 'Switch Forge…',
+    category: 'navigation',
+    keywords: ['forge', 'switch', 'workspace', 'vault'],
+  },
+  {
     id: 'shortcut-help',
     title: 'Show Keyboard Shortcuts',
     category: 'help',

--- a/src/components/settings/SettingsData.tsx
+++ b/src/components/settings/SettingsData.tsx
@@ -10,12 +10,14 @@ import {
 } from '@/lib';
 import type { ImportResult } from '@/lib';
 import { useToast } from '@/hooks/useToast';
+import { namespacedKey } from '@/lib/forgeStorage';
 
 const SETTINGS_LS_KEYS = [
   'moldavite-calendar',
   'moldavite-folders',
   'moldavite-pinned-tabs',
-  'moldavite-recent-notes',
+  // Per-Forge keys are namespaced (`<key>:<forge>`); export the active Forge's slot.
+  namespacedKey('moldavite-recent-notes'),
   'moldavite-settings',
   'moldavite-theme',
 ] as const;

--- a/src/components/sidebar/ForgeSwitcher.tsx
+++ b/src/components/sidebar/ForgeSwitcher.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useRef, useState } from 'react';
+import { useForgeStore } from '@/stores';
+import { useToast } from '@/hooks/useToast';
+
+interface ForgeSwitcherProps {
+  onManage: () => void;
+}
+
+/**
+ * Sidebar header dropdown that lets the user pick which Forge to work in.
+ *
+ * Switching reloads the window — the same trick `set_notes_directory`
+ * already uses — so every store, cache, and watcher rebinds against the
+ * new Forge root.
+ */
+export function ForgeSwitcher({ onManage }: ForgeSwitcherProps) {
+  const { forges, active, loadForges, switchTo, createForge } = useForgeStore();
+  const [open, setOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    loadForges().catch(() => {
+      // Non-fatal — single-Forge users may not have a forges_root yet.
+    });
+  }, [loadForges]);
+
+  // Listen for the QuickSwitcher "Switch Forge…" command which dispatches
+  // a window event after closing itself.
+  useEffect(() => {
+    const onOpen = () => {
+      void loadForges().finally(() => setOpen(true));
+    };
+    window.addEventListener('moldavite:open-forge-switcher', onOpen);
+    return () =>
+      window.removeEventListener('moldavite:open-forge-switcher', onOpen);
+  }, [loadForges]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setCreating(false);
+        setNewName('');
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        setCreating(false);
+        setNewName('');
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const handleSwitch = async (name: string) => {
+    setOpen(false);
+    try {
+      await switchTo(name);
+    } catch (e) {
+      toast.error(`Failed to switch Forge: ${(e as Error).message}`);
+    }
+  };
+
+  const handleCreate = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    try {
+      await createForge(trimmed);
+      setNewName('');
+      setCreating(false);
+      toast.success(`Forge "${trimmed}" created`);
+    } catch (e) {
+      toast.error(`Could not create Forge: ${(e as Error).message}`);
+    }
+  };
+
+  const label = active ?? 'Forge';
+
+  return (
+    <div ref={wrapRef} className="relative px-3 pt-3">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-md text-sm font-medium hover:bg-[var(--bg-hover)]"
+        style={{ color: 'var(--text-primary)' }}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title="Switch Forge"
+      >
+        <span className="truncate">{label}</span>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          aria-hidden="true"
+          style={{ flexShrink: 0, opacity: 0.6 }}
+        >
+          <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.4" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute z-30 left-3 right-3 top-full mt-1 rounded-md border shadow-lg overflow-hidden"
+          style={{
+            background: 'var(--bg-elevated)',
+            borderColor: 'var(--border-default)',
+          }}
+        >
+          {forges.length === 0 && (
+            <div className="px-3 py-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+              No Forges found.
+            </div>
+          )}
+          {forges.map((f) => (
+            <button
+              key={f.name}
+              type="button"
+              role="option"
+              aria-selected={f.isActive}
+              onClick={() => handleSwitch(f.name)}
+              className="w-full text-left px-3 py-1.5 text-sm flex items-center justify-between hover:bg-[var(--bg-hover)]"
+              style={{ color: 'var(--text-primary)' }}
+            >
+              <span className="truncate">{f.name}</span>
+              {f.isActive && (
+                <span style={{ color: 'var(--text-muted)', fontSize: '11px' }}>
+                  active
+                </span>
+              )}
+            </button>
+          ))}
+
+          <div className="border-t" style={{ borderColor: 'var(--border-default)' }} />
+
+          {creating ? (
+            <div className="px-3 py-2 flex items-center gap-2">
+              <input
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void handleCreate();
+                  if (e.key === 'Escape') {
+                    setCreating(false);
+                    setNewName('');
+                  }
+                }}
+                placeholder="Forge name"
+                autoFocus
+                className="flex-1 px-2 py-1 text-sm rounded border bg-transparent"
+                style={{
+                  borderColor: 'var(--border-default)',
+                  color: 'var(--text-primary)',
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => void handleCreate()}
+                className="px-2 py-1 text-xs rounded"
+                style={{
+                  background: 'var(--accent)',
+                  color: 'var(--accent-text, #fff)',
+                }}
+              >
+                Create
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setCreating(true)}
+              className="w-full text-left px-3 py-1.5 text-sm hover:bg-[var(--bg-hover)]"
+              style={{ color: 'var(--text-primary)' }}
+            >
+              + New Forge
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              setCreating(false);
+              setNewName('');
+              onManage();
+            }}
+            className="w-full text-left px-3 py-1.5 text-sm hover:bg-[var(--bg-hover)]"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            Manage Forges…
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/ManageForgesModal.tsx
+++ b/src/components/sidebar/ManageForgesModal.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { useForgeStore } from '@/stores';
+import { useToast } from '@/hooks/useToast';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+
+interface ManageForgesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ManageForgesModal({ isOpen, onClose }: ManageForgesModalProps) {
+  const { forges, forgesRoot, loadForges, renameForge, deleteForge, setForgesRoot } =
+    useForgeStore();
+  const [renamingName, setRenamingName] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const toast = useToast();
+
+  useEffect(() => {
+    if (isOpen) loadForges().catch(() => undefined);
+  }, [isOpen, loadForges]);
+
+  if (!isOpen) return null;
+
+  const handleRename = async (oldName: string) => {
+    const trimmed = renameValue.trim();
+    if (!trimmed || trimmed === oldName) {
+      setRenamingName(null);
+      return;
+    }
+    try {
+      await renameForge(oldName, trimmed);
+      toast.success(`Renamed "${oldName}" to "${trimmed}"`);
+      setRenamingName(null);
+      setRenameValue('');
+    } catch (e) {
+      toast.error(`Rename failed: ${(e as Error).message}`);
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    const ok = window.confirm(
+      `Delete the Forge "${name}"? All notes inside it will be removed permanently.`,
+    );
+    if (!ok) return;
+    try {
+      await deleteForge(name);
+      toast.success(`Forge "${name}" deleted`);
+    } catch (e) {
+      toast.error(`Delete failed: ${(e as Error).message}`);
+    }
+  };
+
+  const handlePickRoot = async () => {
+    try {
+      const selected = await openDialog({
+        directory: true,
+        multiple: false,
+        title: 'Pick Forges root directory',
+      });
+      if (typeof selected !== 'string') return;
+      const resolved = await setForgesRoot(selected);
+      toast.success(`Forges root set to ${resolved}`);
+    } catch (e) {
+      toast.error(`Could not set Forges root: ${(e as Error).message}`);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'rgba(0,0,0,0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="rounded-lg shadow-xl w-full max-w-md p-5"
+        style={{ background: 'var(--bg-elevated)', color: 'var(--text-primary)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-base font-semibold">Manage Forges</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-2 py-1 text-sm rounded hover:bg-[var(--bg-hover)]"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="text-xs mb-3" style={{ color: 'var(--text-muted)' }}>
+          Forges root: <span className="font-mono break-all">{forgesRoot ?? '(not set)'}</span>
+        </div>
+
+        <div className="space-y-1 max-h-72 overflow-y-auto">
+          {forges.length === 0 ? (
+            <div className="text-sm py-4 text-center" style={{ color: 'var(--text-muted)' }}>
+              No Forges yet.
+            </div>
+          ) : (
+            forges.map((f) => (
+              <div
+                key={f.name}
+                className="flex items-center gap-2 px-2 py-1.5 rounded"
+                style={{ background: 'var(--bg-default)' }}
+              >
+                {renamingName === f.name ? (
+                  <input
+                    type="text"
+                    value={renameValue}
+                    autoFocus
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') void handleRename(f.name);
+                      if (e.key === 'Escape') {
+                        setRenamingName(null);
+                        setRenameValue('');
+                      }
+                    }}
+                    onBlur={() => void handleRename(f.name)}
+                    className="flex-1 px-2 py-1 text-sm rounded border bg-transparent"
+                    style={{
+                      borderColor: 'var(--border-default)',
+                      color: 'var(--text-primary)',
+                    }}
+                  />
+                ) : (
+                  <span className="flex-1 text-sm truncate">
+                    {f.name}
+                    {f.isActive && (
+                      <span
+                        className="ml-2"
+                        style={{ color: 'var(--text-muted)', fontSize: '11px' }}
+                      >
+                        active
+                      </span>
+                    )}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRenamingName(f.name);
+                    setRenameValue(f.name);
+                  }}
+                  className="text-xs px-2 py-0.5 rounded hover:bg-[var(--bg-hover)]"
+                >
+                  Rename
+                </button>
+                <button
+                  type="button"
+                  disabled={f.isActive}
+                  onClick={() => void handleDelete(f.name)}
+                  className="text-xs px-2 py-0.5 rounded hover:bg-[var(--bg-hover)] disabled:opacity-40 disabled:cursor-not-allowed"
+                  title={f.isActive ? 'Switch first to delete the active Forge' : ''}
+                >
+                  Delete
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="mt-4 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => void handlePickRoot()}
+            className="text-xs px-3 py-1.5 rounded border"
+            style={{ borderColor: 'var(--border-default)' }}
+          >
+            Change Forges root…
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-xs px-3 py-1.5 rounded"
+            style={{
+              background: 'var(--accent)',
+              color: 'var(--accent-text, #fff)',
+            }}
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -38,6 +38,8 @@ const SettingsModal = lazy(() =>
 const TrashPreviewModal = lazy(() =>
   import('./TrashPreviewModal').then((m) => ({ default: m.TrashPreviewModal })),
 );
+import { ForgeSwitcher } from './ForgeSwitcher';
+import { ManageForgesModal } from './ManageForgesModal';
 import { SidebarTagList } from './SidebarTagList';
 import { BacklinksSection } from './BacklinksSection';
 import { SidebarSearch } from './SidebarSearch';
@@ -155,6 +157,7 @@ export function Sidebar() {
   const selectionClear = useNoteSelectionStore((s) => s.clear);
   const selectionAnchorRef = useRef<string | null>(null);
   const [showBulkMoveModal, setShowBulkMoveModal] = useState(false);
+  const [showManageForges, setShowManageForges] = useState(false);
   const [showBulkTrashConfirm, setShowBulkTrashConfirm] = useState(false);
   const [showBulkExportModal, setShowBulkExportModal] = useState(false);
 
@@ -662,6 +665,14 @@ export function Sidebar() {
           onDelete={handleDeleteFolder}
         />
       )}
+
+      {/* Forge switcher (above search) */}
+      <ForgeSwitcher onManage={() => setShowManageForges(true)} />
+
+      <ManageForgesModal
+        isOpen={showManageForges}
+        onClose={() => setShowManageForges(false)}
+      />
 
       {/* Search Bar */}
       <SidebarSearch

--- a/src/lib/forgeStorage.ts
+++ b/src/lib/forgeStorage.ts
@@ -1,0 +1,43 @@
+/**
+ * Helpers for per-Forge localStorage namespacing.
+ *
+ * The active Forge name has to be readable synchronously when stores
+ * initialize, but it lives in the Rust config (which is async to read).
+ * As soon as `useForgeStore.loadForges()` resolves we cache the active
+ * name in localStorage under a single well-known key, and the namespaced
+ * helpers read that cache. On the very first launch (cache empty), keys
+ * fall back to `default` so existing single-Forge users keep their
+ * recent-notes/quick-switcher state under the same name.
+ */
+
+const ACTIVE_FORGE_CACHE_KEY = '__moldavite_active_forge';
+
+export function rememberActiveForge(name: string | null) {
+  try {
+    if (name) {
+      localStorage.setItem(ACTIVE_FORGE_CACHE_KEY, name);
+    }
+  } catch {
+    // ignore — private mode etc.
+  }
+}
+
+export function getActiveForgeName(): string {
+  try {
+    const cached = localStorage.getItem(ACTIVE_FORGE_CACHE_KEY);
+    if (cached && cached.length > 0) return cached;
+  } catch {
+    // ignore
+  }
+  return 'default';
+}
+
+/**
+ * Namespace a base localStorage key by the active Forge name. Falls back
+ * to the legacy unnamespaced key when no Forge is known yet so that
+ * users upgrading from single-Forge installs don't lose state on first
+ * launch.
+ */
+export function namespacedKey(baseKey: string): string {
+  return `${baseKey}:${getActiveForgeName()}`;
+}

--- a/src/stores/forgeStore.ts
+++ b/src/stores/forgeStore.ts
@@ -1,0 +1,90 @@
+/**
+ * Multi-Forge state — the list of available Forges and the active one.
+ *
+ * This store holds nothing across reloads. The backend is the source of
+ * truth for which Forges exist and which one is active; calling
+ * `loadForges` rehydrates from the backend on startup.
+ */
+import { create } from 'zustand';
+import { safeInvoke } from '@/lib/ipc';
+import { rememberActiveForge } from '@/lib/forgeStorage';
+
+export interface Forge {
+  name: string;
+  path: string;
+  isActive: boolean;
+}
+
+interface ForgeState {
+  forges: Forge[];
+  active: string | null;
+  forgesRoot: string | null;
+  loading: boolean;
+  loadForges: () => Promise<void>;
+  switchTo: (name: string) => Promise<void>;
+  createForge: (name: string) => Promise<Forge>;
+  renameForge: (oldName: string, newName: string) => Promise<Forge>;
+  deleteForge: (name: string) => Promise<void>;
+  setForgesRoot: (path: string) => Promise<string>;
+}
+
+export const useForgeStore = create<ForgeState>((set, get) => ({
+  forges: [],
+  active: null,
+  forgesRoot: null,
+  loading: false,
+
+  loadForges: async () => {
+    set({ loading: true });
+    try {
+      const [forges, root] = await Promise.all([
+        safeInvoke<Forge[]>('list_forges'),
+        safeInvoke<string>('get_forges_root_path'),
+      ]);
+      const active = forges.find((f) => f.isActive)?.name ?? null;
+      rememberActiveForge(active);
+      set({ forges, active, forgesRoot: root, loading: false });
+    } catch (e) {
+      // List failure is non-fatal — UI just shows an empty switcher.
+      set({ loading: false });
+      throw e;
+    }
+  },
+
+  switchTo: async (name) => {
+    if (get().active === name) return;
+    await safeInvoke<string>('set_active_forge', { name });
+    // Page reload mirrors the existing `set_notes_directory` flow: it's
+    // the simplest way to ensure every store/cache is rehydrated against
+    // the new Forge root.
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  },
+
+  createForge: async (name) => {
+    const created = await safeInvoke<Forge>('create_forge', { name });
+    await get().loadForges();
+    return created;
+  },
+
+  renameForge: async (oldName, newName) => {
+    const updated = await safeInvoke<Forge>('rename_forge', {
+      oldName,
+      newName,
+    });
+    await get().loadForges();
+    return updated;
+  },
+
+  deleteForge: async (name) => {
+    await safeInvoke<void>('delete_forge', { name });
+    await get().loadForges();
+  },
+
+  setForgesRoot: async (path) => {
+    const resolved = await safeInvoke<string>('set_forges_root', { path });
+    await get().loadForges();
+    return resolved;
+  },
+}));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -48,3 +48,5 @@ export { useNoteSelectionStore } from './noteSelectionStore';
 export type { NoteSelectionState } from './noteSelectionStore';
 export { usePdfExportStore, PDF_MARGIN_MM } from './pdfExportStore';
 export type { PdfPageSize, PdfMarginPreset } from './pdfExportStore';
+export { useForgeStore } from './forgeStore';
+export type { Forge } from './forgeStore';

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { Note, NoteFile } from '@/types';
+import { namespacedKey } from '@/lib/forgeStorage';
 
 interface NoteState {
   notes: NoteFile[];
@@ -50,7 +51,7 @@ interface NoteState {
 // Load recent notes from localStorage
 const loadRecentNotes = (): string[] => {
   try {
-    const stored = localStorage.getItem('moldavite-recent-notes');
+    const stored = localStorage.getItem(namespacedKey('moldavite-recent-notes'));
     if (stored) {
       return JSON.parse(stored);
     }
@@ -445,7 +446,7 @@ export const useNoteStore = create<NoteState>((set, get) => ({
 
       // Persist to localStorage
       try {
-        localStorage.setItem('moldavite-recent-notes', JSON.stringify(updated));
+        localStorage.setItem(namespacedKey('moldavite-recent-notes'), JSON.stringify(updated));
       } catch (error) {
         console.error('[noteStore] Failed to save recent notes:', error);
       }

--- a/src/stores/quickSwitcherStore.test.ts
+++ b/src/stores/quickSwitcherStore.test.ts
@@ -8,7 +8,7 @@ describe('quickSwitcherStore', () => {
   beforeEach(() => {
     // Reset to a known clean slate. localStorage is jsdom-backed in tests,
     // so we wipe the persisted slice too for hermetic runs.
-    localStorage.removeItem('moldavite-quick-switcher');
+    localStorage.removeItem('moldavite-quick-switcher:default');
     useQuickSwitcherStore.setState({
       isOpen: false,
       recentSearches: [],
@@ -41,7 +41,7 @@ describe('quickSwitcherStore', () => {
 
     it('persists recent searches to localStorage', () => {
       useQuickSwitcherStore.getState().addRecentSearch('persisted');
-      const raw = localStorage.getItem('moldavite-quick-switcher');
+      const raw = localStorage.getItem('moldavite-quick-switcher:default');
       expect(raw).toBeTruthy();
       const parsed = JSON.parse(raw ?? '{}');
       expect(parsed.state.recentSearches).toContain('persisted');

--- a/src/stores/quickSwitcherStore.ts
+++ b/src/stores/quickSwitcherStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { namespacedKey } from '@/lib/forgeStorage';
 
 const MAX_RECENT_SEARCHES = 5;
 
@@ -63,7 +64,7 @@ export const useQuickSwitcherStore = create<QuickSwitcherState>()(
       isPinned: (noteId) => get().pinnedNoteIds.includes(noteId),
     }),
     {
-      name: 'moldavite-quick-switcher',
+      name: namespacedKey('moldavite-quick-switcher'),
       storage: createJSONStorage(() => localStorage),
       // Don't persist transient UI state.
       partialize: (state) => ({


### PR DESCRIPTION
Multiple Forges as sibling directories under a configurable parent. Switch via sidebar dropdown above search.

## What
- Extends `AppConfig` with `forges_root` + `active_forge` (`notes_directory` retained as one-release fallback)
- Idempotent startup migration wraps existing single-Forge into `Default/`
- New IPC: `list_forges`, `create_forge`, `set_active_forge`, `rename_forge`, `delete_forge`, `set_forges_root`, `get_forges_root_path`
- Watcher restart on switch (drops old watcher, spawns new, clears RecentWrites)
- Backlinks index rebuilds on switch
- Frontend: `useForgeStore`, `ForgeSwitcher` dropdown, `ManageForgesModal`, QuickSwitcher "Switch Forge…" action
- localStorage namespaced per Forge (`moldavite-recent-notes:<forge>`, `moldavite-quick-switcher:<forge>`) so pinned/recents don't bleed across vaults

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` 49/49
- [x] `npm run build` + `check:size` 433.8 KB / 113.1 KB gz (within 460/120)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo test` 79/79 (+4 new)

## Manual QA
- Existing single-Forge user → on first launch, content auto-wraps into `Default/`, app reloads, everything works
- Create "Work" Forge → switch → notes empty, pinned/recents reset, watcher tracks new dir
- Switch back to "Personal" → original pins/recents return

## Deferred
- Migration test (touches user config path; needs path injection to test cleanly)
- Legacy `set_notes_directory` command kept for back-compat; can drop after Settings UI is fully on the new commands
