### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [1.7.0] - 2026-07-15
 
 ### Changed
 - **Clearer sidebar hierarchy.** Items inside each sidebar section (Notes, Folders, Daily, Tags, Backlinks) are now indented beneath their section header with a subtle tree guide line, so sections read as collapsible groups at a glance.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -64,8 +64,8 @@
 1. **Plugin UI/write extensions** — build on the shipped Worker/RPC boundary and v2 read/network/secrets surface with conflict-safe note writes and narrow panel slots.
 2. **Persistent search index** — incremental, on-disk; unlocks instant search, better snippets, cheaper backlinks.
 3. **Automatic local backups** — scheduled snapshots of the Forge with retention (fits the local-first/no-cloud identity).
-4. ~~**Note rename UI**~~ — Done (unreleased): sidebar/editor rename keeps tabs, recents, colors, selection, and backlinks synchronized while the backend safely rewrites inbound links.
-5. ~~External-edit conflict handling beyond the file-watcher refresh.~~ Done (unreleased): conflict copies preserve both versions on divergent saves.
+4. ~~**Note rename UI**~~ — Done (v1.6): sidebar/editor rename keeps tabs, recents, colors, selection, and backlinks synchronized while the backend safely rewrites inbound links.
+5. ~~External-edit conflict handling beyond the file-watcher refresh.~~ Done (v1.6): conflict copies preserve both versions on divergent saves.
 
 ## Explicit Non-Goals
 Staying a *note app*: no canvas/whiteboard, no publish service, no database views in core. The plugin system is the extension point for the long tail.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Moldavite — Project Status
 
-**Last Updated:** July 15, 2026 (v1.6.0 + unreleased)
+**Last Updated:** July 15, 2026 (v1.7.0)
 **Status:** Shipping — signed/notarized releases with in-app auto-update since v1.3.1
 
 > Keep this file honest: update it whenever a feature ships, changes, or a
@@ -12,31 +12,31 @@
 - Daily notes (auto-created per day, auto-deleted when emptied — media-only content counts as content), weekly notes, standalone notes with folders
 - TipTap rich-text editor: headings, lists, task lists, images (resizable), highlights, alignment, code, links; slash commands; tabs with pinning
 - Wiki-links `[[Note]]` / `[[Display|target]]` with existence styling, backlinks panel, backlinks sidebar section, and a deterministic force-directed graph whose linked components cluster while orphans stay peripheral
-- Standalone note rename UI in the sidebar and editor; open state follows the new path and inbound wiki-links are rewritten vault-wide (unreleased). Unicode-safe NFC slugs are shared by frontend + backend (v1.5)
+- Standalone note rename UI in the sidebar and editor; open state follows the new path and inbound wiki-links are rewritten vault-wide (v1.6). Unicode-safe NFC slugs are shared by frontend + backend (v1.5)
 - `#tags` with sidebar aggregation and global tag rename
 - Templates (defaults + custom JSON) with `{{date}}`/`{{time}}`/`{{day_of_week}}`; default daily/weekly templates
 - Quick switcher / command palette (⌘P), backend full-text search with snippets, timeline view; opening any note yields transient Timeline/Graph views so navigation cannot remain hidden behind them
-- Local semantic search (unreleased; requires Apple Silicon on macOS, while Intel Macs get keyword search): opt-in per-Forge embeddings index with a curated three-model picker (all-MiniLM-L6-v2 is the default; BGE small English v1.5 and Multilingual E5 small are available). Consent names the active model and download size; model changes trigger a full re-index with live progress. Fully offline afterwards; locked notes are never indexed. Sidebar Keyword/Semantic search mode chip, "Related" notes section under the editor, Settings → AI & Agents toggle + rebuild-index button
+- Local semantic search (v1.6; requires Apple Silicon on macOS, while Intel Macs get keyword search): opt-in per-Forge embeddings index with a curated three-model picker (all-MiniLM-L6-v2 is the default; BGE small English v1.5 and Multilingual E5 small are available). Consent names the active model and download size; model changes trigger a full re-index with live progress. Fully offline afterwards; locked notes are never indexed. Sidebar Keyword/Semantic search mode chip, "Related" notes section under the editor, Settings → AI & Agents toggle + rebuild-index button
 
 ### Storage & Data Safety
 - Real Markdown on disk with YAML frontmatter (color + extensible keys); legacy HTML-bodied files still readable
 - **Atomic writes everywhere** (temp + fsync + rename; 0600 before visibility) — v1.5
 - Folder-relative note addressing (fixed folder-note round-trip data bug) — v1.5
