### PR TITLE
feat: daily automatic update checks with pending-update indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ CLAUDE.local.md
 # Local working files
 AGENTS.md
 AGENTS.local.md
+sdd/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Moldavite are documented here.
 
+## [Unreleased]
+
+### Added
+- **Unobtrusive automatic update checks.** Moldavite checks about 15 seconds after launch, every 24 hours while running, and when a stale app window regains focus. Automatic network and mid-release 404 failures retry silently, while a pending version appears as an accent dot on Settings and its About tab with the existing install action; manual checks continue to show explicit errors.
+
 ## [1.7.0] - 2026-07-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This app carries that spirit. Your notes live only on your Mac—fused with your
 
 **Sync-friendly** — Point iCloud Drive, Dropbox, Syncthing, or git at your Forge. If a note changes on disk while you're editing it in Moldavite, the external version is preserved as a conflict copy instead of being overwritten.
 
-**Automatic updates** — Moldavite checks for new versions and updates in place. After updating, a "What's New" popup summarizes the changes.
+**Automatic updates** — Moldavite checks shortly after launch, every 24 hours while open, and when a stale window regains focus. Pending versions add a quiet dot to Settings and About with an install action; transient automatic-check failures stay silent, while manual checks remain explicit. After updating, a "What's New" popup summarizes the changes.
 
 **Plugins** — build sandboxed command integrations with permissioned unlocked-note reads, exact-host HTTPS requests (including individually revocable runtime host grants), trusted app-rendered forms, and plugin-owned macOS Keychain secrets. Browse in Settings or search the website directory and use its `moldavite://plugin/<id>` install links; Moldavite opens the chosen registry entry and shows its permissions before any install. Downloads stay pinned to the registry repository and Rust verifies both SHA-256 hashes before an atomic install. Every install shows a reopenable setup guide, while enablement and consent remain separate. Install the **Publish to WordPress** reference to publish/update drafts with Application Passwords. Plugins live in your Forge, every capability is host-enforced, and manifest/code changes re-prompt for consent; see [docs/PLUGINS.md](docs/PLUGINS.md).
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Moldavite — Project Status
 
-**Last Updated:** July 15, 2026 (v1.7.0)
+**Last Updated:** July 16, 2026 (post-v1.7.0 development)
 **Status:** Shipping — signed/notarized releases with in-app auto-update since v1.3.1
 
 > Keep this file honest: update it whenever a feature ships, changes, or a
@@ -33,7 +33,7 @@
 
 ### Platform
 - Apple Calendar (EventKit, read-only, permission-gated) in right panel + timeline
-- Signed + notarized releases, minisign-verified auto-updates, "What's New" popup from CHANGELOG (see docs/RELEASING.md)
+- Signed + notarized releases and minisign-verified auto-updates. Checks run about 15 seconds after launch, every 24 hours while open, and on focus after 24 hours without a successful check; automatic network/404 failures stay silent and retry, while pending versions add accent dots to Settings and About plus the existing install action. Manual checks retain explicit errors, and completed upgrades show the CHANGELOG-backed "What's New" popup (see docs/RELEASING.md)
 - Themes/presets, keyboard shortcut overlay (⌘?), settings modal with focus trap
 
 ### Plugins (v2 — v1 shipped 1.4.0, sandbox hardened 1.5.0, v2 shipped 1.6.0)
@@ -47,10 +47,10 @@
 - Bundled first-party Publish to WordPress reference plugin: Application Password verification, draft create/update keyed by Forge-relative note path, self-hosted and WordPress.com Jetpack/Atomic support; WordPress.com Simple OAuth is an explicit limitation
 
 ## Test & Quality Status
-- Frontend: vitest — 247 tests across 39 files (stores, lib, hooks, graph layout, transient-view navigation, Obsidian import, deep-link routing, plugin RPC/manifest/registry/UI)
+- Frontend: vitest — 259 tests across 40 files (stores, lib, hooks, update scheduling/error modes, graph layout, transient-view navigation, Obsidian import, deep-link routing, plugin RPC/manifest/registry/UI)
 - Backend: cargo test — 187 tests incl. stress suite, Obsidian conversion/path-safety, conflict-copy, semantic-index, MCP, plugin install/hash/secret validation, and strict deep-link routing suites
 - Bundle budget enforced via `npm run check:size` (within budget as of v1.7.0)
