### PR TITLE
feat: one-time Obsidian vault importer (Settings → Import)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Moldavite are documented here.
 
+## [Unreleased]
+
+### Added
+- **One-time Obsidian vault importer.** Settings → Import analyzes a user-selected Obsidian vault, previews notes, attachments, folders, Canvas skips, daily-note settings, and estimated naming collisions, then copies it into a brand-new Forge without modifying the source. Supported daily-note names are normalized to `daily/YYYY-MM-DD.md`; other notes keep a sanitized, collision-safe folder structure. Obsidian alias links are converted to Moldavite's `[[Display|target]]` order, heading and block suffixes are removed from targets, referenced attachments are copied atomically into `images/`, and the progress/summary flow reports skipped hidden, trash, Canvas, symlink, unreferenced, and unresolved items.
+
 ## [1.6.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+### Changed
+- **Clearer sidebar hierarchy.** Items inside each sidebar section (Notes, Folders, Daily, Tags, Backlinks) are now indented beneath their section header with a subtle tree guide line, so sections read as collapsible groups at a glance.
+
 ### Added
 - **One-time Obsidian vault importer.** Settings → Import analyzes a user-selected Obsidian vault, previews notes, attachments, folders, Canvas skips, daily-note settings, and estimated naming collisions, then copies it into a brand-new Forge without modifying the source. Supported daily-note names are normalized to `daily/YYYY-MM-DD.md`; other notes keep a sanitized, collision-safe folder structure. Obsidian alias links are converted to Moldavite's `[[Display|target]]` order, heading and block suffixes are removed from targets, referenced attachments are copied atomically into `images/`, and the progress/summary flow reports skipped hidden, trash, Canvas, symlink, unreferenced, and unresolved items.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ This app carries that spirit. Your notes live only on your Mac—fused with your
 
 **Encrypted backups** — Export your entire vault as a password-protected AES-256 archive. Settings can be exported as JSON for cross-device sync.
 
+**Obsidian vault import** — Settings → Import previews an Obsidian vault, then makes a one-time copy into a new Forge. Daily notes, standalone folder structure, wiki-link aliases, frontmatter, and referenced attachments are converted without changing the source; Canvas files, hidden data, trash, and symlinks are skipped and reported.
+
 **Crash-safe by design** — Every save is atomic (write + flush + rename), so a crash or full disk can never truncate a note. Files are owner-readable only.
 
 **Sync-friendly** — Point iCloud Drive, Dropbox, Syncthing, or git at your Forge. If a note changes on disk while you're editing it in Moldavite, the external version is preserved as a conflict copy instead of being overwritten.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Moldavite — Project Status
 
-**Last Updated:** July 13, 2026 (v1.5.1 + unreleased)
+**Last Updated:** July 15, 2026 (v1.6.0 + unreleased)
 **Status:** Shipping — signed/notarized releases with in-app auto-update since v1.3.1
 
 > Keep this file honest: update it whenever a feature ships, changes, or a
@@ -27,6 +27,7 @@
 - Trash with 7-day retention, restore, previews; multiple Forges (vaults) with per-Forge state
 - Note locking (AES-256-GCM + Argon2, rate-limited unlock, auto-lock); encrypted vault backups; settings JSON export/import
 - Import/export: Markdown, PDF, plaintext, bulk export, encrypted archive
+- Obsidian vault importer (unreleased): Settings → Import performs a read-only analysis, then copies supported daily notes, standalone notes with sanitized folder structure, converted wiki-link aliases, verbatim YAML frontmatter, and referenced attachments into a new Forge. Name collisions are suffixed deterministically; hidden items, `.trash`, Canvas files, symlinks, unreferenced attachments, and unresolved embeds are skipped or warned in the final report.
 - Agent-ready Forge (unreleased): Settings → AI & Agents writes `AGENTS.md` + `.gitignore` to the Forge root via a hard-whitelisted backend command (exactly those two filenames), with confirm-overwrite and existence indicator
 - Built-in MCP stdio server (unreleased): the single app binary switches to headless MCP mode with the exact `--mcp` flag, defaults to the active Forge (`--forge <name>` override), exposes four read tools plus three explicitly gated write tools, validates all client paths, refuses locked notes, and uses atomic writes + semantic-index change hooks
 
@@ -46,9 +47,9 @@
 - Bundled first-party Publish to WordPress reference plugin: Application Password verification, draft create/update keyed by Forge-relative note path, self-hosted and WordPress.com Jetpack/Atomic support; WordPress.com Simple OAuth is an explicit limitation
 
 ## Test & Quality Status
-- Frontend: vitest — 241 tests across 38 files (stores, lib, hooks, graph layout, transient-view navigation, deep-link routing, plugin RPC/manifest/registry/UI)
-- Backend: cargo test — 178 tests incl. stress suite, conflict-copy, semantic-index, MCP, plugin install/hash/secret validation, and strict deep-link routing suites
-- Bundle budget enforced via `npm run check:size` (within budget as of v1.5.0)
+- Frontend: vitest — 247 tests across 39 files (stores, lib, hooks, graph layout, transient-view navigation, Obsidian import, deep-link routing, plugin RPC/manifest/registry/UI)
+- Backend: cargo test — 187 tests incl. stress suite, Obsidian conversion/path-safety, conflict-copy, semantic-index, MCP, plugin install/hash/secret validation, and strict deep-link routing suites
+- Bundle budget enforced via `npm run check:size` (within budget as of v1.6.0 + unreleased importer)
 - ESLint: 0 errors, ~22 pre-existing warnings (set-state-in-effect patterns in modals; tracked below)
 
 ## Known Issues / Debt

