### PR TITLE
Release v1.5.1 — fix template editor hidden behind Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Moldavite are documented here.
 
+## [1.5.1] - 2026-07-12
+
+### Fixed
+- **Editing or creating a template from Settings → Templates works again.** The template editor opened behind the Settings window (only the backdrop darkened); it now stacks above Settings.
+
 ## [1.5.0] - 2026-07-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.5.0"
+version = "1.5.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/settings/TemplateEditorModal.tsx
+++ b/src/components/settings/TemplateEditorModal.tsx
@@ -107,7 +107,7 @@ export function TemplateEditorModal({ isOpen, onClose }: TemplateEditorModalProp
 
   return createPortal(
     <div
-      className="fixed inset-0 modal-backdrop-dark flex items-center justify-center z-[70] modal-backdrop-enter"
+      className="fixed inset-0 modal-backdrop-dark flex items-center justify-center z-[10000] modal-backdrop-enter"
       onClick={(e) => e.target === e.currentTarget && !isSaving && onClose()}
       role="dialog"
       aria-modal="true"

--- a/src/components/templates/EditTemplateModal.tsx
+++ b/src/components/templates/EditTemplateModal.tsx
@@ -121,7 +121,7 @@ export function EditTemplateModal({
   if (template.isDefault) {
     return createPortal(
       <div
-        className="fixed inset-0 modal-backdrop-dark flex items-center justify-center z-[70] modal-backdrop-enter"
+        className="fixed inset-0 modal-backdrop-dark flex items-center justify-center z-[10000] modal-backdrop-enter"
         onClick={(e) => e.target === e.currentTarget && handleClose()}
         onKeyDown={handleKeyDown}
         role="dialog"
@@ -164,7 +164,7 @@ export function EditTemplateModal({
 
   return createPortal(
     <div
-      className="fixed inset-0 modal-backdrop-dark flex items-center justify-center z-[70] modal-backdrop-enter"
+      className="fixed inset-0 modal-backdrop-dark flex items-center justify-center z-[10000] modal-backdrop-enter"
       onClick={(e) => e.target === e.currentTarget && !isSaving && handleClose()}
       onKeyDown={handleKeyDown}
       role="dialog"

--- a/src/components/templates/modalStacking.test.tsx
+++ b/src/components/templates/modalStacking.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { EditTemplateModal } from './EditTemplateModal';
+import { TemplateEditorModal } from '@/components/settings/TemplateEditorModal';
+import type { Template } from '@/types/template';
+
+// These modals are portaled to document.body and opened from inside the
+// Settings modal, whose backdrop sits at z-[9999] (SettingsModal.tsx).
+// They must stack above it or they render invisibly behind Settings —
+// the convention for modals-over-settings is z-[10000] (PluginPermissionSheet).
+const SETTINGS_MODAL_Z = 9999;
+
+function dialogZIndex(): number {
+  const dialog = document.body.querySelector('[role="dialog"]');
+  expect(dialog).not.toBeNull();
+  const match = (dialog as HTMLElement).className.match(/z-\[(\d+)\]/);
+  if (!match) throw new Error('dialog has no bracketed z-index class');
+  return Number(match[1]);
+}
+
+const customTemplate: Template = {
+  id: 'custom-1',
+  name: 'My Template',
+  description: '',
+  icon: 'blank',
+  content: '<p>hi</p>',
+  isDefault: false,
+};
+
+describe('template modal stacking above Settings', () => {
+  it('EditTemplateModal (custom template) stacks above the Settings modal', () => {
+    render(
+      <EditTemplateModal
+        isOpen
+        onClose={() => {}}
+        template={customTemplate}
+        onSave={async () => {}}
+      />
+    );
+    expect(dialogZIndex()).toBeGreaterThan(SETTINGS_MODAL_Z);
+  });
+
+  it('EditTemplateModal (default template notice) stacks above the Settings modal', () => {
+    render(
+      <EditTemplateModal
+        isOpen
+        onClose={() => {}}
+        template={{ ...customTemplate, isDefault: true }}
+        onSave={async () => {}}
+      />
+    );
+    expect(dialogZIndex()).toBeGreaterThan(SETTINGS_MODAL_Z);
+  });
+
+  it('TemplateEditorModal (new template) stacks above the Settings modal', () => {
+    render(<TemplateEditorModal isOpen onClose={() => {}} />);
+    expect(dialogZIndex()).toBeGreaterThan(SETTINGS_MODAL_Z);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix: editing or creating a template from Settings → Templates opened the dialog *behind* the Settings window (only the backdrop darkened), making template editing impossible. The portaled `EditTemplateModal` / `TemplateEditorModal` sat at `z-[70]` vs the Settings backdrop's `z-[9999]`; they now use `z-[10000]`, matching the `PluginPermissionSheet` modal-over-settings convention.
- Regression test: `modalStacking.test.tsx` asserts all three portaled template dialogs stack above the Settings z-index.
- Version bumped to 1.5.1 (patch, bug-fix only) with CHANGELOG entry.

## Test plan
- [x] New stacking tests fail at z-70, pass at z-10000
- [x] Full frontend suite: 109 tests pass
- [x] Manually verified in dev: edit + new-template dialogs appear above Settings
