### PR TITLE
Release v1.6.0 — the agent-native release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [1.6.0] - 2026-07-13
 
 ### Added
 - **Searchable plugin directory and safe install links.** The website filters live or bundled registry cards by name, description, author, and permissions, reports result counts, and keeps its offline/no-JavaScript fallback. Each card can open `moldavite://plugin/<id>` in Moldavite; strict backend routing accepts only validated plugin ids, cold-start and running-instance delivery both open Settings → Plugins, and the requested registry entry is highlighted with a permission-visible confirmation. Nothing installs silently: file downloads remain pinned and hash-verified, and enablement still requires the existing consent flow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.5.1"
+version = "1.6.0"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump to 1.6.0 + dated CHANGELOG. Contents: see the [1.6.0] section — semantic search, MCP server, AGENTS.md, Plugin API v2 + WordPress plugin + community registry, rename UI, conflict safety, graph overhaul, and the stress-hardening fixes.