--- a/src-tauri/src/commands/import_obsidian.rs
+++ b/src-tauri/src/commands/import_obsidian.rs
@@ -1,0 +1,1594 @@
+//! One-time, read-only Obsidian vault analysis and COPY import.
+//!
+//! The source tree is traversed with `symlink_metadata` and is never mutated.
+//! Imported notes are planned into a newly scaffolded Forge, path segments are
+//! sanitized and collision-deduplicated, and every destination file is written
+//! through [`crate::persist::write_atomic`].
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use chrono::NaiveDate;
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+
+use crate::commands::forges::{create_forge, looks_like_forge, scaffold_forge};
+use crate::paths::get_forges_root;
+use crate::persist::write_atomic;
+use crate::validation::{is_safe_filename, validate_path_within_base};
+
+pub(crate) const OBSIDIAN_IMPORT_PROGRESS_EVENT: &str = "obsidian-import://progress";
+const PROGRESS_INTERVAL: usize = 10;
+const DEFAULT_DAILY_FORMAT: &str = "YYYY-MM-DD";
+
+lazy_static! {
+    static ref WIKI_LINK_RE: Regex =
+        Regex::new(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]").expect("valid wiki-link regex");
+    static ref WIKI_EMBED_RE: Regex =
+        Regex::new(r"!\[\[([^\]]+)\]\]").expect("valid wiki-embed regex");
+    static ref MARKDOWN_IMAGE_RE: Regex =
+        Regex::new(r#"!\[([^\]]*)\]\((?:<([^>]+)>|([^\s\)]+))(?:\s+([\"'][^\"']*[\"']))?\)"#,)
+            .expect("valid Markdown image regex");
+    static ref FRONTMATTER_RE: Regex =
+        Regex::new(r"(?s)\A(?:\u{feff})?---\r?\n.*?\r?\n---(?:\r?\n|\z)",)
+            .expect("valid frontmatter regex");
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ObsidianDailyNotesConfig {
+    pub(crate) folder: String,
+    pub(crate) format: String,
+}
+
+impl Default for ObsidianDailyNotesConfig {
+    fn default() -> Self {
+        Self {
+            folder: String::new(),
+            format: DEFAULT_DAILY_FORMAT.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ObsidianVaultPreview {
+    pub(crate) note_count: usize,
+    pub(crate) attachment_count: usize,
+    pub(crate) detected_daily_notes: Option<ObsidianDailyNotesConfig>,
+    pub(crate) folder_count: usize,
+    pub(crate) canvas_count: usize,
+    pub(crate) estimated_collisions: usize,
+    pub(crate) has_obsidian_directory: bool,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ObsidianImportProgress {
+    pub(crate) current: usize,
+    pub(crate) total: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SkippedImportItem {
+    pub(crate) path: String,
+    pub(crate) reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ObsidianImportReport {
+    pub(crate) forge_name: String,
+    pub(crate) daily_notes_imported: usize,
+    pub(crate) standalone_notes_imported: usize,
+    pub(crate) attachments_imported: usize,
+    pub(crate) skipped_items: Vec<SkippedImportItem>,
+    pub(crate) link_conversions_performed: usize,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct VaultScan {
+    notes: Vec<SourceFile>,
+    attachments: Vec<SourceFile>,
+    folder_count: usize,
+    canvas_count: usize,
+    skipped: Vec<SkippedImportItem>,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SourceFile {
+    absolute: PathBuf,
+    relative: PathBuf,
+}
+
+#[derive(Debug)]
+struct DailyConfigState {
+    detected: Option<ObsidianDailyNotesConfig>,
+    effective: ObsidianDailyNotesConfig,
+    warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+enum NoteKind {
+    Daily(NaiveDate),
+    Standalone,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedNote {
+    source: SourceFile,
+    destination: PathBuf,
+    kind: NoteKind,
+}
+
+#[derive(Debug, Default)]
+struct NotePlan {
+    notes: Vec<PlannedNote>,
+    collisions: usize,
+}
+
+#[derive(Debug, Default)]
+struct FolderPlanner {
+    mapped: HashMap<PathBuf, PathBuf>,
+    used_by_destination_parent: HashMap<PathBuf, HashSet<String>>,
+    collisions: usize,
+}
+
+impl FolderPlanner {
+    fn new() -> Self {
+        let mut mapped = HashMap::new();
+        mapped.insert(PathBuf::new(), PathBuf::new());
+        Self {
+            mapped,
+            ..Self::default()
+        }
+    }
+
+    fn destination_for(&mut self, source_folder: &Path) -> Result<PathBuf, String> {
+        if let Some(existing) = self.mapped.get(source_folder) {
+            return Ok(existing.clone());
+        }
+        let parent = source_folder.parent().unwrap_or_else(|| Path::new(""));
+        let destination_parent = self.destination_for(parent)?;
+        let raw = source_folder
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| "Source folder has a non-Unicode name".to_string())?;
+        let sanitized = sanitize_path_segment(raw, "Untitled");
+        let used = self
+            .used_by_destination_parent
+            .entry(destination_parent.clone())
+            .or_default();
+        let (deduped, collided) = dedupe_name(&sanitized, None, used);
+        if collided {
+            self.collisions += 1;
+        }
+        let mapped = destination_parent.join(deduped);
+        self.mapped
+            .insert(source_folder.to_path_buf(), mapped.clone());
+        Ok(mapped)
+    }
+}
+
+#[derive(Debug, Default)]
+struct AttachmentIndex {
+    by_relative: HashMap<String, SourceFile>,
+    by_name: HashMap<String, Vec<SourceFile>>,
+}
+
+impl AttachmentIndex {
+    fn new(files: &[SourceFile]) -> Self {
+        let mut index = Self::default();
+        for file in files {
+            let relative_key = normalized_path_key(&file.relative);
+            index.by_relative.insert(relative_key, file.clone());
+            if let Some(name) = file.relative.file_name().and_then(|name| name.to_str()) {
+                index
+                    .by_name
+                    .entry(name.to_lowercase())
+                    .or_default()
+                    .push(file.clone());
+            }
+        }
+        index
+    }
+
+    fn resolve(
+        &self,
+        reference: &str,
+        note_relative: &Path,
+        prefer_note_relative: bool,
+    ) -> Option<SourceFile> {
+        let cleaned = clean_attachment_reference(reference)?;
+        let note_parent = note_relative.parent().unwrap_or_else(|| Path::new(""));
+        let note_relative_candidate = normalize_source_relative(note_parent, &cleaned);
+        let vault_relative_candidate = normalize_source_relative(Path::new(""), &cleaned);
+        let candidates = if prefer_note_relative {
+            [note_relative_candidate, vault_relative_candidate]
+        } else {
+            [vault_relative_candidate, note_relative_candidate]
+        };
+        for candidate in candidates.into_iter().flatten() {
+            if let Some(file) = self.by_relative.get(&normalized_path_key(&candidate)) {
+                return Some(file.clone());
+            }
+        }
+
+        let basename = Path::new(&cleaned).file_name()?.to_str()?.to_lowercase();
+        let matches = self.by_name.get(&basename)?;
+        if matches.len() == 1 {
+            return matches.first().cloned();
+        }
+        None
+    }
+}
+
+struct ImportContext<'a> {
+    source_root: &'a Path,
+    forge_root: &'a Path,
+    attachment_index: AttachmentIndex,
+    copied_attachments: HashMap<PathBuf, String>,
+    used_attachment_names: HashSet<String>,
+    warnings: Vec<String>,
+    skipped: Vec<SkippedImportItem>,
+    link_conversions: usize,
+    attachment_collisions: usize,
+}
+
+impl<'a> ImportContext<'a> {
+    fn new(
+        source_root: &'a Path,
+        forge_root: &'a Path,
+        attachment_files: &[SourceFile],
+        skipped: Vec<SkippedImportItem>,
+        warnings: Vec<String>,
+    ) -> Self {
+        Self {
+            source_root,
+            forge_root,
+            attachment_index: AttachmentIndex::new(attachment_files),
+            copied_attachments: HashMap::new(),
+            used_attachment_names: HashSet::new(),
+            warnings,
+            skipped,
+            link_conversions: 0,
+            attachment_collisions: 0,
+        }
+    }
+
+    fn copy_attachment(&mut self, source: &SourceFile) -> Result<String, String> {
+        if let Some(existing) = self.copied_attachments.get(&source.relative) {
+            return Ok(existing.clone());
+        }
+        validate_source_file(self.source_root, &source.absolute)?;
+        let raw_name = source
+            .relative
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| "Attachment has a non-Unicode name".to_string())?;
+        let (stem, extension) = split_filename(raw_name);
+        let sanitized_stem = sanitize_path_segment(stem, "Attachment");
+        let sanitized_extension = extension.map(sanitize_extension);
+        let (destination_name, collided) = dedupe_name(
+            &sanitized_stem,
+            sanitized_extension.as_deref(),
+            &mut self.used_attachment_names,
+        );
+        if collided {
+            self.attachment_collisions += 1;
+        }
+
+        let images_relative = PathBuf::from("images");
+        ensure_destination_directory(self.forge_root, &images_relative)?;
+        let destination_relative = images_relative.join(&destination_name);
+        let destination = safe_destination_path(self.forge_root, &destination_relative)?;
+        validate_path_within_base(&destination, self.forge_root)?;
+        let bytes = fs::read(&source.absolute).map_err(|error| {
+            format!(
+                "Failed to read attachment '{}': {error}",
+                relative_display(&source.relative)
+            )
+        })?;
+        write_atomic(&destination, &bytes, Some(0o600))?;
+        self.copied_attachments
+            .insert(source.relative.clone(), destination_name.clone());
+        Ok(destination_name)
+    }
+
+    fn unresolved_attachment(&mut self, reference: &str, note: &Path) {
+        self.warnings.push(format!(
+            "Could not resolve attachment '{}' referenced by '{}'",
+            reference,
+            relative_display(note)
+        ));
+    }
+}
+
+#[tauri::command]
+pub(crate) async fn analyze_obsidian_vault(path: String) -> Result<ObsidianVaultPreview, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        analyze_obsidian_vault_from(Path::new(&path), &get_forges_root())
+    })
+    .await
+    .map_err(|error| format!("Obsidian analysis task failed: {error}"))?
+}
+
+#[tauri::command]
+pub(crate) async fn import_obsidian_vault(
+    path: String,
+    forge_name: String,
+    app: AppHandle,
+) -> Result<ObsidianImportReport, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let source = validate_source_vault(Path::new(&path), &get_forges_root())?;
+        // Reuse the standard Forge validation and creation path. The source is
+        // fully scanned before this call, so creating the destination cannot
+        // affect traversal even when the configured roots share an ancestor.
+        let scan = scan_vault(&source)?;
+        let daily = read_daily_notes_config(&source);
+        let plan = plan_notes(&scan.notes, &daily.effective)?;
+        let created = create_forge(forge_name.clone())?;
+        let forge_root = PathBuf::from(&created.path);
+
+        let result = import_prepared_vault(
+            &source,
+            &forge_root,
+            &forge_name,
+            scan,
+            daily,
+            plan,
+            |current, total| {
+                let _ = app.emit(
+                    OBSIDIAN_IMPORT_PROGRESS_EVENT,
+                    ObsidianImportProgress { current, total },
+                );
+            },
+        );
+        if result.is_err() {
+            // This directory was created exclusively for this import. Removing
+            // a failed partial copy makes a retry possible without touching the
+            // source vault or any pre-existing Forge.
+            let _ = fs::remove_dir_all(&forge_root);
+        }
+        result
+    })
+    .await
+    .map_err(|error| format!("Obsidian import task failed: {error}"))?
+}
+
+fn analyze_obsidian_vault_from(
+    source: &Path,
+    forges_root: &Path,
+) -> Result<ObsidianVaultPreview, String> {
+    let source = validate_source_vault(source, forges_root)?;
+    let scan = scan_vault(&source)?;
+    let daily = read_daily_notes_config(&source);
+    let plan = plan_notes(&scan.notes, &daily.effective)?;
+    let attachment_collisions = estimate_attachment_collisions(&scan.attachments);
+    let has_obsidian_directory = is_real_directory(&source.join(".obsidian"));
+    let mut warnings = daily.warnings;
+    if !has_obsidian_directory {
+        warnings.push(
+            "No .obsidian directory was found; default daily-note settings will be used"
+                .to_string(),
+        );
+    }
+    warnings.extend(scan.warnings);
+    Ok(ObsidianVaultPreview {
+        note_count: scan.notes.len(),
+        attachment_count: scan.attachments.len(),
+        detected_daily_notes: daily.detected,
+        folder_count: scan.folder_count,
+        canvas_count: scan.canvas_count,
+        estimated_collisions: plan.collisions + attachment_collisions,
+        has_obsidian_directory,
+        warnings,
+    })
+}
+
+fn import_prepared_vault<F>(
+    source_root: &Path,
+    forge_root: &Path,
+    forge_name: &str,
+    scan: VaultScan,
+    daily: DailyConfigState,
+    plan: NotePlan,
+    mut emit_progress: F,
+) -> Result<ObsidianImportReport, String>
+where
+    F: FnMut(usize, usize),
+{
+    if !forge_root.is_dir() {
+        scaffold_forge(forge_root)?;
+    }
+    let total = plan.notes.len();
+    emit_progress(0, total);
+    let mut context = ImportContext::new(
+        source_root,
+        forge_root,
+        &scan.attachments,
+        scan.skipped,
+        daily.warnings,
+    );
+    let mut daily_notes_imported = 0;
+    let mut standalone_notes_imported = 0;
+
+    for (index, note) in plan.notes.iter().enumerate() {
+        match import_note(note, &mut context) {
+            Ok(()) => match note.kind {
+                NoteKind::Daily(_) => daily_notes_imported += 1,
+                NoteKind::Standalone => standalone_notes_imported += 1,
+            },
+            Err(error) if error.starts_with("SKIP:") => {
+                let reason = error.trim_start_matches("SKIP:").trim().to_string();
+                context.skipped.push(SkippedImportItem {
+                    path: relative_display(&note.source.relative),
+                    reason: reason.clone(),
+                });
+                context.warnings.push(format!(
+                    "Skipped '{}': {}",
+                    relative_display(&note.source.relative),
+                    reason
+                ));
+            }
+            Err(error) => return Err(error),
+        }
+
+        let current = index + 1;
+        if current % PROGRESS_INTERVAL == 0 || current == total {
+            emit_progress(current, total);
+        }
+    }
+
+    for attachment in &scan.attachments {
+        if !context
+            .copied_attachments
+            .contains_key(&attachment.relative)
+        {
+            context.skipped.push(SkippedImportItem {
+                path: relative_display(&attachment.relative),
+                reason: "Unreferenced attachment".to_string(),
+            });
+        }
+    }
+    let total_collisions = plan.collisions + context.attachment_collisions;
+    if total_collisions > 0 {
+        context.warnings.push(format!(
+            "Renamed {total_collisions} imported item(s) to avoid destination collisions"
+        ));
+    }
+    if total == 0 {
+        emit_progress(0, 0);
+    }
+
+    Ok(ObsidianImportReport {
+        forge_name: forge_name.to_string(),
+        daily_notes_imported,
+        standalone_notes_imported,
+        attachments_imported: context.copied_attachments.len(),
+        skipped_items: context.skipped,
+        link_conversions_performed: context.link_conversions,
+        warnings: context.warnings,
+    })
+}
+
+fn import_note(note: &PlannedNote, context: &mut ImportContext<'_>) -> Result<(), String> {
+    validate_source_file(context.source_root, &note.source.absolute)
+        .map_err(|error| format!("SKIP: {error}"))?;
+    let bytes = fs::read(&note.source.absolute)
+        .map_err(|error| format!("SKIP: Could not read source note: {error}"))?;
+    let content =
+        String::from_utf8(bytes).map_err(|_| "SKIP: Source note is not valid UTF-8".to_string())?;
+    let converted = convert_note_content(&content, note, context)?;
+
+    let parent = note
+        .destination
+        .parent()
+        .ok_or_else(|| "Planned note has no destination parent".to_string())?;
+    ensure_destination_directory(context.forge_root, parent)?;
+    let destination = safe_destination_path(context.forge_root, &note.destination)?;
+    validate_path_within_base(&destination, context.forge_root)?;
+    write_atomic(&destination, converted.as_bytes(), Some(0o600))
+}
+
+fn convert_note_content(
+    content: &str,
+    note: &PlannedNote,
+    context: &mut ImportContext<'_>,
+) -> Result<String, String> {
+    let frontmatter_end = FRONTMATTER_RE.find(content).map(|matched| matched.end());
+    let (frontmatter, body) = match frontmatter_end {
+        Some(end) => content.split_at(end),
+        None => ("", content),
+    };
+    let body = convert_attachments(body, note, context)?;
+    let (body, link_conversions) = convert_wiki_links(&body);
+    context.link_conversions += link_conversions;
+    Ok(format!("{frontmatter}{body}"))
+}
+
+enum AttachmentMatch<'a> {
+    Markdown(regex::Captures<'a>),
+    Wiki(regex::Captures<'a>),
+}
+
+impl AttachmentMatch<'_> {
+    fn start(&self) -> usize {
+        match self {
+            Self::Markdown(captures) | Self::Wiki(captures) => {
+                captures.get(0).expect("whole attachment match").start()
+            }
+        }
+    }
+}
+
+/// Convert both supported attachment syntaxes in document order so the first
+/// reference deterministically receives the unsuffixed destination filename.
+fn convert_attachments(
+    body: &str,
+    note: &PlannedNote,
+    context: &mut ImportContext<'_>,
+) -> Result<String, String> {
+    let mut matches = MARKDOWN_IMAGE_RE
+        .captures_iter(body)
+        .map(AttachmentMatch::Markdown)
+        .chain(WIKI_EMBED_RE.captures_iter(body).map(AttachmentMatch::Wiki))
+        .collect::<Vec<_>>();
+    matches.sort_by_key(AttachmentMatch::start);
+
+    let mut output = String::with_capacity(body.len());
+    let mut cursor = 0;
+    for attachment_match in matches {
+        let whole = match &attachment_match {
+            AttachmentMatch::Markdown(captures) | AttachmentMatch::Wiki(captures) => {
+                captures.get(0).expect("whole attachment match")
+            }
+        };
+        if whole.start() < cursor {
+            continue;
+        }
+        output.push_str(&body[cursor..whole.start()]);
+        match attachment_match {
+            AttachmentMatch::Markdown(captures) => {
+                let reference = captures
+                    .get(2)
+                    .or_else(|| captures.get(3))
+                    .map(|matched| matched.as_str())
+                    .unwrap_or_default();
+                if is_remote_or_data_reference(reference) {
+                    output.push_str(whole.as_str());
+                } else if let Some(source) =
+                    context
+                        .attachment_index
+                        .resolve(reference, &note.source.relative, false)
+                {
+                    let name = context.copy_attachment(&source)?;
+                    let relative = relative_image_link(&note.destination, &name);
+                    let alt = captures
+                        .get(1)
+                        .map(|matched| matched.as_str())
+                        .unwrap_or("");
+                    let title = captures.get(4).map(|matched| matched.as_str());
+                    output.push_str(&format!("![{alt}](<{relative}>)"));
+                    if let Some(title) = title {
+                        output.truncate(output.len() - 1);
+                        output.push(' ');
+                        output.push_str(title);
+                        output.push(')');
+                    }
+                } else {
+                    context.unresolved_attachment(reference, &note.source.relative);
+                    output.push_str(whole.as_str());
+                }
+            }
+            AttachmentMatch::Wiki(captures) => {
+                let inside = captures
+                    .get(1)
+                    .map(|matched| matched.as_str())
+                    .unwrap_or("");
+                let reference = inside.split('|').next().unwrap_or(inside).trim();
+                let reference = strip_link_target_suffix(reference).trim();
+                if let Some(source) =
+                    context
+                        .attachment_index
+                        .resolve(reference, &note.source.relative, false)
+                {
+                    let name = context.copy_attachment(&source)?;
+                    let relative = relative_image_link(&note.destination, &name);
+                    output.push_str(&format!("![](<{relative}>)"));
+                } else {
+                    context.unresolved_attachment(reference, &note.source.relative);
+                    output.push_str(whole.as_str());
+                }
+            }
+        }
+        cursor = whole.end();
+    }
+    output.push_str(&body[cursor..]);
+    Ok(output)
+}
+
+/// Convert Obsidian `[[target|Display]]` aliases to Moldavite's verified
+/// `[[Display|target]]` order and remove heading/block suffixes from targets.
+fn convert_wiki_links(body: &str) -> (String, usize) {
+    let mut output = String::with_capacity(body.len());
+    let mut cursor = 0;
+    let mut conversions = 0;
+    for captures in WIKI_LINK_RE.captures_iter(body) {
+        let whole = captures.get(0).expect("whole wiki-link match");
+        output.push_str(&body[cursor..whole.start()]);
+        if whole.start() > 0 && body.as_bytes().get(whole.start() - 1) == Some(&b'!') {
+            output.push_str(whole.as_str());
+            cursor = whole.end();
+            continue;
+        }
+        let target = captures
+            .get(1)
+            .map(|matched| matched.as_str())
+            .unwrap_or("");
+        let stripped_target = strip_link_target_suffix(target);
+        let replacement = match captures.get(2) {
+            Some(display) => format!("[[{}|{}]]", display.as_str().trim(), stripped_target.trim()),
+            None if stripped_target != target => format!("[[{}]]", stripped_target.trim()),
+            None => whole.as_str().to_string(),
+        };
+        if replacement != whole.as_str() {
+            conversions += 1;
+        }
+        output.push_str(&replacement);
+        cursor = whole.end();
+    }
+    output.push_str(&body[cursor..]);
+    (output, conversions)
+}
+
+fn strip_link_target_suffix(target: &str) -> &str {
+    let heading = target.find('#');
+    let block = target.find('^');
+    let end = match (heading, block) {
+        (Some(a), Some(b)) => a.min(b),
+        (Some(index), None) | (None, Some(index)) => index,
+        (None, None) => target.len(),
+    };
+    &target[..end]
+}
+
+fn plan_notes(
+    source_notes: &[SourceFile],
+    daily: &ObsidianDailyNotesConfig,
+) -> Result<NotePlan, String> {
+    let mut sorted = source_notes.to_vec();
+    sorted.sort_by_key(|file| normalized_path_key(&file.relative));
+    let mut folder_planner = FolderPlanner::new();
+    let mut used_note_paths = HashSet::new();
+    let mut notes = Vec::with_capacity(sorted.len());
+    let mut collisions = 0;
+
+    for source in sorted {
+        let kind = parse_daily_note(&source.relative, daily)
+            .map(NoteKind::Daily)
+            .unwrap_or(NoteKind::Standalone);
+        let destination = match kind {
+            NoteKind::Daily(date) => {
+                let base = date.format("%Y-%m-%d").to_string();
+                let (name, collided) =
+                    dedupe_relative_file(Path::new("daily"), &base, "md", &mut used_note_paths);
+                if collided {
+                    collisions += 1;
+                }
+                PathBuf::from("daily").join(name)
+            }
+            NoteKind::Standalone => {
+                let source_parent = source.relative.parent().unwrap_or_else(|| Path::new(""));
+                let mapped_parent = folder_planner.destination_for(source_parent)?;
+                let raw_stem = source
+                    .relative
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .ok_or_else(|| "Source note has a non-Unicode filename".to_string())?;
+                let base = sanitize_path_segment(raw_stem, "Untitled");
+                let destination_parent = PathBuf::from("notes").join(mapped_parent);
+                let (name, collided) =
+                    dedupe_relative_file(&destination_parent, &base, "md", &mut used_note_paths);
+                if collided {
+                    collisions += 1;
+                }
+                destination_parent.join(name)
+            }
+        };
+        notes.push(PlannedNote {
+            source,
+            destination,
+            kind,
+        });
+    }
+    collisions += folder_planner.collisions;
+    Ok(NotePlan { notes, collisions })
+}
+
+fn parse_daily_note(relative: &Path, daily: &ObsidianDailyNotesConfig) -> Option<NaiveDate> {
+    let folder = config_relative_path(&daily.folder)?;
+    let under_folder = relative.strip_prefix(&folder).ok()?;
+    let mut without_extension = under_folder.to_path_buf();
+    if !without_extension
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+    {
+        return None;
+    }
+    without_extension.set_extension("");
+    let value = relative_display(&without_extension);
+    parse_date_with_obsidian_format(&value, &daily.format)
+}
+
+fn parse_date_with_obsidian_format(value: &str, format: &str) -> Option<NaiveDate> {
+    let (regex, tokens) = compile_daily_format(format)?;
+    let captures = regex.captures(value)?;
+    let mut year = None;
+    let mut month = None;
+    let mut day = None;
+    for (index, token) in tokens.iter().enumerate() {
+        let parsed = captures.get(index + 1)?.as_str().parse::<i32>().ok()?;
+        match token.as_str() {
+            "YYYY" => year = Some(parsed),
+            "MM" => month = u32::try_from(parsed).ok(),
+            "DD" => day = u32::try_from(parsed).ok(),
+            _ => return None,
+        }
+    }
+    NaiveDate::from_ymd_opt(year?, month?, day?)
+}
+
+fn compile_daily_format(format: &str) -> Option<(Regex, Vec<String>)> {
+    let mut remaining = format;
+    let mut pattern = String::from("^");
+    let mut tokens = Vec::new();
+    while !remaining.is_empty() {
+        if let Some(token) = ["YYYY", "MM", "DD"]
+            .iter()
+            .find(|token| remaining.starts_with(**token))
+        {
+            pattern.push_str(if *token == "YYYY" {
+                r"(\d{4})"
+            } else {
+                r"(\d{2})"
+            });
+            tokens.push((*token).to_string());
+            remaining = &remaining[token.len()..];
+            continue;
+        }
+        let separator = remaining.chars().next()?;
+        if !matches!(separator, '-' | '_' | '.' | '/') {
+            return None;
+        }
+        pattern.push_str(&regex::escape(&separator.to_string()));
+        remaining = &remaining[separator.len_utf8()..];
+    }
+    if tokens.len() != 3
+        || tokens
+            .iter()
+            .filter(|token| token.as_str() == "YYYY")
+            .count()
+            != 1
+        || tokens.iter().filter(|token| token.as_str() == "MM").count() != 1
+        || tokens.iter().filter(|token| token.as_str() == "DD").count() != 1
+    {
+        return None;
+    }
+    pattern.push('$');
+    Regex::new(&pattern).ok().map(|regex| (regex, tokens))
+}
+
+fn read_daily_notes_config(source: &Path) -> DailyConfigState {
+    let default = ObsidianDailyNotesConfig::default();
+    let obsidian_dir = source.join(".obsidian");
+    if !is_real_directory(&obsidian_dir) {
+        return DailyConfigState {
+            detected: None,
+            effective: default,
+            warnings: Vec::new(),
+        };
+    }
+    let path = obsidian_dir.join("daily-notes.json");
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_file() => metadata,
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return DailyConfigState {
+                detected: None,
+                effective: default,
+                warnings: vec![
+                    "Skipped symlinked .obsidian/daily-notes.json configuration".to_string()
+                ],
+            }
+        }
+        _ => {
+            return DailyConfigState {
+                detected: None,
+                effective: default,
+                warnings: Vec::new(),
+            }
+        }
+    };
+    let _ = metadata;
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) => {
+            return DailyConfigState {
+                detected: None,
+                effective: default,
+                warnings: vec![format!(
+                    "Could not read daily-notes configuration; defaults will be used: {error}"
+                )],
+            }
+        }
+    };
+    #[derive(Deserialize)]
+    struct RawDailyConfig {
+        folder: Option<String>,
+        format: Option<String>,
+    }
+    let parsed: RawDailyConfig = match serde_json::from_str(&raw) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return DailyConfigState {
+                detected: None,
+                effective: default,
+                warnings: vec![format!(
+                    "Could not parse daily-notes configuration; defaults will be used: {error}"
+                )],
+            }
+        }
+    };
+    let detected = ObsidianDailyNotesConfig {
+        folder: parsed.folder.unwrap_or_default(),
+        format: parsed
+            .format
+            .unwrap_or_else(|| DEFAULT_DAILY_FORMAT.to_string()),
+    };
+    let mut effective = detected.clone();
+    let mut warnings = Vec::new();
+    if config_relative_path(&effective.folder).is_none() {
+        warnings
+            .push("Daily-notes folder is unsafe; the vault root will be used instead".to_string());
+        effective.folder.clear();
+    }
+    if compile_daily_format(&effective.format).is_none() {
+        warnings.push(format!(
+            "Daily-note format '{}' is unsupported; {} will be used instead",
+            effective.format, DEFAULT_DAILY_FORMAT
+        ));
+        effective.format = DEFAULT_DAILY_FORMAT.to_string();
+    }
+    DailyConfigState {
+        detected: Some(detected),
+        effective,
+        warnings,
+    }
+}
+
+fn validate_source_vault(source: &Path, forges_root: &Path) -> Result<PathBuf, String> {
+    if !source.is_absolute() {
+        return Err("Obsidian vault path must be absolute".to_string());
+    }
+    let metadata = fs::symlink_metadata(source)
+        .map_err(|_| "Selected Obsidian vault does not exist".to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Err("The selected Obsidian vault cannot be a symlink".to_string());
+    }
+    if !metadata.is_dir() {
+        return Err("Selected Obsidian vault is not a folder".to_string());
+    }
+    let canonical_source = source
+        .canonicalize()
+        .map_err(|_| "Could not resolve the selected Obsidian vault".to_string())?;
+    validate_source_against_forge_roots(&canonical_source, forges_root)?;
+    Ok(canonical_source)
+}
+
+fn validate_source_against_forge_roots(source: &Path, forges_root: &Path) -> Result<(), String> {
+    if let Ok(canonical_root) = forges_root.canonicalize() {
+        if source == canonical_root || canonical_root.starts_with(source) {
+            return Err(
+                "The selected vault overlaps the configured Moldavite Forges root".to_string(),
+            );
+        }
+        if let Ok(entries) = fs::read_dir(&canonical_root) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if !looks_like_forge(&path) {
+                    continue;
+                }
+                if let Ok(forge) = path.canonicalize() {
+                    if source == forge || source.starts_with(&forge) {
+                        return Err(
+                            "Cannot import a folder from inside an existing Moldavite Forge"
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn scan_vault(source: &Path) -> Result<VaultScan, String> {
+    let mut scan = VaultScan::default();
+    scan_directory(source, source, &mut scan)?;
+    scan.notes
+        .sort_by_key(|file| normalized_path_key(&file.relative));
+    scan.attachments
+        .sort_by_key(|file| normalized_path_key(&file.relative));
+    Ok(scan)
+}
+
+fn scan_directory(
+    source_root: &Path,
+    directory: &Path,
+    scan: &mut VaultScan,
+) -> Result<(), String> {
+    let mut entries = fs::read_dir(directory)
+        .map_err(|error| format!("Could not read selected vault directory: {error}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("Could not inspect selected vault: {error}"))?;
+    entries.sort_by_key(|entry| entry.file_name().to_string_lossy().to_lowercase());
+
+    for entry in entries {
+        let absolute = entry.path();
+        let relative = absolute
+            .strip_prefix(source_root)
+            .map_err(|_| "Source entry escaped the selected vault".to_string())?
+            .to_path_buf();
+        let name = match entry.file_name().into_string() {
+            Ok(name) => name,
+            Err(_) => {
+                scan.skipped.push(SkippedImportItem {
+                    path: relative_display(&relative),
+                    reason: "Non-Unicode file or folder name".to_string(),
+                });
+                continue;
+            }
+        };
+        let metadata = match fs::symlink_metadata(&absolute) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                scan.skipped.push(SkippedImportItem {
+                    path: relative_display(&relative),
+                    reason: format!("Could not inspect item: {error}"),
+                });
+                continue;
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            scan.skipped.push(SkippedImportItem {
+                path: relative_display(&relative),
+                reason: "Symlink skipped (links are never followed)".to_string(),
+            });
+            scan.warnings
+                .push(format!("Skipped symlink '{}'", relative_display(&relative)));
+            continue;
+        }
+        if name.starts_with('.') {
+            let reason = match name.as_str() {
+                ".obsidian" => "Obsidian settings directory",
+                ".trash" => "Obsidian trash directory",
+                _ => "Hidden file or directory",
+            };
+            scan.skipped.push(SkippedImportItem {
+                path: relative_display(&relative),
+                reason: reason.to_string(),
+            });
+            continue;
+        }
+        if metadata.is_dir() {
+            scan.folder_count += 1;
+            scan_directory(source_root, &absolute, scan)?;
+            continue;
+        }
+        if !metadata.is_file() {
+            scan.skipped.push(SkippedImportItem {
+                path: relative_display(&relative),
+                reason: "Unsupported filesystem item".to_string(),
+            });
+            continue;
+        }
+        let extension = absolute
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("");
+        if extension.eq_ignore_ascii_case("canvas") {
+            scan.canvas_count += 1;
+            scan.skipped.push(SkippedImportItem {
+                path: relative_display(&relative),
+                reason: "Obsidian Canvas files are not imported".to_string(),
+            });
+        } else if extension.eq_ignore_ascii_case("md") {
+            scan.notes.push(SourceFile { absolute, relative });
+        } else {
+            scan.attachments.push(SourceFile { absolute, relative });
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_file(source_root: &Path, source: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source)
+        .map_err(|_| "Source file disappeared during import".to_string())?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err("Source item is no longer a regular file".to_string());
+    }
+    let canonical = source
+        .canonicalize()
+        .map_err(|_| "Could not resolve source file".to_string())?;
+    if !canonical.starts_with(source_root) {
+        return Err("Source file escaped the selected vault".to_string());
+    }
+    Ok(())
+}
+
+fn ensure_destination_directory(forge_root: &Path, relative: &Path) -> Result<(), String> {
+    let mut current = forge_root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(segment) = component else {
+            return Err("Unsafe destination directory".to_string());
+        };
+        let segment = segment
+            .to_str()
+            .ok_or_else(|| "Destination directory is not valid Unicode".to_string())?;
+        if !is_safe_filename(segment) || segment.starts_with('.') {
+            return Err("Unsafe destination directory segment".to_string());
+        }
+        current.push(segment);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err("Refusing to traverse a destination symlink".to_string())
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err("Destination directory is occupied by a file".to_string())
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(&current)
+                    .map_err(|error| format!("Failed to create import directory: {error}"))?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    fs::set_permissions(&current, fs::Permissions::from_mode(0o700))
+                        .map_err(|error| format!("Failed to secure import directory: {error}"))?;
+                }
+            }
+            Err(error) => {
+                return Err(format!("Failed to inspect import directory: {error}"));
+            }
+        }
+        let canonical = current
+            .canonicalize()
+            .map_err(|_| "Could not resolve import directory".to_string())?;
+        let canonical_root = forge_root
+            .canonicalize()
+            .map_err(|_| "Could not resolve new Forge".to_string())?;
+        if !canonical.starts_with(&canonical_root) {
+            return Err("Import destination escaped the new Forge".to_string());
+        }
+    }
+    Ok(())
+}
+
+fn safe_destination_path(forge_root: &Path, relative: &Path) -> Result<PathBuf, String> {
+    if relative.is_absolute() {
+        return Err("Import destination must be Forge-relative".to_string());
+    }
+    for component in relative.components() {
+        let Component::Normal(segment) = component else {
+            return Err("Import destination contains traversal".to_string());
+        };
+        let segment = segment
+            .to_str()
+            .ok_or_else(|| "Import destination is not valid Unicode".to_string())?;
+        if !is_safe_filename(segment) || segment.starts_with('.') {
+            return Err("Import destination contains an unsafe segment".to_string());
+        }
+    }
+    let destination = forge_root.join(relative);
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "Import destination has no parent".to_string())?;
+    let canonical_root = forge_root
+        .canonicalize()
+        .map_err(|_| "Could not resolve new Forge".to_string())?;
+    let canonical_parent = parent
+        .canonicalize()
+        .map_err(|_| "Import destination parent does not exist".to_string())?;
+    if !canonical_parent.starts_with(&canonical_root) {
+        return Err("Import destination escaped the new Forge".to_string());
+    }
+    Ok(destination)
+}
+
+fn sanitize_path_segment(raw: &str, fallback: &str) -> String {
+    let mut sanitized = String::with_capacity(raw.len());
+    for character in raw.trim().chars() {
+        if character.is_control()
+            || matches!(
+                character,
+                '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'
+            )
+        {
+            sanitized.push('-');
+        } else {
+            sanitized.push(character);
+        }
+    }
+    while sanitized.contains("..") {
+        sanitized = sanitized.replace("..", "-");
+    }
+    let sanitized = sanitized.trim().trim_matches('.').trim().to_string();
+    let mut sanitized = if sanitized.is_empty() {
+        fallback.to_string()
+    } else {
+        sanitized
+    };
+    if sanitized.chars().count() > 180 {
+        sanitized = sanitized.chars().take(180).collect();
+    }
+    if !is_safe_filename(&sanitized) {
+        fallback.to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn sanitize_extension(raw: &str) -> String {
+    let sanitized: String = raw
+        .chars()
+        .filter(|character| character.is_alphanumeric() || matches!(character, '-' | '_'))
+        .take(24)
+        .collect();
+    if sanitized.is_empty() {
+        "bin".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn split_filename(filename: &str) -> (&str, Option<&str>) {
+    let path = Path::new(filename);
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(filename);
+    let extension = path.extension().and_then(|extension| extension.to_str());
+    (stem, extension)
+}
+
+fn dedupe_name(base: &str, extension: Option<&str>, used: &mut HashSet<String>) -> (String, bool) {
+    let build = |counter: Option<usize>| {
+        let stem = counter
+            .map(|counter| format!("{base} {counter}"))
+            .unwrap_or_else(|| base.to_string());
+        extension
+            .map(|extension| format!("{stem}.{extension}"))
+            .unwrap_or(stem)
+    };
+    let first = build(None);
+    if used.insert(first.to_lowercase()) {
+        return (first, false);
+    }
+    for counter in 2..=10_000 {
+        let candidate = build(Some(counter));
+        if used.insert(candidate.to_lowercase()) {
+            return (candidate, true);
+        }
+    }
+    let fallback = build(Some(10_001));
+    used.insert(fallback.to_lowercase());
+    (fallback, true)
+}
+
+fn dedupe_relative_file(
+    parent: &Path,
+    base: &str,
+    extension: &str,
+    used_paths: &mut HashSet<String>,
+) -> (String, bool) {
+    let build = |counter: Option<usize>| {
+        let stem = counter
+            .map(|counter| format!("{base} {counter}"))
+            .unwrap_or_else(|| base.to_string());
+        format!("{stem}.{extension}")
+    };
+    let first = build(None);
+    if used_paths.insert(normalized_path_key(&parent.join(&first))) {
+        return (first, false);
+    }
+    for counter in 2..=10_000 {
+        let candidate = build(Some(counter));
+        if used_paths.insert(normalized_path_key(&parent.join(&candidate))) {
+            return (candidate, true);
+        }
+    }
+    let fallback = build(Some(10_001));
+    used_paths.insert(normalized_path_key(&parent.join(&fallback)));
+    (fallback, true)
+}
+
+fn estimate_attachment_collisions(attachments: &[SourceFile]) -> usize {
+    let mut used = HashSet::new();
+    let mut collisions = 0;
+    for attachment in attachments {
+        let Some(name) = attachment
+            .relative
+            .file_name()
+            .and_then(|name| name.to_str())
+        else {
+            continue;
+        };
+        let (stem, extension) = split_filename(name);
+        let base = sanitize_path_segment(stem, "Attachment");
+        let extension = extension.map(sanitize_extension);
+        let (_, collided) = dedupe_name(&base, extension.as_deref(), &mut used);
+        if collided {
+            collisions += 1;
+        }
+    }
+    collisions
+}
+
+fn config_relative_path(value: &str) -> Option<PathBuf> {
+    if value.is_empty() {
+        return Some(PathBuf::new());
+    }
+    let normalized = value.replace('\\', "/");
+    let path = Path::new(&normalized);
+    if path.is_absolute() {
+        return None;
+    }
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => {
+                let segment = segment.to_str()?;
+                if segment.is_empty() || segment == ".." || segment.starts_with('.') {
+                    return None;
+                }
+                result.push(segment);
+            }
+            Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    Some(result)
+}
+
+fn normalize_source_relative(base: &Path, reference: &str) -> Option<PathBuf> {
+    let normalized = reference.replace('\\', "/");
+    let path = Path::new(&normalized);
+    if path.is_absolute() || normalized.contains(':') {
+        return None;
+    }
+    let mut parts: Vec<PathBuf> = base
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => Some(PathBuf::from(segment)),
+            _ => None,
+        })
+        .collect();
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => parts.push(PathBuf::from(segment)),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                parts.pop()?;
+            }
+            _ => return None,
+        }
+    }
+    let mut result = PathBuf::new();
+    for part in parts {
+        result.push(part);
+    }
+    Some(result)
+}
+
+fn clean_attachment_reference(reference: &str) -> Option<String> {
+    let trimmed = reference.trim();
+    if trimmed.is_empty() || is_remote_or_data_reference(trimmed) {
+        return None;
+    }
+    let without_suffix = strip_link_target_suffix(trimmed).trim();
+    if without_suffix.is_empty() {
+        return None;
+    }
+    Some(without_suffix.replace("%20", " "))
+}
+
+fn is_remote_or_data_reference(reference: &str) -> bool {
+    let lower = reference.trim().to_lowercase();
+    lower.starts_with("http://")
+        || lower.starts_with("https://")
+        || lower.starts_with("data:")
+        || lower.starts_with("file:")
+        || lower.starts_with('#')
+}
+
+fn relative_image_link(note_destination: &Path, attachment_name: &str) -> String {
+    let parent = note_destination.parent().unwrap_or_else(|| Path::new(""));
+    let depth = parent.components().count();
+    let mut parts = vec![".."; depth];
+    parts.push("images");
+    parts.push(attachment_name);
+    parts.join("/")
+}
+
+fn normalized_path_key(path: &Path) -> String {
+    relative_display(path).to_lowercase()
+}
+
+fn relative_display(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => Some(segment.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn is_real_directory(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("target")
+                .join(format!(
+                    "moldavite-obsidian-import-{tag}-{}",
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_nanos()
+                ));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_fixture(path: &Path, bytes: &[u8]) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn import_fixture(source: &Path, forge: &Path) -> Result<ObsidianImportReport, String> {
+        scaffold_forge(forge)?;
+        let scan = scan_vault(source)?;
+        let daily = read_daily_notes_config(source);
+        let plan = plan_notes(&scan.notes, &daily.effective)?;
+        import_prepared_vault(source, forge, "Imported", scan, daily, plan, |_, _| {})
+    }
+
+    #[test]
+    fn swaps_obsidian_alias_order_and_strips_target_suffixes() {
+        let input = "[[Target|Display]] [[Plain]] [[Note#Heading]] [[Block^abc]] ![[keep.png]]";
+        let (converted, count) = convert_wiki_links(input);
+        assert_eq!(
+            converted,
+            "[[Display|Target]] [[Plain]] [[Note]] [[Block]] ![[keep.png]]"
+        );
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn preserves_frontmatter_verbatim_while_converting_body_links() {
+        let tmp = TempDir::new("frontmatter");
+        let source = tmp.path().join("source");
+        let forge = tmp.path().join("forge");
+        let frontmatter = "---\ntitle: '[[Target|YAML alias]]'\ncustom: true\n---\n";
+        write_fixture(
+            &source.join("Note.md"),
+            format!("{frontmatter}Body [[Target|Visible]]").as_bytes(),
+        );
+        import_fixture(&source, &forge).unwrap();
+        let imported = fs::read_to_string(forge.join("notes/Note.md")).unwrap();
+        assert!(imported.starts_with(frontmatter));
+        assert!(imported.ends_with("Body [[Visible|Target]]"));
+    }
+
+    #[test]
+    fn parses_daily_formats_nested_folders_and_rejects_bad_names() {
+        let config = ObsidianDailyNotesConfig {
+            folder: "Journal/Daily".to_string(),
+            format: "DD-MM-YYYY".to_string(),
+        };
+        assert_eq!(
+            parse_daily_note(Path::new("Journal/Daily/31-12-2025.md"), &config),
+            NaiveDate::from_ymd_opt(2025, 12, 31)
+        );
+        assert_eq!(
+            parse_daily_note(Path::new("Journal/Daily/not-a-date.md"), &config),
+            None
+        );
+        assert_eq!(
+            parse_daily_note(Path::new("Other/31-12-2025.md"), &config),
+            None
+        );
+
+        let slash_config = ObsidianDailyNotesConfig {
+            folder: "Daily".to_string(),
+            format: "YYYY/MM/DD".to_string(),
+        };
+        assert_eq!(
+            parse_daily_note(Path::new("Daily/2026/07/15.md"), &slash_config),
+            NaiveDate::from_ymd_opt(2026, 7, 15)
+        );
+        assert_eq!(
+            parse_daily_note(Path::new("Daily/2026/02/30.md"), &slash_config),
+            None
+        );
+    }
+
+    #[test]
+    fn converts_embeds_copies_attachments_and_dedupes_collisions() {
+        let tmp = TempDir::new("embeds");
+        let source = tmp.path().join("source");
+        let forge = tmp.path().join("forge");
+        write_fixture(&source.join("Attachments/photo.png"), b"first");
+        write_fixture(&source.join("Other/photo.png"), b"second");
+        write_fixture(
+            &source.join("Projects/Note.md"),
+            b"![[Attachments/photo.png]]\n![second](Other/photo.png)",
+        );
+
+        let report = import_fixture(&source, &forge).unwrap();
+        assert_eq!(report.attachments_imported, 2);
+        let note = fs::read_to_string(forge.join("notes/Projects/Note.md")).unwrap();
+        assert_eq!(
+            note,
+            "![](<../../images/photo.png>)\n![second](<../../images/photo 2.png>)"
+        );
+        assert_eq!(fs::read(forge.join("images/photo.png")).unwrap(), b"first");
+        assert_eq!(
+            fs::read(forge.join("images/photo 2.png")).unwrap(),
+            b"second"
+        );
+    }
+
+    #[test]
+    fn path_safety_rejects_traversal_and_absolute_destinations() {
+        let tmp = TempDir::new("path-safety");
+        let forge = tmp.path().join("forge");
+        scaffold_forge(&forge).unwrap();
+        assert!(safe_destination_path(&forge, Path::new("../evil.md")).is_err());
+        assert!(safe_destination_path(&forge, Path::new("/tmp/evil.md")).is_err());
+        assert!(normalize_source_relative(Path::new("notes"), "../../evil.png").is_none());
+        assert!(normalize_source_relative(Path::new(""), "/etc/passwd").is_none());
+        let sanitized = sanitize_path_segment("..evil", "Untitled");
+        assert!(is_safe_filename(&sanitized));
+        assert!(!sanitized.contains(".."));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scanner_never_follows_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new("symlink");
+        let source = tmp.path().join("source");
+        let outside = tmp.path().join("outside");
+        write_fixture(&outside.join("secret.md"), b"secret");
+        fs::create_dir_all(&source).unwrap();
+        symlink(&outside, source.join("linked")).unwrap();
+        let scan = scan_vault(&source).unwrap();
+        assert!(scan.notes.is_empty());
+        assert_eq!(scan.skipped.len(), 1);
+        assert!(scan.skipped[0].reason.contains("Symlink"));
+        assert_eq!(scan.warnings.len(), 1);
+    }
+
+    #[test]
+    fn report_counts_daily_standalone_attachments_skips_links_and_warnings() {
+        let tmp = TempDir::new("report");
+        let source = tmp.path().join("source");
+        let forge = tmp.path().join("forge");
+        write_fixture(
+            &source.join(".obsidian/daily-notes.json"),
+            br#"{"folder":"Journal","format":"DD-MM-YYYY"}"#,
+        );
+        write_fixture(
+            &source.join("Journal/15-07-2026.md"),
+            b"Daily [[Target|Shown]] ![[assets/pic.png]]",
+        );
+        write_fixture(
+            &source.join("Journal/bad-name.md"),
+            b"Standalone ![[missing.png]]",
+        );
+        write_fixture(&source.join("Notes/Regular.md"), b"Regular");
+        write_fixture(&source.join("assets/pic.png"), b"pic");
+        write_fixture(&source.join("assets/unused.pdf"), b"unused");
+        write_fixture(&source.join("Board.canvas"), b"{}");
+        write_fixture(&source.join(".hidden.md"), b"hidden");
+
+        let report = import_fixture(&source, &forge).unwrap();
+        assert_eq!(report.daily_notes_imported, 1);
+        assert_eq!(report.standalone_notes_imported, 2);
+        assert_eq!(report.attachments_imported, 1);
+        assert_eq!(report.link_conversions_performed, 1);
+        assert!(report
+            .skipped_items
+            .iter()
+            .any(|item| item.path == "Board.canvas"));
+        assert!(report
+            .skipped_items
+            .iter()
+            .any(|item| item.path == "assets/unused.pdf"));
+        assert!(report
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("missing.png")));
+        assert_eq!(
+            fs::read_to_string(forge.join("daily/2026-07-15.md")).unwrap(),
+            "Daily [[Shown|Target]] ![](<../images/pic.png>)"
+        );
+        assert!(forge.join("notes/Journal/bad-name.md").is_file());
+    }
+
+    #[test]
+    fn analysis_reports_preview_and_estimated_collisions() {
+        let tmp = TempDir::new("analysis");
+        let source = tmp.path().join("source");
+        let forges = tmp.path().join("forges");
+        fs::create_dir_all(&forges).unwrap();
+        write_fixture(&source.join("A:B.md"), b"one");
+        write_fixture(&source.join("A?B.md"), b"two");
+        write_fixture(&source.join("one/photo.png"), b"one");
+        write_fixture(&source.join("two/photo.png"), b"two");
+        write_fixture(&source.join("view.canvas"), b"{}");
+
+        let preview = analyze_obsidian_vault_from(&source, &forges).unwrap();
+        assert_eq!(preview.note_count, 2);
+        assert_eq!(preview.attachment_count, 2);
+        assert_eq!(preview.canvas_count, 1);
+        assert!(!preview.has_obsidian_directory);
+        assert_eq!(preview.estimated_collisions, 2);
+    }
+
+    #[test]
+    fn rejects_sources_inside_existing_forges_or_overlapping_the_root() {
+        let tmp = TempDir::new("forge-overlap");
+        let root = tmp.path().join("forges");
+        let forge = root.join("Existing");
+        scaffold_forge(&forge).unwrap();
+        fs::create_dir_all(forge.join("nested")).unwrap();
+        let root = root.canonicalize().unwrap();
+        let forge = forge.canonicalize().unwrap();
+        assert!(validate_source_against_forge_roots(&forge, &root).is_err());
+        assert!(validate_source_against_forge_roots(&forge.join("nested"), &root).is_err());
+        assert!(validate_source_against_forge_roots(&root, &root).is_err());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod export_import;
 pub mod folders;
 pub mod forges;
 pub mod graph;
+pub mod import_obsidian;
 pub mod locking;
 pub mod mcp_settings;
 pub mod misc;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,6 +71,7 @@ use commands::forges::{
     set_active_forge, set_forges_root,
 };
 use commands::graph::get_note_graph;
+use commands::import_obsidian::{analyze_obsidian_vault, import_obsidian_vault};
 use commands::locking::{is_note_locked, lock_note, permanently_unlock_note, unlock_note};
 use commands::mcp_settings::{get_app_binary_path, get_mcp_writes_enabled, set_mcp_writes_enabled};
 use commands::misc::{
@@ -339,6 +340,9 @@ pub fn run() {
             delete_forge,
             set_forges_root,
             get_forges_root_path,
+            // One-time Obsidian vault COPY importer
+            analyze_obsidian_vault,
+            import_obsidian_vault,
             // Export/Import commands
             export_notes,
             import_notes,

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -18,6 +18,7 @@
  * - **AI & Agents** (`AgentsSection`)    — agent-ready Forge (AGENTS.md)
  * - **Templates** (`SettingsTemplates`)  — template management
  * - **Data** (`SettingsData`)            — bulk import / export actions
+ * - **Import** (`ImportSection`)         — one-time Obsidian vault COPY import
  * - **About** (`AboutSection`)           — version, updates, shortcuts
  *
  * Shared primitives (`Toggle`, `InfoTooltip`, `ShortcutRow`) live under
@@ -44,6 +45,7 @@ import {
   Database,
   Puzzle,
   Bot,
+  FileInput,
 } from 'lucide-react';
 import { SettingsData } from './SettingsData';
 import { AboutSection } from './sections/AboutSection';
@@ -55,6 +57,7 @@ import { CalendarSection } from './sections/CalendarSection';
 import { GeneralSection } from './sections/GeneralSection';
 import { PluginsSection } from './sections/PluginsSection';
 import { AgentsSection } from './sections/AgentsSection';
+import { ImportSection } from './sections/ImportSection';
 import { SettingsTemplates } from '@/components/templates/SettingsTemplates';
 import { useTemplates } from '@/hooks/useTemplates';
 
@@ -75,6 +78,7 @@ export function SettingsModal() {
     plugins: null,
     agents: null,
     data: null,
+    import: null,
     about: null,
   });
   const dialogRef = useRef<HTMLDivElement | null>(null);
@@ -119,6 +123,7 @@ export function SettingsModal() {
       { id: 'plugins', label: 'Plugins', icon: <Puzzle className="w-4 h-4" /> },
       { id: 'agents', label: 'AI & Agents', icon: <Bot className="w-4 h-4" /> },
       { id: 'data', label: 'Data', icon: <Database className="w-4 h-4" /> },
+      { id: 'import', label: 'Import', icon: <FileInput className="w-4 h-4" /> },
       { id: 'about', label: 'About', icon: <Info className="w-4 h-4" /> },
     ],
     []
@@ -302,6 +307,7 @@ export function SettingsModal() {
               {activeTab === 'plugins' && <PluginsSection />}
               {activeTab === 'agents' && <AgentsSection />}
               {activeTab === 'data' && <SettingsData />}
+              {activeTab === 'import' && <ImportSection />}
               {activeTab === 'about' && <AboutSection />}
             </div>
           </div>

--- a/src/components/settings/sections/ImportSection.tsx
+++ b/src/components/settings/sections/ImportSection.tsx
@@ -1,0 +1,281 @@
+/** Settings → Import: one-time, read-only Obsidian vault COPY import wizard. */
+
+import { useEffect, useRef } from 'react';
+import { open } from '@tauri-apps/plugin-dialog';
+import { AlertTriangle, CheckCircle2, FolderOpen, Loader2, X } from 'lucide-react';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+import { useForgeStore } from '@/stores/forgeStore';
+import { useObsidianImportStore } from '@/stores/obsidianImportStore';
+import { getForgeNameError } from '@/lib/obsidianImport';
+
+export function ImportSection() {
+  const stage = useObsidianImportStore((state) => state.stage);
+  const analyze = useObsidianImportStore((state) => state.analyze);
+
+  const chooseVault = async () => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      title: 'Choose an Obsidian vault',
+    });
+    if (typeof selected !== 'string') return;
+    await analyze(selected).catch(() => undefined);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold obs-import-title">Import</h2>
+        <p className="text-sm mt-1 obs-import-copy">
+          Bring an existing vault into a new Forge without changing the source.
+        </p>
+      </div>
+      <div className="obs-import-card space-y-4">
+        <div>
+          <h3 className="text-sm font-medium obs-import-title">Obsidian vault</h3>
+          <p className="text-xs mt-1 obs-import-copy">
+            Copy notes, supported daily notes, wiki-links, and referenced attachments into a new
+            Forge. Hidden items, Canvas files, trash, and symlinks are skipped.
+          </p>
+        </div>
+        <div className="obs-import-safe text-xs">
+          The source is opened read-only. Moldavite never edits, moves, or deletes its files.
+        </div>
+        <button type="button" onClick={() => void chooseVault()} className="obs-import-primary">
+          <FolderOpen className="w-4 h-4" /> Import Obsidian vault…
+        </button>
+      </div>
+      {stage !== 'idle' && <Wizard chooseVault={chooseVault} />}
+    </div>
+  );
+}
+
+function Wizard({ chooseVault }: { chooseVault: () => Promise<void> }) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const store = useObsidianImportStore();
+  const switchTo = useForgeStore((state) => state.switchTo);
+  const importing = store.stage === 'importing';
+  const nameError = getForgeNameError(store.forgeName);
+  useFocusTrap(dialogRef, store.stage !== 'idle');
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.stopPropagation();
+      if (!importing) store.reset();
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [importing, store]);
+
+  const close = () => !importing && store.reset();
+  const percent =
+    store.progress && store.progress.total > 0
+      ? Math.min(100, Math.round((store.progress.current / store.progress.total) * 100))
+      : 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-[10000] modal-backdrop-dark flex items-center justify-center modal-backdrop-enter"
+      onMouseDown={(event) => event.target === event.currentTarget && close()}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="obsidian-import-title"
+        className="obs-import-modal modal-elevated modal-content-enter"
+      >
+        <div className="flex items-start justify-between gap-4 mb-5">
+          <h2 id="obsidian-import-title" className="text-lg font-semibold obs-import-title">
+            {store.stage === 'summary' ? 'Import complete' : 'Import Obsidian vault'}
+          </h2>
+          {!importing && (
+            <button type="button" onClick={close} className="obs-import-close" aria-label="Close">
+              <X className="w-5 h-5" />
+            </button>
+          )}
+        </div>
+
+        {store.stage === 'analyzing' && <Busy label="Analyzing vault…" />}
+
+        {store.stage === 'error' && (
+          <div className="space-y-5">
+            <Notice tone="error">{store.error ?? 'The vault could not be analyzed.'}</Notice>
+            <Actions>
+              <button type="button" onClick={store.reset} className="obs-import-secondary">
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void chooseVault()}
+                className="obs-import-primary"
+              >
+                Choose another vault…
+              </button>
+            </Actions>
+          </div>
+        )}
+
+        {store.stage === 'preview' && store.preview && (
+          <div className="space-y-5">
+            {!store.preview.hasObsidianDirectory && (
+              <Notice tone="warning">
+                No <code>.obsidian</code> folder was found. Default daily-note settings will be
+                used.
+              </Notice>
+            )}
+            <div className="obs-import-grid">
+              <Metric label="Notes" value={store.preview.noteCount} />
+              <Metric label="Attachments" value={store.preview.attachmentCount} />
+              <Metric label="Folders" value={store.preview.folderCount} />
+              <Metric label="Canvas skipped" value={store.preview.canvasCount} />
+            </div>
+            <div className="text-xs obs-import-copy space-y-1">
+              <p>
+                Daily notes:{' '}
+                {store.preview.detectedDailyNotes
+                  ? `${store.preview.detectedDailyNotes.folder || 'vault root'} · ${store.preview.detectedDailyNotes.format}`
+                  : 'default · YYYY-MM-DD'}
+              </p>
+              <p>Estimated collisions: {store.preview.estimatedCollisions}</p>
+            </div>
+            {store.preview.warnings.length > 0 && store.preview.hasObsidianDirectory && (
+              <Notice tone="warning">{store.preview.warnings.join(' · ')}</Notice>
+            )}
+            {store.error && <Notice tone="error">{store.error}</Notice>}
+            <div>
+              <label htmlFor="obsidian-forge-name" className="text-sm font-medium obs-import-title">
+                New Forge name
+              </label>
+              <input
+                id="obsidian-forge-name"
+                value={store.forgeName}
+                maxLength={64}
+                onChange={(event) => store.setForgeName(event.target.value)}
+                aria-invalid={Boolean(nameError)}
+                className={`obs-import-input ${nameError ? 'is-error' : ''}`}
+              />
+              {nameError && <p className="obs-import-error">{nameError}</p>}
+            </div>
+            <Actions split>
+              <button
+                type="button"
+                onClick={() => void chooseVault()}
+                className="obs-import-secondary"
+              >
+                Choose another…
+              </button>
+              <button
+                type="button"
+                disabled={Boolean(nameError)}
+                onClick={() => void store.startImport().catch(() => undefined)}
+                className="obs-import-primary"
+              >
+                Import into new Forge
+              </button>
+            </Actions>
+          </div>
+        )}
+
+        {importing && (
+          <div className="space-y-5 py-6">
+            <Busy label="Copying and converting…" />
+            <div
+              role="progressbar"
+              aria-label="Obsidian import progress"
+              aria-valuemin={0}
+              aria-valuemax={store.progress?.total ?? 0}
+              aria-valuenow={store.progress?.current ?? 0}
+              className="obs-import-progress"
+            >
+              <div style={{ width: store.progress?.total ? `${percent}%` : '12%' }} />
+            </div>
+            <p className="text-xs text-right obs-import-copy">
+              {store.progress?.total
+                ? `${store.progress.current} of ${store.progress.total} notes`
+                : 'Preparing import…'}
+            </p>
+          </div>
+        )}
+
+        {store.stage === 'summary' && store.report && (
+          <div className="space-y-5">
+            <div className="flex items-start gap-3">
+              <CheckCircle2 className="w-6 h-6 obs-import-success" />
+              <div>
+                <p className="text-sm font-medium obs-import-title">
+                  “{store.report.forgeName}” is ready
+                </p>
+                <p className="text-xs mt-1 obs-import-copy">The source vault was left unchanged.</p>
+              </div>
+            </div>
+            <div className="obs-import-grid">
+              <Metric
+                label="Notes"
+                value={store.report.dailyNotesImported + store.report.standaloneNotesImported}
+              />
+              <Metric label="Daily" value={store.report.dailyNotesImported} />
+              <Metric label="Attachments" value={store.report.attachmentsImported} />
+              <Metric label="Links converted" value={store.report.linkConversionsPerformed} />
+            </div>
+            {(store.report.warnings.length > 0 || store.report.skippedItems.length > 0) && (
+              <div className="obs-import-details text-xs">
+                {store.report.warnings.map((warning, index) => (
+                  <p key={`w-${index}`}>Warning: {warning}</p>
+                ))}
+                {store.report.skippedItems.map((item, index) => (
+                  <p key={`s-${index}`}>
+                    <code>{item.path}</code> — {item.reason}
+                  </p>
+                ))}
+              </div>
+            )}
+            <Actions>
+              <button type="button" onClick={store.reset} className="obs-import-secondary">
+                Done
+              </button>
+              <button
+                type="button"
+                onClick={() => store.report && void switchTo(store.report.forgeName)}
+                className="obs-import-primary"
+              >
+                <FolderOpen className="w-4 h-4" /> Open Forge
+              </button>
+            </Actions>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Busy({ label }: { label: string }) {
+  return (
+    <div className="obs-import-busy">
+      <Loader2 className="w-6 h-6 animate-spin" /> <span>{label}</span>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="obs-import-metric">
+      <strong>{value}</strong>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function Actions({ children, split = false }: { children: React.ReactNode; split?: boolean }) {
+  return <div className={`obs-import-actions ${split ? 'split' : ''}`}>{children}</div>;
+}
+
+function Notice({ children, tone }: { children: React.ReactNode; tone: 'warning' | 'error' }) {
+  return (
+    <div className={`obs-import-notice ${tone}`}>
+      <AlertTriangle className="w-4 h-4" /> <span>{children}</span>
+    </div>
+  );
+}

--- a/src/components/sidebar/CollapsibleSection.tsx
+++ b/src/components/sidebar/CollapsibleSection.tsx
@@ -67,7 +67,11 @@ export function CollapsibleSection({
           transition: 'max-height 250ms cubic-bezier(0.16, 1, 0.3, 1), opacity 200ms ease',
         }}
       >
-        {children}
+        {/* Indent section contents under the header with a tree guide line so
+            the section hierarchy stays readable at a glance. */}
+        <div className="ml-[18px] pl-1.5 border-l" style={{ borderColor: 'var(--border-default)' }}>
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -3544,3 +3544,188 @@ textarea:focus {
 .dark .slash-command-description {
   color: var(--text-secondary, #9098a8);
 }
+
+/* Settings → Import wizard. Theme tokens keep the lazy-loaded UI compact. */
+.obs-import-title {
+  color: var(--text-primary);
+}
+
+.obs-import-copy {
+  color: var(--text-tertiary);
+}
+
+.obs-import-card,
+.obs-import-metric {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-md);
+}
+
+.obs-import-card {
+  padding: 1rem;
+}
+
+.obs-import-safe,
+.obs-import-details {
+  padding: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--bg-inset);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-sm);
+}
+
+.obs-import-primary,
+.obs-import-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: opacity var(--duration-fast);
+}
+
+.obs-import-primary {
+  color: var(--bg-base);
+  background: var(--accent-primary);
+}
+
+.obs-import-secondary {
+  color: var(--text-secondary);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-default);
+}
+
+.obs-import-primary:disabled,
+.obs-import-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.obs-import-modal {
+  width: min(36rem, calc(100% - 2rem));
+  max-height: 82vh;
+  padding: 1.5rem;
+  overflow-y: auto;
+  border-radius: var(--radius-md);
+}
+
+.obs-import-close {
+  padding: 0.25rem;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+}
+
+.obs-import-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.obs-import-metric {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem;
+}
+
+.obs-import-metric strong {
+  color: var(--text-primary);
+}
+
+.obs-import-metric span {
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+}
+
+.obs-import-input {
+  width: 100%;
+  margin-top: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+}
+
+.obs-import-input.is-error {
+  border-color: var(--error);
+}
+
+.obs-import-error {
+  margin-top: 0.25rem;
+  color: var(--error);
+  font-size: 0.75rem;
+}
+
+.obs-import-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.obs-import-actions.split {
+  justify-content: space-between;
+}
+
+.obs-import-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+}
+
+.obs-import-notice svg {
+  flex-shrink: 0;
+}
+
+.obs-import-notice.warning {
+  background: var(--warning-muted);
+  border: 1px solid var(--warning);
+}
+
+.obs-import-notice.error {
+  background: var(--error-muted);
+  border: 1px solid var(--error);
+}
+
+.obs-import-busy {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 6rem;
+  color: var(--accent-primary);
+}
+
+.obs-import-progress {
+  height: 0.5rem;
+  overflow: hidden;
+  background: var(--bg-inset);
+  border-radius: var(--radius-sm);
+}
+
+.obs-import-progress div {
+  height: 100%;
+  background: var(--accent-primary);
+  border-radius: inherit;
+  transition: width var(--duration-normal);
+}
+
+.obs-import-success {
+  flex-shrink: 0;
+  color: var(--success);
+}
+
+.obs-import-details {
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+.obs-import-details p + p {
+  margin-top: 0.375rem;
+}

--- a/src/lib/obsidianImport.ts
+++ b/src/lib/obsidianImport.ts
@@ -1,0 +1,73 @@
+/** Typed IPC contract for the one-time, read-only Obsidian vault COPY importer. */
+
+import { safeInvoke } from './ipc';
+
+export const OBSIDIAN_IMPORT_PROGRESS_EVENT = 'obsidian-import://progress';
+
+export interface ObsidianDailyNotesConfig {
+  folder: string;
+  format: string;
+}
+
+export interface ObsidianVaultPreview {
+  noteCount: number;
+  attachmentCount: number;
+  detectedDailyNotes: ObsidianDailyNotesConfig | null;
+  folderCount: number;
+  canvasCount: number;
+  estimatedCollisions: number;
+  hasObsidianDirectory: boolean;
+  warnings: string[];
+}
+
+export interface ObsidianImportProgress {
+  current: number;
+  total: number;
+}
+
+export interface SkippedImportItem {
+  path: string;
+  reason: string;
+}
+
+export interface ObsidianImportReport {
+  forgeName: string;
+  dailyNotesImported: number;
+  standaloneNotesImported: number;
+  attachmentsImported: number;
+  skippedItems: SkippedImportItem[];
+  linkConversionsPerformed: number;
+  warnings: string[];
+}
+
+export function analyzeObsidianVault(path: string): Promise<ObsidianVaultPreview> {
+  return safeInvoke<ObsidianVaultPreview>('analyze_obsidian_vault', { path });
+}
+
+export function importObsidianVault(
+  path: string,
+  forgeName: string
+): Promise<ObsidianImportReport> {
+  return safeInvoke<ObsidianImportReport>('import_obsidian_vault', { path, forgeName });
+}
+
+/** Mirror `commands::forges::is_valid_forge_name` for immediate form feedback. */
+export function getForgeNameError(name: string): string | null {
+  if (!name) return 'Forge name is required';
+  if (name.includes('\0')) return 'Forge name cannot contain null characters';
+  if (name.includes('..')) return 'Forge name cannot contain ".."';
+  if (name.startsWith('/') || name.startsWith('\\') || name.includes('/') || name.includes('\\')) {
+    return 'Forge name must be a single folder name';
+  }
+  if (name.startsWith('.')) return 'Forge name cannot start with a period';
+  if (['CON', 'PRN', 'AUX', 'NUL'].includes(name.toUpperCase())) {
+    return 'That Forge name is reserved';
+  }
+  if (Array.from(name).length > 64) return 'Forge name must be 64 characters or less';
+  return null;
+}
+
+export function forgeNameFromVaultPath(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : '';
+}

--- a/src/stores/obsidianImportStore.test.ts
+++ b/src/stores/obsidianImportStore.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { __resetObsidianImportStoreForTests, useObsidianImportStore } from './obsidianImportStore';
+import { OBSIDIAN_IMPORT_PROGRESS_EVENT } from '@/lib/obsidianImport';
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+const mockInvoke = vi.mocked(invoke);
+const mockListen = vi.mocked(listen);
+type Handler = (event: { payload: unknown }) => void;
+let handlers: Record<string, Handler>;
+
+const preview = {
+  noteCount: 12,
+  attachmentCount: 3,
+  detectedDailyNotes: { folder: 'Journal', format: 'DD-MM-YYYY' },
+  folderCount: 4,
+  canvasCount: 1,
+  estimatedCollisions: 2,
+  hasObsidianDirectory: true,
+  warnings: [],
+};
+
+const report = {
+  forgeName: 'Research',
+  dailyNotesImported: 5,
+  standaloneNotesImported: 7,
+  attachmentsImported: 2,
+  skippedItems: [{ path: 'Board.canvas', reason: 'Obsidian Canvas files are not imported' }],
+  linkConversionsPerformed: 9,
+  warnings: ['Could not resolve attachment missing.png'],
+};
+
+describe('obsidianImportStore', () => {
+  beforeEach(() => {
+    __resetObsidianImportStoreForTests();
+    handlers = {};
+    mockListen.mockReset();
+    mockListen.mockImplementation(async (event, handler) => {
+      handlers[event as string] = handler as Handler;
+      return () => {};
+    });
+    mockInvoke.mockReset();
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'analyze_obsidian_vault') return preview;
+      if (command === 'import_obsidian_vault') return report;
+      return undefined;
+    });
+  });
+
+  it('analyzes a selected folder and prefills the Forge name from its final segment', async () => {
+    await useObsidianImportStore.getState().analyze('/Users/example/Obsidian/Research');
+
+    expect(mockInvoke).toHaveBeenCalledWith('analyze_obsidian_vault', {
+      path: '/Users/example/Obsidian/Research',
+    });
+    const state = useObsidianImportStore.getState();
+    expect(state.stage).toBe('preview');
+    expect(state.forgeName).toBe('Research');
+    expect(state.preview).toEqual(preview);
+    expect(Object.keys(handlers)).toEqual([OBSIDIAN_IMPORT_PROGRESS_EVENT]);
+  });
+
+  it('supports Windows-style selected paths without using Array.at', async () => {
+    await useObsidianImportStore.getState().analyze('C:\\Notes\\Personal Vault');
+    expect(useObsidianImportStore.getState().forgeName).toBe('Personal Vault');
+  });
+
+  it('rejects an unsafe Forge name before invoking the import command', async () => {
+    await useObsidianImportStore.getState().analyze('/vaults/Research');
+    mockInvoke.mockClear();
+    useObsidianImportStore.getState().setForgeName('../escape');
+
+    await expect(useObsidianImportStore.getState().startImport()).rejects.toThrow(
+      'cannot contain ".."'
+    );
+    expect(mockInvoke).not.toHaveBeenCalled();
+    expect(useObsidianImportStore.getState().stage).toBe('preview');
+  });
+
+  it('streams progress and finishes on the summary report', async () => {
+    let resolveImport: ((value: typeof report) => void) | undefined;
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'analyze_obsidian_vault') return preview;
+      if (command === 'import_obsidian_vault') {
+        return await new Promise<typeof report>((resolve) => {
+          resolveImport = resolve;
+        });
+      }
+      return undefined;
+    });
+    await useObsidianImportStore.getState().analyze('/vaults/Research');
+    const importing = useObsidianImportStore.getState().startImport();
+    await Promise.resolve();
+    handlers[OBSIDIAN_IMPORT_PROGRESS_EVENT]({ payload: { current: 10, total: 12 } });
+    expect(useObsidianImportStore.getState().progress).toEqual({ current: 10, total: 12 });
+
+    if (!resolveImport) throw new Error('Import command was not invoked');
+    resolveImport(report);
+    await expect(importing).resolves.toEqual(report);
+    const state = useObsidianImportStore.getState();
+    expect(state.stage).toBe('summary');
+    expect(state.report).toEqual(report);
+    expect(state.progress).toBeNull();
+  });
+
+  it('reset clears all transient wizard state', async () => {
+    await useObsidianImportStore.getState().analyze('/vaults/Research');
+    useObsidianImportStore.getState().reset();
+    const state = useObsidianImportStore.getState();
+    expect(state.stage).toBe('idle');
+    expect(state.sourcePath).toBeNull();
+    expect(state.preview).toBeNull();
+    expect(state.report).toBeNull();
+  });
+});