-- **External-edit conflict safety** (unreleased): saves send the content hash from the last read; if the disk copy diverged (sync tool, other editor), the disk version is preserved as a `<name> (conflict YYYY-MM-DD HHMM).md` copy before the save, with a warning toast + list refresh
+- **External-edit conflict safety** (v1.6): saves send the content hash from the last read; if the disk copy diverged (sync tool, other editor), the disk version is preserved as a `<name> (conflict YYYY-MM-DD HHMM).md` copy before the save, with a warning toast + list refresh
 - Forge file watcher: external changes refresh the note list live (self-writes suppressed)
 - Trash with 7-day retention, restore, previews; multiple Forges (vaults) with per-Forge state
 - Note locking (AES-256-GCM + Argon2, rate-limited unlock, auto-lock); encrypted vault backups; settings JSON export/import
 - Import/export: Markdown, PDF, plaintext, bulk export, encrypted archive
-- Obsidian vault importer (unreleased): Settings → Import performs a read-only analysis, then copies supported daily notes, standalone notes with sanitized folder structure, converted wiki-link aliases, verbatim YAML frontmatter, and referenced attachments into a new Forge. Name collisions are suffixed deterministically; hidden items, `.trash`, Canvas files, symlinks, unreferenced attachments, and unresolved embeds are skipped or warned in the final report.
-- Agent-ready Forge (unreleased): Settings → AI & Agents writes `AGENTS.md` + `.gitignore` to the Forge root via a hard-whitelisted backend command (exactly those two filenames), with confirm-overwrite and existence indicator
-- Built-in MCP stdio server (unreleased): the single app binary switches to headless MCP mode with the exact `--mcp` flag, defaults to the active Forge (`--forge <name>` override), exposes four read tools plus three explicitly gated write tools, validates all client paths, refuses locked notes, and uses atomic writes + semantic-index change hooks
+- Obsidian vault importer (v1.7): Settings → Import performs a read-only analysis, then copies supported daily notes, standalone notes with sanitized folder structure, converted wiki-link aliases, verbatim YAML frontmatter, and referenced attachments into a new Forge. Name collisions are suffixed deterministically; hidden items, `.trash`, Canvas files, symlinks, unreferenced attachments, and unresolved embeds are skipped or warned in the final report.
+- Agent-ready Forge (v1.6): Settings → AI & Agents writes `AGENTS.md` + `.gitignore` to the Forge root via a hard-whitelisted backend command (exactly those two filenames), with confirm-overwrite and existence indicator
+- Built-in MCP stdio server (v1.6): the single app binary switches to headless MCP mode with the exact `--mcp` flag, defaults to the active Forge (`--forge <name>` override), exposes four read tools plus three explicitly gated write tools, validates all client paths, refuses locked notes, and uses atomic writes + semantic-index change hooks
 
 ### Platform
 - Apple Calendar (EventKit, read-only, permission-gated) in right panel + timeline
 - Signed + notarized releases, minisign-verified auto-updates, "What's New" popup from CHANGELOG (see docs/RELEASING.md)
 - Themes/presets, keyboard shortcut overlay (⌘?), settings modal with focus trap
 
-### Plugins (v2 — v1 shipped 1.4.0, sandbox hardened 1.5.0, v2 unreleased)
+### Plugins (v2 — v1 shipped 1.4.0, sandbox hardened 1.5.0, v2 shipped 1.6.0)
 - API v2: commands/editor/toasts plus trusted host-rendered prompt forms, permissioned unlocked-note metadata + Markdown reads, host-performed HTTPS behind manifest and individually revocable user-approved exact hosts, and per-plugin macOS Keychain secrets; API v1 remains compatible
 - Per-Forge enable state; permission sheet shows human-readable capabilities, manifest hosts, and runtime hosts with per-host revoke; manifest consent remains pinned to SHA-256 of raw manifest + code while runtime host consent is stored app-side
 - Every successful in-app install opens a themed manifest-sourced setup guide; an ⓘ action on each installed card reopens its description, commands, instructions, and permissions at any time
