### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Moldavite are documented here.
 
+## [1.3.0] - 2026-05-02
+
+### Added
+- **Multiple Forges** — sibling vault directories you can switch between (Obsidian-style). New sidebar dropdown above the search bar lists all Forges; "Manage Forges…" lets you create/rename/delete. Each Forge has its own pinned/recent state (localStorage namespaced per-Forge). Existing single-Forge users auto-migrate on first launch — content wraps into a `Default/` Forge in place. New IPC: `list_forges`, `create_forge`, `set_active_forge`, `rename_forge`, `delete_forge`, `set_forges_root`, `get_forges_root_path`. QuickSwitcher gains a "Switch Forge…" action.
+- **Settings tab navigation** — the modal now has a left tab list instead of a long vertical scroll. Up/Down/Home/End keyboard nav, full ARIA tablist semantics.
+- **Plugins design doc** — `docs/PLUGINS_DESIGN.md` records the intended shape for an Obsidian-style plugin system (no implementation yet — design only).
+
+### Fixed
+- **Right sidebar resizing** — calendar grid now shrinks gracefully instead of clipping when the sidebar narrows; timeline + month-switch buttons remain visible at minimum width.
+- **Theme preset / dark base mode mismatch** — picking a light-only preset (Sepia) while in dark mode no longer leaves the editor with a black background and Sepia chrome. The applied preset auto-falls back to default when the picked preset doesn't cover the active base mode; the user's preference stays stored.
+- **Settings → Templates** — section was rendering see-through under non-default presets due to hardcoded Tailwind grays. Now uses theme tokens (`var(--bg-*)`, `var(--text-*)`).
+
+### Changed
+- File watcher restarts cleanly on Forge switch (drops old watcher, spawns a new one rooted at the new active Forge, clears the self-write ignore-list).
+
 ## [1.2.0] - 2026-05-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.2.0"
+version = "1.3.0"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bumps to 1.3.0 + CHANGELOG.

Highlights: multi-Forge, Settings tab nav, calendar shrink fix, theme preset fallback, Settings Templates token fix, plugins design doc.

After merge I'll tag v1.3.0 to trigger the release workflow.