### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Moldavite are documented here.
 
+## [1.3.1] - 2026-05-02
+
+### Fixed
+- **Pinned tabs survive sidebar navigation** — clicking another note in the sidebar while a pinned tab is active now opens the new note in a fresh tab instead of replacing the pinned one.
+
+### Added
+- **Settings → Plugins tab** — informational surface promoting community-built integrations. Status banner ("design phase"), starter ideas (Zoom / Meet / Web Clipper / custom exports), and CTAs linking to `docs/PLUGINS_DESIGN.md` + the issues tracker. No loader yet — sets expectations and invites contributions.
+
 ## [1.3.0] - 2026-05-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.3.0"
+version = "1.3.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Patch release: pinned-tab fix + Plugins settings tab.

Tag v1.3.1 after merge to trigger release workflow.