-- ESLint: 0 errors, ~22 pre-existing warnings (set-state-in-effect patterns in modals; tracked below)
+- ESLint: 0 errors, 18 pre-existing warnings (set-state-in-effect patterns in modals; tracked below)
 
 ## Known Issues / Debt
 - **Search scales linearly** — live WalkDir scan per query; fine to ~1k notes. Planned: persistent incremental index (would also speed backlinks + previews).

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -31,7 +31,14 @@
  */
 
 import { useEffect, useRef, useMemo } from 'react';
-import { useSettingsStore, useThemeStore, applyTheme, type SettingsTab } from '@/stores';
+import {
+  useSettingsStore,
+  useThemeStore,
+  useUpdateStore,
+  selectHasPendingUpdate,
+  applyTheme,
+  type SettingsTab,
+} from '@/stores';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
 import {
   Calendar,
@@ -67,6 +74,7 @@ export function SettingsModal() {
   const { deleteExistingTemplate, updateExistingTemplate } = useTemplates();
   const activeTab = settingsStore.activeSettingsTab;
   const setActiveTab = settingsStore.setActiveSettingsTab;
+  const hasPendingUpdate = useUpdateStore(selectHasPendingUpdate);
   const tabRefs = useRef<Record<SettingsTab, HTMLButtonElement | null>>({
     general: null,
     appearance: null,
@@ -248,6 +256,9 @@ export function SettingsModal() {
                   type="button"
                   aria-selected={isActive}
                   aria-controls={tabPanelId(tab.id)}
+                  aria-label={
+                    tab.id === 'about' && hasPendingUpdate ? 'About (update available)' : undefined
+                  }
                   tabIndex={isActive ? 0 : -1}
                   onClick={() => setActiveTab(tab.id)}
                   onKeyDown={(e) => handleTabKeyDown(e, index)}
@@ -272,6 +283,17 @@ export function SettingsModal() {
                 >
                   {tab.icon}
                   <span>{tab.label}</span>
+                  {tab.id === 'about' && hasPendingUpdate && (
+                    <span
+                      aria-hidden="true"
+                      className="ml-auto rounded-full"
+                      style={{
+                        width: '7px',
+                        height: '7px',
+                        backgroundColor: 'var(--accent-primary)',
+                      }}
+                    />
+                  )}
                 </button>
               );
             })}

--- a/src/components/settings/sections/AboutSection.tsx
+++ b/src/components/settings/sections/AboutSection.tsx
@@ -12,10 +12,9 @@ import { ShortcutRow } from '../common';
 
 function SoftwareUpdatesSection() {
   const {
-    available,
-    version,
+    availableVersion,
     isChecking,
-    lastChecked,
+    lastCheckedAt,
     error,
     checkForUpdate,
     installUpdate,
@@ -34,7 +33,7 @@ function SoftwareUpdatesSection() {
 
       <div className="space-y-3">
         {/* Update status */}
-        {available ? (
+        {availableVersion ? (
           <div
             className="flex items-center gap-2 p-3"
             style={{
@@ -50,7 +49,7 @@ function SoftwareUpdatesSection() {
             />
             <div className="flex-1">
               <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                Update Available: v{version}
+                Update available: v{availableVersion}
               </p>
               <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
                 A new version is ready to install
@@ -75,9 +74,9 @@ function SoftwareUpdatesSection() {
               <p className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>
                 {isChecking ? 'Checking for updates...' : "You're up to date"}
               </p>
-              {lastChecked && (
+              {lastCheckedAt && (
                 <p className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
-                  Last checked: {lastChecked.toLocaleString()}
+                  Last checked: {new Date(lastCheckedAt).toLocaleString()}
                 </p>
               )}
             </div>
@@ -111,7 +110,7 @@ function SoftwareUpdatesSection() {
 
         {/* Action buttons */}
         <div className="flex gap-2">
-          {available ? (
+          {availableVersion ? (
             <button
               onClick={installUpdate}
               disabled={downloading}

--- a/src/components/sidebar/SidebarFooter.tsx
+++ b/src/components/sidebar/SidebarFooter.tsx
@@ -8,7 +8,7 @@ import {
   AlignJustify,
   Share2,
 } from 'lucide-react';
-import { useTimelineStore, useGraphStore } from '@/stores';
+import { selectHasPendingUpdate, useGraphStore, useTimelineStore, useUpdateStore } from '@/stores';
 
 interface SidebarFooterProps {
   onToday: () => void;
@@ -29,6 +29,7 @@ export function SidebarFooter({ onToday, onNewNote, onSettings, onTrash }: Sideb
   const trashBtnRef = useRef<HTMLButtonElement>(null);
   const { isOpen: isTimelineOpen, toggle: toggleTimeline } = useTimelineStore();
   const { isOpen: isGraphOpen, toggle: toggleGraph } = useGraphStore();
+  const hasPendingUpdate = useUpdateStore(selectHasPendingUpdate);
 
   useEffect(() => {
     getVersion()
@@ -121,15 +122,22 @@ export function SidebarFooter({ onToday, onNewNote, onSettings, onTrash }: Sideb
         <button
           type="button"
           onClick={onSettings}
-          className="flex items-center justify-center gap-1.5 py-2 text-xs transition-colors"
+          className="relative flex items-center justify-center gap-1.5 py-2 text-xs transition-colors"
           style={iconBtnStyle}
           onMouseEnter={handleIconEnter}
           onMouseLeave={handleIconLeave}
           title="Settings (⌘,)"
-          aria-label="Open settings"
+          aria-label={hasPendingUpdate ? 'Open settings (update available)' : 'Open settings'}
         >
           <SettingsIcon aria-hidden="true" className="w-4 h-4" />
           <span>Settings</span>
+          {hasPendingUpdate && (
+            <span
+              aria-hidden="true"
+              className="absolute top-1 right-1.5 rounded-full"
+              style={{ width: '7px', height: '7px', backgroundColor: 'var(--accent-primary)' }}
+            />
+          )}
         </button>
         <button
           type="button"

--- a/src/components/updates/UpdateNotification.tsx
+++ b/src/components/updates/UpdateNotification.tsx
@@ -4,8 +4,7 @@ import { Download, X, RefreshCw } from 'lucide-react';
 
 export function UpdateNotification() {
   const {
-    available,
-    version,
+    availableVersion,
     downloading,
     progress,
     error,
@@ -22,7 +21,7 @@ export function UpdateNotification() {
   }, [startPeriodicChecks]);
 
   // Don't render if no update available or dismissed
-  if (!available || dismissed) {
+  if (!availableVersion || dismissed) {
     return null;
   }
 
@@ -63,7 +62,7 @@ export function UpdateNotification() {
           <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
             Version{' '}
             <span className="font-medium" style={{ color: 'var(--text-primary)' }}>
-              {version}
+              {availableVersion}
             </span>{' '}
             is ready to install.
           </p>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -50,7 +50,7 @@ export type {
 export { useCalendarStore } from './calendarStore';
 export { useTemplateStore } from './templateStore';
 export { useNoteColorsStore, buildNotePath } from './noteColorsStore';
-export { useUpdateStore } from './updateStore';
+export { useUpdateStore, selectHasPendingUpdate } from './updateStore';
 export { useWhatsNewStore } from './whatsNewStore';
 export { usePluginCommandStore } from './pluginCommandStore';
 export { usePluginStore } from './pluginStore';

--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { check } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
+import {
+  INITIAL_UPDATE_CHECK_DELAY_MS,
+  UPDATE_CHECK_INTERVAL_MS,
+  __resetUpdateStoreForTests,
+  isUpdateCheckStale,
+  selectHasPendingUpdate,
+  useUpdateStore,
+} from './updateStore';
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-process', () => ({
+  relaunch: vi.fn(),
+}));
+
+const mockCheck = vi.mocked(check);
+const mockRelaunch = vi.mocked(relaunch);
+
+function mockUpdate(version = '1.8.0') {
+  return {
+    version,
+    downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('updateStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetUpdateStoreForTests();
+    mockCheck.mockReset();
+    mockRelaunch.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('treats missing and 24-hour-old successful checks as stale', () => {
+    const now = Date.UTC(2026, 6, 16, 12);
+
+    expect(isUpdateCheckStale(null, now)).toBe(true);
+    expect(isUpdateCheckStale(now - UPDATE_CHECK_INTERVAL_MS + 1, now)).toBe(false);
+    expect(isUpdateCheckStale(now - UPDATE_CHECK_INTERVAL_MS, now)).toBe(true);
+  });
+
+  it('drives indicator visibility from the pending version, independent of dismissal', () => {
+    expect(selectHasPendingUpdate({ availableVersion: null })).toBe(false);
+    expect(selectHasPendingUpdate({ availableVersion: '1.8.0' })).toBe(true);
+
+    useUpdateStore.setState({ availableVersion: '1.8.0', dismissed: true });
+    expect(selectHasPendingUpdate(useUpdateStore.getState())).toBe(true);
+  });
+
+  it('persists only app-wide update metadata under a global key', () => {
+    useUpdateStore.setState({
+      availableVersion: '1.8.0',
+      lastCheckedAt: 1234,
+      dismissed: true,
+      progress: 42,
+      error: 'transient',
+    });
+
+    const persisted = JSON.parse(localStorage.getItem('moldavite-updates') || '{}');
+    expect(persisted.state).toEqual({
+      availableVersion: '1.8.0',
+      lastCheckedAt: 1234,
+      dismissed: true,
+    });
+  });
+
+  it('records a successful automatic discovery without requesting a notification', async () => {
+    const update = mockUpdate();
+    mockCheck.mockResolvedValue(update as never);
+
+    await useUpdateStore.getState().checkForUpdateSilently();
+
+    const state = useUpdateStore.getState();
+    expect(state.availableVersion).toBe('1.8.0');
+    expect(state.update).toBe(update);
+    expect(state.dismissed).toBe(true);
+    expect(state.error).toBeNull();
+    expect(state.lastCheckedAt).toEqual(expect.any(Number));
+  });
+
+  it('clears a pending indicator when a successful check offers no update', async () => {
+    useUpdateStore.setState({ availableVersion: '1.8.0', dismissed: true });
+    mockCheck.mockResolvedValue(null);
+
+    await useUpdateStore.getState().checkForUpdateSilently();
+
+    expect(useUpdateStore.getState().availableVersion).toBeNull();
+    expect(selectHasPendingUpdate(useUpdateStore.getState())).toBe(false);
+  });
+
+  it('logs automatic failures without surfacing an error or advancing lastCheckedAt', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockCheck.mockRejectedValue(new Error('404 latest.json'));
+
+    await useUpdateStore.getState().checkForUpdateSilently();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[updateStore] Automatic update check failed:',
+      expect.any(Error)
+    );
+    expect(useUpdateStore.getState().error).toBeNull();
+    expect(useUpdateStore.getState().lastCheckedAt).toBeNull();
+  });
+
+  it('surfaces manual failures without advancing lastCheckedAt', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockCheck.mockRejectedValue(new Error('Could not reach update server'));
+
+    await useUpdateStore.getState().checkForUpdate();
+
+    expect(consoleError).toHaveBeenCalled();
+    expect(useUpdateStore.getState().error).toBe('Could not reach update server');
+    expect(useUpdateStore.getState().lastCheckedAt).toBeNull();
+  });
+
+  it('keeps the explicit notification path for a successful manual check', async () => {
+    mockCheck.mockResolvedValue(mockUpdate() as never);
+
+    await useUpdateStore.getState().checkForUpdate();
+
+    expect(useUpdateStore.getState().availableVersion).toBe('1.8.0');
+    expect(useUpdateStore.getState().dismissed).toBe(false);
+  });
+
+  it('clears the pending indicator after installation completes', async () => {
+    const update = mockUpdate();
+    useUpdateStore.setState({ availableVersion: update.version, update: update as never });
+
+    await useUpdateStore.getState().installUpdate();
+
+    expect(update.downloadAndInstall).toHaveBeenCalled();
+    expect(useUpdateStore.getState().availableVersion).toBeNull();
+    expect(mockRelaunch).toHaveBeenCalled();
+  });
+
+  it('reacquires an updater handle before installing persisted pending metadata', async () => {
+    const update = mockUpdate();
+    useUpdateStore.setState({ availableVersion: update.version, update: null });
+    mockCheck.mockResolvedValue(update as never);
+
+    await useUpdateStore.getState().installUpdate();
+
+    expect(mockCheck).toHaveBeenCalledTimes(1);
+    expect(update.downloadAndInstall).toHaveBeenCalled();
+    expect(useUpdateStore.getState().availableVersion).toBeNull();
+  });
+
+  it('checks after 15 seconds and every 24 hours while running', async () => {
+    vi.useFakeTimers();
+    mockCheck.mockResolvedValue(null);
+    const cleanup = useUpdateStore.getState().startPeriodicChecks();
+
+    await vi.advanceTimersByTimeAsync(INITIAL_UPDATE_CHECK_DELAY_MS - 1);
+    expect(mockCheck).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mockCheck).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(UPDATE_CHECK_INTERVAL_MS - INITIAL_UPDATE_CHECK_DELAY_MS);
+    expect(mockCheck).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+
+  it('checks on focus only when the last successful check is stale', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-16T12:00:00Z'));
+    mockCheck.mockResolvedValue(null);
+    const now = Date.now();
+    const cleanup = useUpdateStore.getState().startPeriodicChecks();
+
+    useUpdateStore.setState({ lastCheckedAt: now - UPDATE_CHECK_INTERVAL_MS + 1 });
+    window.dispatchEvent(new Event('focus'));
+    await Promise.resolve();
+    expect(mockCheck).not.toHaveBeenCalled();
+
+    useUpdateStore.setState({ lastCheckedAt: now - UPDATE_CHECK_INTERVAL_MS });
+    window.dispatchEvent(new Event('focus'));
+    await Promise.resolve();
+    expect(mockCheck).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+});

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -1,132 +1,228 @@
 /**
- * Application-update polling, download progress, and install lifecycle state.
- * Only one check/download is active at a time, automatic checks are interval-gated,
- * and the updater plugin's returned handle remains authoritative for installation.
+ * Application-update checks, persisted pending metadata, and install lifecycle state.
+ * Automatic checks are silent and indicator-only; manual checks retain explicit feedback.
  */
 
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 
-// Check for updates every 24 hours (in milliseconds)
-const UPDATE_CHECK_INTERVAL = 24 * 60 * 60 * 1000;
+export const INITIAL_UPDATE_CHECK_DELAY_MS = 15 * 1000;
+export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-interface UpdateState {
-  available: boolean;
-  version: string | null;
+export interface UpdateState {
+  availableVersion: string | null;
   downloading: boolean;
   progress: number;
   error: string | null;
   isChecking: boolean;
-  lastChecked: Date | null;
+  /** Unix timestamp of the last successful updater response. */
+  lastCheckedAt: number | null;
   dismissed: boolean;
+  /** Live updater handle; intentionally not persisted. */
   update: Update | null;
   checkForUpdate: () => Promise<void>;
+  checkForUpdateSilently: () => Promise<void>;
   installUpdate: () => Promise<void>;
   dismiss: () => void;
   startPeriodicChecks: () => () => void;
 }
 
-export const useUpdateStore = create<UpdateState>((set, get) => ({
-  available: false,
-  version: null,
+type PersistedUpdateState = Pick<UpdateState, 'availableVersion' | 'lastCheckedAt' | 'dismissed'>;
+
+const initialUpdateState = {
+  availableVersion: null,
   downloading: false,
   progress: 0,
   error: null,
   isChecking: false,
-  lastChecked: null,
+  lastCheckedAt: null,
   dismissed: false,
   update: null,
+} satisfies Omit<
+  UpdateState,
+  'checkForUpdate' | 'checkForUpdateSilently' | 'installUpdate' | 'dismiss' | 'startPeriodicChecks'
+>;
 
-  checkForUpdate: async () => {
-    set({ isChecking: true, error: null });
-    try {
-      const update = await check();
-      if (update) {
-        set({
-          available: true,
-          version: update.version,
-          update,
-          dismissed: false,
-          isChecking: false,
-          lastChecked: new Date(),
-        });
-      } else {
-        set({
-          available: false,
-          version: null,
-          update: null,
-          isChecking: false,
-          lastChecked: new Date(),
-        });
-      }
-    } catch (error) {
-      console.error('[updateStore] Update check failed:', error);
-      set({
-        isChecking: false,
-        lastChecked: new Date(),
-        error: error instanceof Error ? error.message : 'Update check failed',
-      });
-    }
-  },
+export function isUpdateCheckStale(lastCheckedAt: number | null, now = Date.now()): boolean {
+  return lastCheckedAt === null || now - lastCheckedAt >= UPDATE_CHECK_INTERVAL_MS;
+}
 
-  installUpdate: async () => {
-    const { update } = get();
-    if (!update) return;
+export function selectHasPendingUpdate(state: Pick<UpdateState, 'availableVersion'>): boolean {
+  return state.availableVersion !== null;
+}
 
-    set({ downloading: true, progress: 0, error: null });
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
 
-    try {
-      let downloaded = 0;
-      let contentLength = 0;
+export const useUpdateStore = create<UpdateState>()(
+  persist(
+    (set, get) => {
+      const runCheck = async (silent: boolean) => {
+        if (get().isChecking) return;
 
-      await update.downloadAndInstall((event) => {
-        switch (event.event) {
-          case 'Started':
-            contentLength = event.data.contentLength || 0;
-            break;
-          case 'Progress':
-            downloaded += event.data.chunkLength;
-            if (contentLength > 0) {
-              const progress = Math.round((downloaded / contentLength) * 100);
-              set({ progress });
-            }
-            break;
-          case 'Finished':
-            set({ progress: 100 });
-            break;
+        set({ isChecking: true, error: null });
+        try {
+          const update = await check();
+          const checkedAt = Date.now();
+
+          if (update) {
+            const previous = get();
+            set({
+              availableVersion: update.version,
+              update,
+              // Automatic discoveries are indicator-only. If an explicit check
+              // already opened this version's notification, leave it alone.
+              dismissed: silent
+                ? previous.availableVersion === update.version
+                  ? previous.dismissed
+                  : true
+                : false,
+              isChecking: false,
+              lastCheckedAt: checkedAt,
+            });
+          } else {
+            set({
+              availableVersion: null,
+              update: null,
+              dismissed: false,
+              isChecking: false,
+              lastCheckedAt: checkedAt,
+            });
+          }
+        } catch (error) {
+          console.error(
+            silent
+              ? '[updateStore] Automatic update check failed:'
+              : '[updateStore] Update check failed:',
+            error
+          );
+          set({
+            isChecking: false,
+            error: silent ? null : errorMessage(error, 'Update check failed'),
+          });
         }
-      });
+      };
 
-      // Relaunch the app after successful download
-      await relaunch();
-    } catch (error) {
-      set({
-        downloading: false,
-        error: error instanceof Error ? error.message : 'Download failed',
-      });
+      return {
+        ...initialUpdateState,
+
+        checkForUpdate: () => runCheck(false),
+
+        checkForUpdateSilently: () => runCheck(true),
+
+        installUpdate: async () => {
+          let update = get().update;
+          if (!update && !get().availableVersion) return;
+
+          set({ downloading: true, progress: 0, error: null });
+
+          try {
+            // Persisted metadata survives a relaunch, but the updater handle
+            // cannot. Re-check only when needed to recover an installable handle.
+            if (!update) {
+              update = await check();
+              const checkedAt = Date.now();
+              if (!update) {
+                set({
+                  availableVersion: null,
+                  update: null,
+                  dismissed: false,
+                  downloading: false,
+                  lastCheckedAt: checkedAt,
+                });
+                return;
+              }
+              set({
+                availableVersion: update.version,
+                update,
+                lastCheckedAt: checkedAt,
+              });
+            }
+
+            let downloaded = 0;
+            let contentLength = 0;
+
+            await update.downloadAndInstall((event) => {
+              switch (event.event) {
+                case 'Started':
+                  contentLength = event.data.contentLength || 0;
+                  break;
+                case 'Progress': {
+                  downloaded += event.data.chunkLength;
+                  if (contentLength > 0) {
+                    set({ progress: Math.round((downloaded / contentLength) * 100) });
+                  }
+                  break;
+                }
+                case 'Finished':
+                  set({ progress: 100 });
+                  break;
+              }
+            });
+
+            // Clear persisted pending state before relaunch so the installed
+            // version never rehydrates with a stale indicator.
+            set({
+              availableVersion: null,
+              update: null,
+              dismissed: false,
+              downloading: false,
+              progress: 100,
+            });
+            await relaunch();
+          } catch (error) {
+            set({
+              downloading: false,
+              error: errorMessage(error, 'Download failed'),
+            });
+          }
+        },
+
+        dismiss: () => {
+          set({ dismissed: true });
+        },
+
+        startPeriodicChecks: () => {
+          const runAutomaticCheck = () => {
+            void get().checkForUpdateSilently();
+          };
+
+          const initialTimeout = window.setTimeout(
+            runAutomaticCheck,
+            INITIAL_UPDATE_CHECK_DELAY_MS
+          );
+          const interval = window.setInterval(runAutomaticCheck, UPDATE_CHECK_INTERVAL_MS);
+          const handleFocus = () => {
+            if (isUpdateCheckStale(get().lastCheckedAt)) {
+              runAutomaticCheck();
+            }
+          };
+
+          window.addEventListener('focus', handleFocus);
+
+          return () => {
+            window.clearTimeout(initialTimeout);
+            window.clearInterval(interval);
+            window.removeEventListener('focus', handleFocus);
+          };
+        },
+      };
+    },
+    {
+      name: 'moldavite-updates',
+      partialize: (state): PersistedUpdateState => ({
+        availableVersion: state.availableVersion,
+        lastCheckedAt: state.lastCheckedAt,
+        dismissed: state.dismissed,
+      }),
     }
-  },
+  )
+);
 
-  dismiss: () => {
-    set({ dismissed: true });
-  },
-
-  startPeriodicChecks: () => {
-    // Initial check after a short delay to let app fully load
-    const initialTimeout = setTimeout(() => {
-      get().checkForUpdate();
-    }, 5000);
-
-    // Periodic checks every 24 hours
-    const interval = setInterval(() => {
-      get().checkForUpdate();
-    }, UPDATE_CHECK_INTERVAL);
-
-    // Return cleanup function
-    return () => {
-      clearTimeout(initialTimeout);
-      clearInterval(interval);
-    };
-  },
-}));
+export function __resetUpdateStoreForTests(): void {
+  useUpdateStore.setState(initialUpdateState);
+  void useUpdateStore.persist.clearStorage();
+}


### PR DESCRIPTION
- Silent auto-check 15s after launch, every 24h while running, and on window focus if the last successful check is >24h old
- Auto-check failures are silent (fixes the confusing error during the mid-release asset-upload 404 window); manual checks keep explicit errors
- Pending update ⇒ accent dot on the sidebar Settings gear + the About tab inside Settings, and an 'Update available: vX.Y.Z' install row in About; auto-discoveries are indicator-only (no banner), explicit checks keep the existing notification
- Update handle is recovered by re-checking if the app restarted between discovery and install
- vitest 259 passed (12 new store tests) · ESLint 0 errors · build + bundle budgets pass · frontend-only change