### PR TITLE
Release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [1.7.1] - 2026-07-16
 
 ### Added
 - **Unobtrusive automatic update checks.** Moldavite checks about 15 seconds after launch, every 24 hours while running, and when a stale app window regains focus. Automatic network and mid-release 404 failures retry silently, while a pending version appears as an accent dot on Settings and its About tab with the existing install action; manual checks continue to show explicit errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.7.0"
+version = "1.7.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump + dated changelog. Ships daily automatic update checks with pending-update indicator dots (Settings gear + About tab).