@@ -49,7 +49,7 @@
 ## Test & Quality Status
 - Frontend: vitest — 247 tests across 39 files (stores, lib, hooks, graph layout, transient-view navigation, Obsidian import, deep-link routing, plugin RPC/manifest/registry/UI)
 - Backend: cargo test — 187 tests incl. stress suite, Obsidian conversion/path-safety, conflict-copy, semantic-index, MCP, plugin install/hash/secret validation, and strict deep-link routing suites
-- Bundle budget enforced via `npm run check:size` (within budget as of v1.6.0 + unreleased importer)
+- Bundle budget enforced via `npm run check:size` (within budget as of v1.7.0)
 - ESLint: 0 errors, ~22 pre-existing warnings (set-state-in-effect patterns in modals; tracked below)
 
 ## Known Issues / Debt

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -6,7 +6,7 @@
     <title>Using Moldavite — v1.6 User Guide</title>
     <meta
       name="description"
-      content="The Moldavite v1.6 guide: Forges, editing, semantic search, MCP clients, agent-ready files, plugins, WordPress publishing, conflicts, and privacy."
+      content="The Moldavite v1.6 guide: Forges, Obsidian import, editing, semantic search, MCP clients, agent-ready files, plugins, WordPress publishing, conflicts, and privacy."
     />
     <link rel="icon" type="image/png" href="icon.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -60,6 +60,7 @@
       <nav class="docs-toc" aria-label="On this page">
         <strong>On this page</strong>
         <a href="#getting-started">Getting started</a>
+        <a href="#obsidian-import">Import from Obsidian</a>
         <a href="#editor">Editor, links, and graph</a>
         <a href="#organization">Organization and search</a>
         <a href="#semantic-search">Local semantic search</a>
@@ -103,6 +104,37 @@
           does not understand, so metadata from another tool survives an app save.
         </p>
       </div>
+
+      <h2 id="obsidian-import">Import from Obsidian</h2>
+      <p>
+        Open <strong>Settings → Import</strong> and choose an Obsidian vault folder. Moldavite first
+        shows a read-only preview, then copies the vault into a <strong>new Forge</strong>; it never
+        edits, moves, or deletes anything in the source vault. You choose the new Forge name and can
+        switch to it from the completion summary.
+      </p>
+      <ul>
+        <li>
+          Daily-note settings from <code>.obsidian/daily-notes.json</code> are detected when present.
+          Formats made from <code>YYYY</code>, <code>MM</code>, and <code>DD</code> with
+          <code>-</code>, <code>_</code>, <code>.</code>, or <code>/</code> separators are normalized to
+          <code>daily/YYYY-MM-DD.md</code>; names that do not parse remain standalone notes.
+        </li>
+        <li>
+          Other Markdown notes retain their folder structure with filesystem-safe, collision-deduped
+          names. YAML frontmatter is preserved verbatim.
+        </li>
+        <li>
+          Obsidian <code>[[target|Display]]</code> aliases become Moldavite
+          <code>[[Display|target]]</code> aliases, while heading and block suffixes are removed from
+          link targets. Referenced wiki embeds and local Markdown images are copied into
+          <code>images/</code> and rewritten to relative Markdown image paths.
+        </li>
+        <li>
+          <code>.obsidian/</code>, <code>.trash/</code>, hidden items, Canvas files, and symlinks are
+          never imported. Unreferenced attachments and unresolved embeds remain listed in the final
+          report; unresolved embed text is left in the note.
+        </li>
+      </ul>
 
       <h2 id="editor">The editor, wiki-links, and graph</h2>
       <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -268,6 +268,16 @@
               <a href="guide.html#conflicts">Understand conflict copies →</a>
             </article>
             <article class="feature-card liquid-glass">
+              <span class="feature-icon" aria-hidden="true">→MD</span>
+              <h3>Move from Obsidian safely</h3>
+              <p>
+                Preview a vault, then copy its notes, supported daily-note layout, wiki-links, and
+                referenced attachments into a new Forge. The source stays unchanged; skipped and
+                unresolved items are reported.
+              </p>
+              <a href="guide.html#obsidian-import">See exactly what imports →</a>
+            </article>
+            <article class="feature-card liquid-glass">
               <span class="feature-icon" aria-hidden="true">API</span>
               <h3>Sandboxed Plugin API v2</h3>
               <p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.6.0"
+version = "1.7.0"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump to 1.7.0, dated changelog, website guide copy for the Obsidian importer, and PROJECT_STATUS release-marker refresh.

Ships: one-time Obsidian vault importer (Settings → Import) and clearer sidebar section hierarchy.