--- a/src/stores/obsidianImportStore.ts
+++ b/src/stores/obsidianImportStore.ts
@@ -1,0 +1,123 @@
+/** Transient wizard state for analyzing and importing one Obsidian vault. */
+
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { create } from 'zustand';
+import {
+  OBSIDIAN_IMPORT_PROGRESS_EVENT,
+  analyzeObsidianVault,
+  forgeNameFromVaultPath,
+  getForgeNameError,
+  importObsidianVault,
+  type ObsidianImportProgress,
+  type ObsidianImportReport,
+  type ObsidianVaultPreview,
+} from '@/lib/obsidianImport';
+
+export type ObsidianImportStage =
+  | 'idle'
+  | 'analyzing'
+  | 'preview'
+  | 'importing'
+  | 'summary'
+  | 'error';
+
+interface ObsidianImportState {
+  stage: ObsidianImportStage;
+  sourcePath: string | null;
+  forgeName: string;
+  preview: ObsidianVaultPreview | null;
+  progress: ObsidianImportProgress | null;
+  report: ObsidianImportReport | null;
+  error: string | null;
+  initialize: () => Promise<void>;
+  analyze: (path: string) => Promise<void>;
+  setForgeName: (name: string) => void;
+  startImport: () => Promise<ObsidianImportReport>;
+  reset: () => void;
+}
+
+const initialState = {
+  stage: 'idle' as ObsidianImportStage,
+  sourcePath: null as string | null,
+  forgeName: '',
+  preview: null as ObsidianVaultPreview | null,
+  progress: null as ObsidianImportProgress | null,
+  report: null as ObsidianImportReport | null,
+  error: null as string | null,
+};
+
+let initialized = false;
+const unlistenFns: UnlistenFn[] = [];
+
+export const useObsidianImportStore = create<ObsidianImportState>((set, get) => ({
+  ...initialState,
+
+  initialize: async () => {
+    if (initialized) return;
+    initialized = true;
+    try {
+      const unlisten = await listen<ObsidianImportProgress>(
+        OBSIDIAN_IMPORT_PROGRESS_EVENT,
+        (event) => {
+          if (get().stage === 'importing') set({ progress: event.payload });
+        }
+      );
+      unlistenFns.push(unlisten);
+    } catch (error) {
+      // Event delivery is an enhancement; the import report remains authoritative.
+      console.error('[obsidianImportStore] progress subscription failed:', error);
+    }
+  },
+
+  analyze: async (path) => {
+    const sourcePath = path.trim();
+    set({
+      ...initialState,
+      stage: 'analyzing',
+      sourcePath,
+      forgeName: forgeNameFromVaultPath(sourcePath),
+    });
+    await get().initialize();
+    try {
+      const preview = await analyzeObsidianVault(sourcePath);
+      set({ stage: 'preview', preview, error: null });
+    } catch (error) {
+      set({ stage: 'error', error: error instanceof Error ? error.message : String(error) });
+      throw error;
+    }
+  },
+
+  setForgeName: (forgeName) => set({ forgeName, error: null }),
+
+  startImport: async () => {
+    const { sourcePath, forgeName } = get();
+    if (!sourcePath) throw new Error('Choose an Obsidian vault first');
+    const nameError = getForgeNameError(forgeName);
+    if (nameError) {
+      set({ error: nameError });
+      throw new Error(nameError);
+    }
+    set({ stage: 'importing', progress: { current: 0, total: 0 }, error: null });
+    try {
+      const report = await importObsidianVault(sourcePath, forgeName);
+      set({ stage: 'summary', report, progress: null, error: null });
+      return report;
+    } catch (error) {
+      set({
+        stage: 'preview',
+        progress: null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  },
+
+  reset: () => set(initialState),
+}));
+
+/** Test-only reset for module-level Tauri event subscription bookkeeping. */
+export function __resetObsidianImportStoreForTests(): void {
+  initialized = false;
+  for (const unlisten of unlistenFns.splice(0)) unlisten();
+  useObsidianImportStore.setState(initialState);
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -32,6 +32,7 @@ export type SettingsTab =
   | 'plugins'
   | 'agents'
   | 'data'
+  | 'import'
   | 'about';
 
 interface SettingsState {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,15 +42,18 @@ export default defineConfig({
           if (id.includes('CHANGELOG.md')) return 'changelog';
           if (!id.includes('node_modules')) return undefined;
           if (id.includes('@tiptap') || id.includes('prosemirror')) return 'tiptap-vendor';
-          if (
-            id.includes('markdown-it') ||
-            id.includes('turndown') ||
-            id.includes('dompurify')
-          )
+          if (id.includes('markdown-it') || id.includes('turndown') || id.includes('dompurify'))
             return 'markdown-vendor';
           if (id.includes('date-fns')) return 'date-vendor';
           if (id.includes('@dnd-kit')) return 'dnd-vendor';
-          if (id.includes('react-dom') || id.includes('/react/')) return 'react-vendor';
+          if (
+            id.includes('react-dom') ||
+            id.includes('/react/') ||
+            id.includes('@tauri-apps') ||
+            id.includes('lucide-react') ||
+            id.includes('/zustand/')
+          )
+            return 'react-vendor';
           return undefined;
         },
       },


### PR DESCRIPTION
## What

New **Settings → Import** section: pick an Obsidian vault folder, get a read-only analysis preview (note/attachment/folder counts, detected daily-note config, collision estimate, warnings), name the new Forge, and import with live progress and a final report.

## How it converts

- **Source vault is strictly read-only** — traversed with symlink_metadata, symlinks never followed, re-validated at copy time.
- Daily notes: `.obsidian/daily-notes.json` folder/format detected; YYYY/MM/DD-token formats normalized to `daily/YYYY-MM-DD.md`; non-parsing names stay standalone.
- Wiki-links: Obsidian `[[target|Display]]` swapped to Moldavite `[[Display|target]]`; `#heading`/`^block` suffixes stripped.
- Embeds `![[file]]` become standard markdown images; referenced attachments are flattened into `images/` with deterministic collision suffixes.
- Frontmatter preserved verbatim; folder structure kept under `notes/` with sanitized, deduped segments.
- Skipped with reasons: `.obsidian/`, `.trash/`, hidden files, `.canvas`, symlinks, non-Unicode names.
- Every destination path is component-validated and canonically contained in the new Forge; all writes via `write_atomic`; a failed import removes the partially created Forge.

## Verification

- cargo test: 187 passed (9 new importer tests) · clippy `-D warnings` clean
- vitest: 247 passed (39 files) · ESLint 0 errors · bundle budgets unchanged
- Website guide copy is intentionally **not** in this PR (feature isn't in a shipped build yet); it's parked on `site/obsidian-import` to merge with the release.