### PR TITLE
fix(tabs): pinned tabs survive sidebar navigation

### DIFF
--- a/src/stores/noteStore.test.ts
+++ b/src/stores/noteStore.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useNoteStore } from './noteStore';
+import type { Note } from '@/types';
+
+const makeNote = (id: string, overrides: Partial<Note> = {}): Note => ({
+  id,
+  title: id,
+  content: `<p>${id}</p>`,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  isDaily: false,
+  isWeekly: false,
+  ...overrides,
+});
+
+describe('noteStore - pinned tabs', () => {
+  beforeEach(() => {
+    localStorage.removeItem('moldavite-pinned-tabs');
+    useNoteStore.setState({
+      notes: [],
+      openTabs: [],
+      activeTabId: null,
+      currentNote: null,
+      isLoading: false,
+      isSaving: false,
+    });
+  });
+
+  it('opens sidebar note in a new tab when active tab is pinned (does not replace pinned tab)', () => {
+    const { openTab, pinTab, setCurrentNote } = useNoteStore.getState();
+
+    // Open first note as preview tab
+    const a = makeNote('a');
+    openTab(a, false);
+    expect(useNoteStore.getState().openTabs).toHaveLength(1);
+
+    // Pin the active tab
+    const result = pinTab('a');
+    expect(result.success).toBe(true);
+    expect(useNoteStore.getState().openTabs[0].isPinned).toBe(true);
+
+    // Click another sidebar note (uses setCurrentNote -> openTab(note, false))
+    const b = makeNote('b');
+    setCurrentNote(b);
+
+    const state = useNoteStore.getState();
+    expect(state.openTabs).toHaveLength(2);
+    expect(state.openTabs.map((t) => t.id).sort()).toEqual(['a', 'b']);
+    expect(state.openTabs.find((t) => t.id === 'a')?.isPinned).toBe(true);
+    expect(state.activeTabId).toBe('b');
+  });
+
+  it('replaces active tab when it is unpinned (preview-mode behavior)', () => {
+    const { openTab } = useNoteStore.getState();
+
+    openTab(makeNote('a'), false);
+    openTab(makeNote('b'), false);
+
+    const state = useNoteStore.getState();
+    expect(state.openTabs).toHaveLength(1);
+    expect(state.openTabs[0].id).toBe('b');
+    expect(state.activeTabId).toBe('b');
+  });
+
+  it('preserves multiple pinned tabs across sidebar navigation', () => {
+    const { openTab, pinTab } = useNoteStore.getState();
+
+    openTab(makeNote('a'), true);
+    pinTab('a');
+    openTab(makeNote('b'), true);
+    pinTab('b');
+
+    expect(useNoteStore.getState().openTabs.filter((t) => t.isPinned)).toHaveLength(2);
+
+    // Simulate sidebar click on a third note
+    openTab(makeNote('c'), false);
+
+    const state = useNoteStore.getState();
+    expect(state.openTabs).toHaveLength(3);
+    expect(state.openTabs.find((t) => t.id === 'a')?.isPinned).toBe(true);
+    expect(state.openTabs.find((t) => t.id === 'b')?.isPinned).toBe(true);
+    expect(state.activeTabId).toBe('c');
+
+    // Another sidebar click should replace 'c' (unpinned active) — pinned tabs survive
+    openTab(makeNote('d'), false);
+    const state2 = useNoteStore.getState();
+    expect(state2.openTabs).toHaveLength(3);
+    expect(state2.openTabs.map((t) => t.id).sort()).toEqual(['a', 'b', 'd']);
+  });
+
+  it('switches to existing tab when re-opening an already open pinned note', () => {
+    const { openTab, pinTab } = useNoteStore.getState();
+
+    openTab(makeNote('a'), false);
+    pinTab('a');
+    openTab(makeNote('b'), true);
+    expect(useNoteStore.getState().activeTabId).toBe('b');
+
+    // Click pinned note in sidebar
+    openTab(makeNote('a'), false);
+
+    const state = useNoteStore.getState();
+    expect(state.openTabs).toHaveLength(2);
+    expect(state.activeTabId).toBe('a');
+  });
+});

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -173,8 +173,13 @@ export const useNoteStore = create<NoteState>((set, get) => ({
         };
       }
 
-      if (inNewTab || state.openTabs.length === 0) {
-        // Open in new tab
+      const activeTab = state.openTabs.find((t) => t.id === state.activeTabId);
+      const activeTabIsPinned = !!activeTab?.isPinned;
+
+      if (inNewTab || state.openTabs.length === 0 || activeTabIsPinned) {
+        // Open in a new tab when explicitly requested, when no tabs exist,
+        // or when the active tab is pinned (pinned tabs must not be replaced
+        // by sidebar navigation / preview-mode reuse).
         const newTabs = [...state.openTabs, note];
         return {
           openTabs: newTabs,
@@ -182,7 +187,8 @@ export const useNoteStore = create<NoteState>((set, get) => ({
           currentNote: note,
         };
       } else {
-        // Replace active tab's content (single-click behavior)
+        // Replace active tab's content (single-click "preview" behavior).
+        // Only applies when the active tab is unpinned.
         const activeIndex = state.openTabs.findIndex((t) => t.id === state.activeTabId);
         if (activeIndex >= 0) {
           const newTabs = state.openTabs.map((t, i) =>


### PR DESCRIPTION
Bug: pinning an open note then clicking another sidebar note closed the pinned note (active tab was replaced via preview-mode reuse).

Fix: `openTab` short-circuits to the new-tab path when the active tab is `isPinned`. Pin/unpin/close-X behavior unchanged.

Tests: +4 in `noteStore.test.ts` (53/53 passing). Confirmed pin affordance lives in `TabBar.tsx` and works.
