### PR TITLE
fix: bootstrap missing Forges and stop clobbering external note writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Moldavite are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Fresh installs always have a usable Default Forge.** Startup now scaffolds a missing active Forge, adopts note folders accidentally created at the Forges root, and lets an unpinned MCP session repair a missing active Forge without weakening strict `--forge` selection.
+- **Agent and external edits can no longer disappear behind an open buffer.** Clean notes reload automatically; dirty notes keep their buffer and show choices that preserve either the disk or buffer version as a conflict copy. Virtual notes establish a conflict base before editing, implicit empty-note deletion refuses changed disk content, and MCP whole-note replacement preserves frontmatter.
+
 ## [1.7.2] - 2026-07-27
 
 ### Fixed

--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -138,9 +138,11 @@ external edit:
 
 Conflict copies are ordinary Markdown notes. A simultaneous collision in the
 same minute receives a numeric suffix such as `(2)` so an earlier copy is never
-overwritten. This protection applies to saves made through Moldavite after it
-has read the note; a program writing Forge files directly is responsible for
-its own concurrency behavior.
+overwritten. When an external writer changes an open note, a clean Moldavite
+buffer reloads automatically. A dirty buffer stays untouched and shows a thin
+banner: **Keep my version** saves the buffer and preserves the disk version as a
+conflict copy; **Use disk version** preserves the buffer as a conflict copy and
+then reloads the disk content. Neither side is silently discarded.
 
 ## Agent-ready files
 

--- a/src-tauri/src/commands/forges.rs
+++ b/src-tauri/src/commands/forges.rs
@@ -15,7 +15,7 @@ use tauri::{AppHandle, Manager, State};
 
 use crate::backlinks_index::BacklinksIndex;
 use crate::forge_watcher::{self, RecentWrites, WatcherHandle};
-use crate::paths::{get_active_forge_name, get_forges_root};
+use crate::paths::{get_active_forge_name, get_forges_root, DEFAULT_FORGE_NAME};
 use crate::persist::{read_config, write_config};
 use crate::types::ForgeInfo;
 use crate::validation::is_safe_filename;
@@ -68,6 +68,25 @@ pub(crate) fn scaffold_forge(path: &Path) -> Result<(), String> {
         let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
     }
     Ok(())
+}
+
+fn ensure_forge_at(path: &Path) -> Result<PathBuf, String> {
+    if fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return Err("Refusing to use a symlinked Forge".to_string());
+    }
+    if !path.is_dir() {
+        scaffold_forge(path)?;
+    }
+    Ok(path.to_path_buf())
+}
+
+pub(crate) fn ensure_active_forge() -> Result<PathBuf, String> {
+    let root = get_forges_root();
+    let name = get_active_forge_name();
+    ensure_forge_at(&root.join(name))
 }
 
 #[tauri::command]
@@ -237,10 +256,17 @@ pub(crate) fn set_forges_root(path: String) -> Result<String, String> {
     }
     let canonical = match new_root.canonicalize() {
         Ok(p) => p,
-        Err(_) => new_root
-            .parent()
-            .and_then(|p| p.canonicalize().ok())
-            .unwrap_or_else(|| new_root.clone()),
+        Err(_) => {
+            let parent = new_root
+                .parent()
+                .ok_or_else(|| "Path must have a parent directory".to_string())?
+                .canonicalize()
+                .map_err(|e| format!("Failed to resolve parent directory: {}", e))?;
+            let name = new_root
+                .file_name()
+                .ok_or_else(|| "Path must name a directory".to_string())?;
+            parent.join(name)
+        }
     };
     let path_str = canonical.to_string_lossy().to_lowercase();
     let forbidden = [
@@ -268,9 +294,11 @@ pub(crate) fn set_forges_root(path: String) -> Result<String, String> {
         return Err("Forges root must be in your home folder or on an external volume".to_string());
     }
 
-    fs::create_dir_all(&new_root).map_err(|e| format!("Failed to create root: {}", e))?;
+    fs::create_dir_all(&canonical).map_err(|e| format!("Failed to create root: {}", e))?;
+    ensure_forge_at(&canonical.join(DEFAULT_FORGE_NAME))?;
     let mut cfg = read_config();
     cfg.forges_root = Some(canonical.to_string_lossy().to_string());
+    cfg.notes_directory = None;
     write_config(&cfg)?;
     Ok(canonical.to_string_lossy().to_string())
 }
@@ -341,5 +369,49 @@ mod tests {
             assert!(tmp.join(sub).is_dir(), "missing {}", sub);
         }
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ensure_forge_scaffolds_missing_path() {
+        let tmp = std::env::temp_dir().join(format!(
+            "moldavite-ensure-forge-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        assert_eq!(ensure_forge_at(&tmp), Ok(tmp.clone()));
+        for sub in ["daily", "notes", "weekly", "templates", ".trash"] {
+            assert!(tmp.join(sub).is_dir(), "missing {}", sub);
+        }
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_forge_rejects_symlink_without_creating_target() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!(
+            "moldavite-ensure-forge-symlink-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let target = base.join("target");
+        let forge = base.join("Default");
+        fs::create_dir_all(&base).unwrap();
+        symlink(&target, &forge).unwrap();
+
+        assert_eq!(
+            ensure_forge_at(&forge),
+            Err("Refusing to use a symlinked Forge".to_string())
+        );
+        assert!(!target.exists());
+
+        let _ = fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -85,6 +85,18 @@ fn conflict_copy_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn conflict_copy_destination(path: &Path, stamp: &str) -> Result<(PathBuf, String), String> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| "Invalid note path".to_string())?;
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| "Invalid note path".to_string())?;
+    let name = generate_unique_filename(dir, &format!("{} (conflict {})", stem, stamp), "md");
+    Ok((dir.join(&name), name))
+}
+
 /// Test wrapper with an injectable timestamp.
 #[cfg(test)]
 fn preserve_conflict_copy_at(
@@ -122,18 +134,43 @@ fn preserve_conflict_copy_unlocked(
     if sha256_hex(&disk_body) == base || disk_body == new_content {
         return Ok(None);
     }
-    let dir = path
-        .parent()
-        .ok_or_else(|| "Invalid note path".to_string())?;
-    let stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| "Invalid note path".to_string())?;
-    let conflict_name =
-        generate_unique_filename(dir, &format!("{} (conflict {})", stem, stamp), "md");
+    let (conflict_path, conflict_name) = conflict_copy_destination(path, stamp)?;
     // Preserve the disk version byte-for-byte (frontmatter included).
-    write_atomic(&dir.join(&conflict_name), raw.as_bytes(), Some(0o600))?;
+    write_atomic(&conflict_path, raw.as_bytes(), Some(0o600))?;
     Ok(Some((conflict_name, disk_body)))
+}
+
+#[cfg(test)]
+fn preserve_buffer_copy_at(path: &Path, content: &str, stamp: &str) -> Result<String, String> {
+    let _guard = conflict_copy_lock()
+        .lock()
+        .map_err(|_| "Conflict-copy lock poisoned".to_string())?;
+    preserve_buffer_copy_unlocked(path, content, stamp)
+}
+
+fn preserve_buffer_copy_unlocked(
+    path: &Path,
+    content: &str,
+    stamp: &str,
+) -> Result<String, String> {
+    let (conflict_path, conflict_name) = conflict_copy_destination(path, stamp)?;
+    write_atomic(&conflict_path, content.as_bytes(), Some(0o600))?;
+    Ok(conflict_name)
+}
+
+fn delete_note_at(path: &Path, base_hash: Option<&str>) -> Result<bool, String> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    if let Some(base) = base_hash {
+        let raw = fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let body = frontmatter::parse_note(&raw).body;
+        if sha256_hex(&body) != base {
+            return Err("Note changed on disk since it was last read — not deleting".to_string());
+        }
+    }
+    fs::remove_file(path).map_err(|e| e.to_string())?;
+    Ok(true)
 }
 
 /// Serialize conflict detection, frontmatter preservation, and the replacing
@@ -482,6 +519,7 @@ pub(crate) fn delete_note(
     filename: String,
     is_daily: bool,
     is_weekly: bool,
+    base_hash: Option<String>,
     index: State<'_, Arc<BacklinksIndex>>,
 ) -> Result<(), String> {
     // Prevent path traversal attacks; standalone notes may include a folder path.
@@ -499,14 +537,59 @@ pub(crate) fn delete_note(
 
     let path = dir.join(&filename);
 
-    if path.exists() {
-        fs::remove_file(&path).map_err(|e| e.to_string())?;
-    }
+    delete_note_at(&path, base_hash.as_deref())?;
     index.remove_note(&index_key(&filename));
     crate::semantic::note_removed(&crate::semantic::note_rel_path(
         &filename, is_daily, is_weekly,
     ));
     Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn preserve_buffer_copy(
+    filename: String,
+    is_daily: bool,
+    is_weekly: bool,
+    content: String,
+    index: State<'_, Arc<BacklinksIndex>>,
+    recent: State<'_, Arc<RecentWrites>>,
+) -> Result<String, String> {
+    if !is_valid_note_ref(&filename, is_daily, is_weekly) {
+        return Err("Invalid filename".to_string());
+    }
+
+    let dir = if is_weekly {
+        get_weekly_dir()
+    } else if is_daily {
+        get_daily_dir()
+    } else {
+        get_standalone_dir()
+    };
+    let path = dir.join(&filename);
+    validate_path_within_base(&path, &dir).map_err(|_| "Invalid note path".to_string())?;
+
+    let stamp = chrono::Local::now().format("%Y-%m-%d %H%M").to_string();
+    let conflict_name = {
+        let _guard = conflict_copy_lock()
+            .lock()
+            .map_err(|_| "Conflict-copy lock poisoned".to_string())?;
+        preserve_buffer_copy_unlocked(&path, &content, &stamp)?
+    };
+    let conflict_path = path
+        .parent()
+        .ok_or_else(|| "Invalid note path".to_string())?
+        .join(&conflict_name);
+    recent.record(&conflict_path);
+    index.update_note(&conflict_name, &content);
+
+    let relative = match filename.rsplit_once('/') {
+        Some((folder, _)) => format!("{}/{}", folder, conflict_name),
+        None => conflict_name,
+    };
+    crate::semantic::note_changed(&crate::semantic::note_rel_path(
+        &relative, is_daily, is_weekly,
+    ));
+    Ok(relative)
 }
 
 #[tauri::command]
@@ -1061,6 +1144,39 @@ mod tests {
     }
 
     #[test]
+    fn guarded_delete_removes_matching_disk_body() {
+        let tmp = TempDir::new("guarded-delete-match");
+        let path = tmp.path().join("note.md");
+        fs::write(&path, "---\ncolor: blue\n---\nbody").unwrap();
+
+        assert_eq!(delete_note_at(&path, Some(&sha256_hex("body"))), Ok(true));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn guarded_delete_rejects_changed_disk_body() {
+        let tmp = TempDir::new("guarded-delete-mismatch");
+        let path = tmp.path().join("note.md");
+        fs::write(&path, "external body").unwrap();
+
+        assert_eq!(
+            delete_note_at(&path, Some(&sha256_hex("previous body"))),
+            Err("Note changed on disk since it was last read — not deleting".to_string())
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap(), "external body");
+    }
+
+    #[test]
+    fn unguarded_delete_keeps_legacy_behavior() {
+        let tmp = TempDir::new("unguarded-delete");
+        let path = tmp.path().join("note.md");
+        fs::write(&path, "external body").unwrap();
+
+        assert_eq!(delete_note_at(&path, None), Ok(true));
+        assert!(!path.exists());
+    }
+
+    #[test]
     fn conflict_filename_is_uniquified_with_counter() {
         let tmp = TempDir::new("unique");
         let path = tmp.path().join("note.md");
@@ -1086,6 +1202,26 @@ mod tests {
         assert_eq!(
             fs::read_to_string(tmp.path().join(&second)).unwrap(),
             "external two"
+        );
+    }
+
+    #[test]
+    fn preserved_buffer_copy_uses_unique_conflict_names() {
+        let tmp = TempDir::new("buffer-copy-unique");
+        let path = tmp.path().join("note.md");
+
+        let first = preserve_buffer_copy_at(&path, "first buffer", STAMP).unwrap();
+        let second = preserve_buffer_copy_at(&path, "second buffer", STAMP).unwrap();
+
+        assert_eq!(first, format!("note (conflict {}).md", STAMP));
+        assert_eq!(second, format!("note (conflict {}) (2).md", STAMP));
+        assert_eq!(
+            fs::read_to_string(tmp.path().join(first)).unwrap(),
+            "first buffer"
+        );
+        assert_eq!(
+            fs::read_to_string(tmp.path().join(second)).unwrap(),
+            "second buffer"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,7 +81,8 @@ use commands::misc::{
 };
 use commands::notes::{
     clear_all_notes, create_note, delete_note, duplicate_note, export_single_note,
-    fix_note_permissions, list_notes, move_note, read_note, rename_note, write_note,
+    fix_note_permissions, list_notes, move_note, preserve_buffer_copy, read_note, rename_note,
+    write_note,
 };
 use commands::plugins::{
     install_example_plugin, install_plugin_from_data, install_wordpress_plugin, list_plugins,
@@ -223,6 +224,12 @@ pub fn run() {
             if let Err(e) = migration::migrate_legacy_single_forge_to_multi() {
                 log::warn!("[forge] multi-Forge migration error: {}", e);
             }
+            if let Err(e) = migration::adopt_stray_root_layout() {
+                log::warn!("[forge] stray root layout migration error: {}", e);
+            }
+            if let Err(e) = commands::forges::ensure_active_forge() {
+                log::warn!("[forge] active Forge bootstrap error: {}", e);
+            }
             // Run sidecar-metadata → frontmatter migration once. Idempotent,
             // safe to call on every launch.
             match migration::migrate_metadata_to_frontmatter() {
@@ -272,6 +279,7 @@ pub fn run() {
             read_note,
             write_note,
             delete_note,
+            preserve_buffer_copy,
             create_note,
             duplicate_note,
             export_single_note,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -55,14 +55,23 @@ fn resolve_forge(requested: Option<&str>) -> Result<PathBuf, String> {
     let name = requested
         .map(str::to_owned)
         .unwrap_or_else(crate::paths::get_active_forge_name);
-    resolve_forge_at(&crate::paths::get_forges_root(), &name, explicit)
+    resolve_forge_at(
+        &crate::paths::get_forges_root(),
+        &name,
+        explicit,
+        crate::migration::adopt_stray_root_layout,
+    )
 }
 
-fn resolve_forge_at(
+fn resolve_forge_at<F>(
     forges_root: &std::path::Path,
     name: &str,
     explicit: bool,
-) -> Result<PathBuf, String> {
+    adopt_strays: F,
+) -> Result<PathBuf, String>
+where
+    F: FnOnce() -> Result<bool, String>,
+{
     if !crate::validation::is_safe_filename(name) {
         return Err("Invalid Forge name".to_string());
     }
@@ -77,8 +86,13 @@ fn resolve_forge_at(
         return Err("Refusing to use a symlinked Forge".to_string());
     }
     if !root.is_dir() {
-        crate::commands::forges::scaffold_forge(&root)?;
-        eprintln!("Created missing active Forge '{name}' at {}", root.display());
+        // MCP-first installs leave the default config implicit; GUI startup
+        // persists forgesRoot/activeForge through the normal migration path.
+        adopt_strays()?;
+        if !root.is_dir() {
+            crate::commands::forges::scaffold_forge(&root)?;
+            eprintln!("Created missing active Forge '{name}' at {}", root.display());
+        }
     }
     Ok(root)
 }
@@ -115,7 +129,7 @@ mod tests {
         let root = temp_root("pinned-missing");
 
         assert_eq!(
-            resolve_forge_at(&root, "Missing", true),
+            resolve_forge_at(&root, "Missing", true, || Ok(false)),
             Err("Forge 'Missing' does not exist".to_string())
         );
         assert!(!root.join("Missing").exists());
@@ -124,11 +138,31 @@ mod tests {
     #[test]
     fn unpinned_missing_forge_is_scaffolded() {
         let root = temp_root("unpinned-missing");
-        let forge = resolve_forge_at(&root, "Default", false).unwrap();
+        let forge = resolve_forge_at(&root, "Default", false, || Ok(false)).unwrap();
 
         for sub in ["daily", "notes", "weekly", "templates", ".trash"] {
             assert!(forge.join(sub).is_dir(), "missing {sub}");
         }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn unpinned_missing_forge_adopts_strays_before_scaffolding() {
+        let root = temp_root("unpinned-adoption");
+        std::fs::create_dir_all(root.join("daily")).unwrap();
+        std::fs::write(root.join("daily/stray.md"), "preserved").unwrap();
+
+        let forge = resolve_forge_at(&root, "Default", false, || {
+            crate::migration::adopt_stray_root_layout_at(&root, "Default")
+        })
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(forge.join("daily/stray.md")).unwrap(),
+            "preserved"
+        );
+        assert!(!root.join("daily").exists());
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -144,7 +178,7 @@ mod tests {
         symlink(&target, root.join("Default")).unwrap();
 
         assert_eq!(
-            resolve_forge_at(&root, "Default", false),
+            resolve_forge_at(&root, "Default", false, || Ok(false)),
             Err("Refusing to use a symlinked Forge".to_string())
         );
 

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -51,14 +51,36 @@ pub fn run_from_env() -> Result<(), String> {
 }
 
 fn resolve_forge(requested: Option<&str>) -> Result<PathBuf, String> {
+    let explicit = requested.is_some();
     let name = requested
         .map(str::to_owned)
         .unwrap_or_else(crate::paths::get_active_forge_name);
-    if !crate::validation::is_safe_filename(&name) {
+    resolve_forge_at(&crate::paths::get_forges_root(), &name, explicit)
+}
+
+fn resolve_forge_at(
+    forges_root: &std::path::Path,
+    name: &str,
+    explicit: bool,
+) -> Result<PathBuf, String> {
+    if !crate::validation::is_safe_filename(name) {
         return Err("Invalid Forge name".to_string());
     }
-    let root = crate::paths::get_forges_root().join(&name);
-    validate_forge_root(&name, root)
+    let root = forges_root.join(name);
+    if explicit {
+        return validate_forge_root(name, root);
+    }
+    if std::fs::symlink_metadata(&root)
+        .map(|metadata| metadata.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return Err("Refusing to use a symlinked Forge".to_string());
+    }
+    if !root.is_dir() {
+        crate::commands::forges::scaffold_forge(&root)?;
+        eprintln!("Created missing active Forge '{name}' at {}", root.display());
+    }
+    Ok(root)
 }
 
 fn validate_forge_root(name: &str, root: PathBuf) -> Result<PathBuf, String> {
@@ -72,4 +94,60 @@ fn validate_forge_root(name: &str, root: PathBuf) -> Result<PathBuf, String> {
         return Err(format!("Forge '{name}' does not exist"));
     }
     Ok(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "moldavite-mcp-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn pinned_missing_forge_errors() {
+        let root = temp_root("pinned-missing");
+
+        assert_eq!(
+            resolve_forge_at(&root, "Missing", true),
+            Err("Forge 'Missing' does not exist".to_string())
+        );
+        assert!(!root.join("Missing").exists());
+    }
+
+    #[test]
+    fn unpinned_missing_forge_is_scaffolded() {
+        let root = temp_root("unpinned-missing");
+        let forge = resolve_forge_at(&root, "Default", false).unwrap();
+
+        for sub in ["daily", "notes", "weekly", "templates", ".trash"] {
+            assert!(forge.join(sub).is_dir(), "missing {sub}");
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_forge_errors_before_resolution() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_root("symlink");
+        let target = root.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+        symlink(&target, root.join("Default")).unwrap();
+
+        assert_eq!(
+            resolve_forge_at(&root, "Default", false),
+            Err("Refusing to use a symlinked Forge".to_string())
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -300,6 +300,30 @@ mod tests {
     }
 
     #[test]
+    fn write_note_preserves_existing_frontmatter() {
+        let root = temp_forge("frontmatter-write");
+        fs::write(
+            root.join("notes/colored.md"),
+            "---\ncolor: blue\ntags:\n- kept\n---\nold body",
+        )
+        .unwrap();
+
+        let response = ToolContext::new(root.clone(), true, false).call(
+            "write_note",
+            &json!({"path":"notes/colored.md","content":"new body"}),
+        );
+        assert_eq!(response["isError"], false);
+
+        let raw = fs::read_to_string(root.join("notes/colored.md")).unwrap();
+        let parsed = crate::frontmatter::parse_note(&raw);
+        assert_eq!(parsed.color.as_deref(), Some("blue"));
+        assert!(parsed.extra.contains_key("tags"));
+        assert_eq!(parsed.body, "new body");
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn rejects_traversal_and_locked_notes() {
         let root = temp_forge("security");
         fs::write(root.join("notes/secret.md.locked"), "ciphertext").unwrap();

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -318,7 +318,15 @@ impl ToolContext {
         if !path.exists() {
             return Err("Note does not exist; use create_note first".to_string());
         }
-        write_atomic(&path, content.as_bytes(), Some(0o600))?;
+        let raw = fs::read_to_string(&path)
+            .map_err(|error| format!("Failed to read note before writing: {error}"))?;
+        let parsed = crate::frontmatter::parse_note(&raw);
+        let serialized = crate::frontmatter::serialize_note(
+            parsed.color.as_deref(),
+            &parsed.extra,
+            content,
+        );
+        write_atomic(&path, serialized.as_bytes(), Some(0o600))?;
         self.note_changed(forge_root, &rel);
         Ok(json!({ "path": rel, "written": true }))
     }

--- a/src-tauri/src/migration.rs
+++ b/src-tauri/src/migration.rs
@@ -107,7 +107,7 @@ pub fn migrate_legacy_single_forge_to_multi() -> Result<bool, String> {
     Ok(true)
 }
 
-pub fn adopt_stray_root_layout() -> Result<bool, String> {
+pub(crate) fn adopt_stray_root_layout() -> Result<bool, String> {
     let cfg = read_config();
     let Some(root) = cfg.forges_root.as_deref().filter(|root| !root.is_empty()) else {
         return Ok(false);
@@ -122,7 +122,7 @@ pub fn adopt_stray_root_layout() -> Result<bool, String> {
     adopt_stray_root_layout_at(Path::new(root), active)
 }
 
-fn adopt_stray_root_layout_at(root: &Path, active: &str) -> Result<bool, String> {
+pub(crate) fn adopt_stray_root_layout_at(root: &Path, active: &str) -> Result<bool, String> {
     let forge = root.join(active);
     if forge.exists()
         || !["daily", "notes", "weekly"]

--- a/src-tauri/src/migration.rs
+++ b/src-tauri/src/migration.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+use crate::commands::forges::scaffold_forge;
 use crate::frontmatter;
 use crate::paths::{get_metadata_path, get_notes_dir, DEFAULT_FORGE_NAME};
 use crate::persist::{read_config, write_config};
@@ -38,6 +39,10 @@ pub fn migrate_legacy_single_forge_to_multi() -> Result<bool, String> {
     };
 
     if !legacy_dir.is_dir() {
+        let default_forge = legacy_dir.join(DEFAULT_FORGE_NAME);
+        if let Err(e) = scaffold_forge(&default_forge) {
+            log::warn!("[forge migration] failed to scaffold Default Forge: {}", e);
+        }
         cfg.forges_root = Some(legacy_dir.to_string_lossy().to_string());
         cfg.active_forge = Some(DEFAULT_FORGE_NAME.to_string());
         cfg.notes_directory = None;
@@ -50,6 +55,10 @@ pub fn migrate_legacy_single_forge_to_multi() -> Result<bool, String> {
         .any(|s| legacy_dir.join(s).is_dir());
 
     if !has_forge_layout {
+        let default_forge = legacy_dir.join(DEFAULT_FORGE_NAME);
+        if let Err(e) = scaffold_forge(&default_forge) {
+            log::warn!("[forge migration] failed to scaffold Default Forge: {}", e);
+        }
         cfg.forges_root = Some(legacy_dir.to_string_lossy().to_string());
         cfg.active_forge = Some(DEFAULT_FORGE_NAME.to_string());
         cfg.notes_directory = None;
@@ -95,6 +104,59 @@ pub fn migrate_legacy_single_forge_to_multi() -> Result<bool, String> {
         "[forge migration] wrapped legacy Forge into {:?}",
         default_forge
     );
+    Ok(true)
+}
+
+pub fn adopt_stray_root_layout() -> Result<bool, String> {
+    let cfg = read_config();
+    let Some(root) = cfg.forges_root.as_deref().filter(|root| !root.is_empty()) else {
+        return Ok(false);
+    };
+    let Some(active) = cfg
+        .active_forge
+        .as_deref()
+        .filter(|active| !active.is_empty())
+    else {
+        return Ok(false);
+    };
+    adopt_stray_root_layout_at(Path::new(root), active)
+}
+
+fn adopt_stray_root_layout_at(root: &Path, active: &str) -> Result<bool, String> {
+    let forge = root.join(active);
+    if forge.exists()
+        || !["daily", "notes", "weekly"]
+            .iter()
+            .any(|entry| root.join(entry).is_dir())
+    {
+        return Ok(false);
+    }
+
+    fs::create_dir_all(&forge)
+        .map_err(|e| format!("Failed to create active Forge for stray layout: {}", e))?;
+    for entry in [
+        "daily",
+        "notes",
+        "weekly",
+        "templates",
+        "images",
+        ".trash",
+        ".note-metadata.json",
+    ] {
+        let source = root.join(entry);
+        if !source.exists() {
+            continue;
+        }
+        let destination = forge.join(entry);
+        if let Err(e) = fs::rename(&source, &destination) {
+            log::warn!(
+                "[forge migration] failed to move {:?} → {:?}: {}",
+                source,
+                destination,
+                e
+            );
+        }
+    }
     Ok(true)
 }
 
@@ -207,6 +269,16 @@ pub fn migrate_metadata_to_frontmatter() -> Result<u32, String> {
 mod tests {
     use super::*;
 
+    fn temp_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "moldavite-{label}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
     #[test]
     fn resolve_rejects_traversal() {
         let base = PathBuf::from("/tmp/forge");
@@ -226,5 +298,72 @@ mod tests {
             resolve_note_path(&base, "daily/2024-01-01.md"),
             Some(base.join("daily/2024-01-01.md"))
         );
+    }
+
+    #[test]
+    fn adopts_stray_root_layout_and_preserves_files() {
+        let root = temp_root("adopt-strays");
+        fs::create_dir_all(root.join("daily")).unwrap();
+        fs::create_dir_all(root.join("notes")).unwrap();
+        fs::create_dir_all(root.join("templates")).unwrap();
+        fs::write(root.join("daily/2026-07-31.md"), "daily").unwrap();
+        fs::write(root.join("notes/idea.md"), "idea").unwrap();
+        fs::write(root.join(".note-metadata.json"), "{}").unwrap();
+
+        assert_eq!(adopt_stray_root_layout_at(&root, "Default"), Ok(true));
+        assert_eq!(
+            fs::read_to_string(root.join("Default/daily/2026-07-31.md")).unwrap(),
+            "daily"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("Default/notes/idea.md")).unwrap(),
+            "idea"
+        );
+        assert!(root.join("Default/templates").is_dir());
+        assert!(root.join("Default/.note-metadata.json").is_file());
+        assert!(!root.join("daily").exists());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn existing_active_forge_leaves_strays_untouched() {
+        let root = temp_root("adopt-existing");
+        fs::create_dir_all(root.join("Default")).unwrap();
+        fs::create_dir_all(root.join("daily")).unwrap();
+        fs::write(root.join("daily/keep.md"), "keep").unwrap();
+
+        assert_eq!(adopt_stray_root_layout_at(&root, "Default"), Ok(false));
+        assert_eq!(fs::read_to_string(root.join("daily/keep.md")).unwrap(), "keep");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn adoption_leaves_sibling_forges_untouched() {
+        let root = temp_root("adopt-sibling");
+        fs::create_dir_all(root.join("daily")).unwrap();
+        fs::create_dir_all(root.join("Work/notes")).unwrap();
+        fs::write(root.join("Work/notes/project.md"), "project").unwrap();
+
+        assert_eq!(adopt_stray_root_layout_at(&root, "Default"), Ok(true));
+        assert_eq!(
+            fs::read_to_string(root.join("Work/notes/project.md")).unwrap(),
+            "project"
+        );
+        assert!(root.join("Work").is_dir());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn adoption_is_idempotent() {
+        let root = temp_root("adopt-idempotent");
+        fs::create_dir_all(root.join("weekly")).unwrap();
+
+        assert_eq!(adopt_stray_root_layout_at(&root, "Default"), Ok(true));
+        assert_eq!(adopt_stray_root_layout_at(&root, "Default"), Ok(false));
+
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -79,10 +79,7 @@ pub(crate) fn get_notes_dir() -> PathBuf {
         config.active_forge.as_deref(),
     ) {
         if !root.is_empty() && !name.is_empty() {
-            let path = PathBuf::from(root).join(name);
-            if path.exists() {
-                return path;
-            }
+            return PathBuf::from(root).join(name);
         }
     }
     // Back-compat: legacy `notes_directory` field.

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -68,10 +68,13 @@ import { WelcomeEmptyState } from '@/components/ui/EmptyState';
 import { EmptyNoteTemplatePicker } from '@/components/templates/EmptyNoteTemplatePicker';
 import { TemplatePickerModal } from '@/components/templates/TemplatePickerModal';
 import { BacklinksPanel } from '@/components/backlinks';
+import { ExternalChangeBanner } from './ExternalChangeBanner';
 
 export function Editor() {
   const { currentNote, updateNoteContent, isSaving, setSelectedDate, notes, openTabs } =
     useNoteStore();
+  const currentNoteId = currentNote?.id;
+  const currentNoteContent = currentNote?.content;
   const { spellCheck, tagsEnabled } = useSettingsStore();
   const { theme } = useThemeStore();
   const { deleteCurrentNote, loadDailyNote, createNote, loadNote, renameNote } = useNotes();
@@ -216,13 +219,13 @@ export function Editor() {
 
   // Check if note is empty and show template picker
   useEffect(() => {
-    if (currentNote) {
+    if (currentNoteId) {
       // Shared emptiness rule: media-only notes count as content.
-      setShowInlineTemplatePicker(isContentEmpty(currentNote.content || ''));
+      setShowInlineTemplatePicker(isContentEmpty(currentNoteContent || ''));
     } else {
       setShowInlineTemplatePicker(false);
     }
-  }, [currentNote?.id, currentNote?.content]);
+  }, [currentNoteId, currentNoteContent]);
 
   // Handle template selection for empty note
   const handleTemplateSelect = async (templateId: string) => {
@@ -855,7 +858,7 @@ export function Editor() {
     } catch (error) {
       console.error('[Editor] Content update error:', error);
     }
-  }, [editor, currentNote?.id]);
+  }, [editor, currentNoteId, currentNote?.externalRev]);
 
   // Resolve wiki-link existence once the note is loaded so stale links render
   // with the `wiki-link-missing` style and live ones with `wiki-link-exists`.
@@ -864,7 +867,7 @@ export function Editor() {
   // typical notes have a handful of wiki links.
   useEffect(() => {
     if (!editor || editor.isDestroyed) return;
-    if (!currentNote) return;
+    if (!currentNoteId) return;
 
     const raf = requestAnimationFrame(() => {
       if (!isMountedRef.current || !editor || editor.isDestroyed) return;
@@ -904,7 +907,7 @@ export function Editor() {
     });
 
     return () => cancelAnimationFrame(raf);
-  }, [editor, currentNote?.id, notes]);
+  }, [editor, currentNoteId, notes]);
 
   // Auto-save hook
   useAutoSave();
@@ -1010,6 +1013,8 @@ export function Editor() {
 
       {/* Tab bar - only show when there are open tabs */}
       {openTabs.length > 0 && <TabBar />}
+
+      <ExternalChangeBanner />
 
       {/* Editor */}
       <div

--- a/src/components/editor/ExternalChangeBanner.tsx
+++ b/src/components/editor/ExternalChangeBanner.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { useToast } from '@/hooks/useToast';
+import {
+  htmlToMarkdown,
+  isHtmlContent,
+  listNotes,
+  markdownToHtml,
+  preserveBufferCopy,
+  readNoteWithMeta,
+} from '@/lib/fileSystem';
+import { flushPendingAutosave, resetAutosaveBaseline } from '@/lib/autosaveFlush';
+import { useNoteStore } from '@/stores/noteStore';
+
+export function ExternalChangeBanner() {
+  const currentNote = useNoteStore((state) => state.currentNote);
+  const externallyChanged = useNoteStore((state) => state.externallyChanged);
+  const [isResolving, setIsResolving] = useState(false);
+  const toast = useToast();
+
+  if (!currentNote || !externallyChanged.has(currentNote.id)) return null;
+
+  const filename = currentNote.isDaily
+    ? `${currentNote.date}.md`
+    : currentNote.isWeekly
+      ? `${currentNote.week}.md`
+      : currentNote.id.startsWith('notes/')
+        ? currentNote.id.slice('notes/'.length)
+        : `${currentNote.title}.md`;
+
+  const keepBuffer = async () => {
+    setIsResolving(true);
+    await flushPendingAutosave();
+    useNoteStore.getState().clearExternallyChanged(currentNote.id);
+    setIsResolving(false);
+  };
+
+  const handleUseDisk = async () => {
+    setIsResolving(true);
+    try {
+      const copy = await preserveBufferCopy(
+        filename,
+        htmlToMarkdown(currentNote.content),
+        currentNote.isDaily,
+        currentNote.isWeekly
+      );
+      const disk = await readNoteWithMeta(filename, currentNote.isDaily, currentNote.isWeekly);
+      const html = isHtmlContent(disk.content) ? disk.content : markdownToHtml(disk.content);
+      useNoteStore.getState().applyExternalContent(currentNote.id, html);
+      resetAutosaveBaseline(currentNote.id, html);
+      listNotes()
+        .then((notes) => useNoteStore.getState().setNotes(notes))
+        .catch((error) => {
+          console.error('[ExternalChangeBanner] Failed to refresh note list:', error);
+        });
+      toast.success(`Saved your version as ${copy.split('/').pop() ?? copy}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(`Could not use the disk version: ${message}`);
+    } finally {
+      setIsResolving(false);
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center justify-between gap-3 px-4 py-2 text-sm border-b"
+      style={{
+        backgroundColor: 'var(--warning-muted)',
+        borderColor: 'var(--warning)',
+        color: 'var(--text-primary)',
+      }}
+      role="status"
+      aria-live="polite"
+    >
+      <span>This note changed on disk.</span>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          className="btn btn-sm focus-ring"
+          disabled={isResolving}
+          onClick={() => void keepBuffer()}
+        >
+          Keep my version
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-primary focus-ring"
+          disabled={isResolving}
+          onClick={() => void handleUseDisk()}
+        >
+          Use disk version
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/AppOnboardingModal.tsx
+++ b/src/components/onboarding/AppOnboardingModal.tsx
@@ -35,7 +35,14 @@ import {
 } from 'lucide-react';
 import { open as openDirDialog } from '@tauri-apps/plugin-dialog';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { getNotesDirectory, setNotesDirectory } from '@/lib/fileSystem';
+import { useNoteStore } from '@/stores/noteStore';
+import {
+  ensureDirectories,
+  getNotesDirectory,
+  listNotes,
+  setActiveForge,
+  setForgesRoot,
+} from '@/lib/fileSystem';
 
 /**
  * Bump this when adding new feature pages so existing users see them once.
@@ -199,8 +206,11 @@ export function AppOnboardingModal() {
         title: 'Select Forge Directory',
       });
       if (selected && typeof selected === 'string') {
-        await setNotesDirectory(selected);
-        setForgePath(selected);
+        await setForgesRoot(selected);
+        await setActiveForge('Default');
+        setForgePath(await getNotesDirectory());
+        await ensureDirectories();
+        useNoteStore.getState().setNotes(await listNotes());
       }
     } catch (err) {
       setPickError(String(err));
@@ -418,8 +428,8 @@ function ForgeStep({
         className="text-sm leading-relaxed mb-4 text-center"
         style={{ color: 'var(--text-secondary)' }}
       >
-        Your Forge is the folder where every note is stored as a plain .md file. You can keep the
-        default or pick anywhere you like.
+        This folder becomes the location of your Forges, with a Default Forge created inside it.
+        Every note stays a plain .md file.
       </p>
 
       <label className="text-xs mb-1.5 block" style={{ color: 'var(--text-tertiary)' }}>

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -19,7 +19,11 @@ import {
   notifyConflictCopy,
   LockedNoteWriteError,
 } from '@/lib';
-import { registerAutosaveFlush } from '@/lib/autosaveFlush';
+import {
+  registerAutosaveBaselineReset,
+  registerAutosaveFlush,
+  registerAutosavePendingProbe,
+} from '@/lib/autosaveFlush';
 import type { Note, NoteFile } from '@/types';
 
 /**
@@ -78,16 +82,14 @@ export function useAutoSave() {
             // Content is empty - delete the file if it exists
             if (existsInList) {
               try {
-                await deleteNote(filename, true, false);
+                await deleteNote(filename, true, false, { guarded: true });
+                const updatedNotes = freshNotes.filter((n) => !(n.isDaily && n.date === dateStr));
+                setNotes(updatedNotes);
+                if (dateStr) removeTaskStatus(dateStr);
               } catch (deleteError) {
                 console.error('[useAutoSave] Delete failed:', deleteError);
               }
-              // Remove from notes list
-              const updatedNotes = freshNotes.filter((n) => !(n.isDaily && n.date === dateStr));
-              setNotes(updatedNotes);
-            }
-            // Remove task status for this date
-            if (dateStr) {
+            } else if (dateStr) {
               removeTaskStatus(dateStr);
             }
           } else {
@@ -123,13 +125,12 @@ export function useAutoSave() {
             // Content is empty - delete the file if it exists
             if (existsInList) {
               try {
-                await deleteNote(filename, false, true);
+                await deleteNote(filename, false, true, { guarded: true });
+                const updatedNotes = freshNotes.filter((n) => !(n.isWeekly && n.week === weekStr));
+                setNotes(updatedNotes);
               } catch (deleteError) {
                 console.error('[useAutoSave] Delete weekly note failed:', deleteError);
               }
-              // Remove from notes list
-              const updatedNotes = freshNotes.filter((n) => !(n.isWeekly && n.week === weekStr));
-              setNotes(updatedNotes);
             }
           } else {
             // Content is not empty - save and add to list if needed
@@ -184,6 +185,24 @@ export function useAutoSave() {
 
   // Expose the flush so a Forge switch can await it before reloading the window.
   useEffect(() => registerAutosaveFlush(flushPending), [flushPending]);
+
+  const pendingProbe = useCallback(
+    () => (timeoutRef.current !== null ? (pendingRef.current?.id ?? null) : null),
+    []
+  );
+  useEffect(() => registerAutosavePendingProbe(pendingProbe), [pendingProbe]);
+
+  const resetBaseline = useCallback((noteId: string, content: string) => {
+    if (pendingRef.current?.id === noteId) {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+      pendingRef.current = null;
+    }
+    if (lastNoteIdRef.current === noteId) {
+      lastContentRef.current = content;
+    }
+  }, []);
+  useEffect(() => registerAutosaveBaselineReset(resetBaseline), [resetBaseline]);
 
   useEffect(() => {
     if (!currentNote) {

--- a/src/hooks/useForgeWatcher.test.ts
+++ b/src/hooks/useForgeWatcher.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLastPersistedMarkdown, markdownToHtml, readNoteWithMeta } from '@/lib/fileSystem';
+import { registerAutosaveBaselineReset, registerAutosavePendingProbe } from '@/lib/autosaveFlush';
+import { useNoteStore } from '@/stores/noteStore';
+import type { Note } from '@/types';
+
+const invokeMock = vi.fn();
+
+vi.mock('@/lib/ipc', () => ({
+  safeInvoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { reconcileExternalNoteChange } from './useForgeWatcher';
+
+const dailyTab = (content: string): Note => ({
+  id: '2026-07-31.md',
+  title: 'July 31, 2026',
+  content,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  isDaily: true,
+  isWeekly: false,
+  date: '2026-07-31',
+});
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  useNoteStore.setState({
+    notes: [],
+    openTabs: [],
+    activeTabId: null,
+    currentNote: null,
+    externallyChanged: new Set(),
+  });
+});
+
+describe('external Forge watcher reconciliation', () => {
+  it('replaces a clean tab, refreshes persistence state, and resets autosave baseline', async () => {
+    invokeMock.mockResolvedValueOnce({ content: 'old body', color: null, contentHash: 'old-hash' });
+    await readNoteWithMeta('2026-07-31.md', true, false);
+    const tab = dailyTab(markdownToHtml('old body'));
+    useNoteStore.setState({ openTabs: [tab], activeTabId: tab.id, currentNote: tab });
+    invokeMock.mockResolvedValueOnce({
+      content: 'agent body',
+      color: null,
+      contentHash: 'new-hash',
+    });
+    const reset = vi.fn();
+    const unregisterReset = registerAutosaveBaselineReset(reset);
+    const unregisterProbe = registerAutosavePendingProbe(() => null);
+
+    await reconcileExternalNoteChange('daily/2026-07-31.md');
+
+    const current = useNoteStore.getState().currentNote;
+    expect(current?.content).toContain('agent body');
+    expect(current?.externalRev).toBe(1);
+    expect(useNoteStore.getState().externallyChanged.has(tab.id)).toBe(false);
+    expect(getLastPersistedMarkdown('2026-07-31.md', true, false)).toBe('agent body');
+    expect(reset).toHaveBeenCalledWith(tab.id, current?.content);
+    unregisterProbe();
+    unregisterReset();
+  });
+
+  it('leaves a dirty standalone buffer and its stale hash untouched', async () => {
+    invokeMock.mockResolvedValueOnce({ content: 'old body', color: null, contentHash: 'old-hash' });
+    await readNoteWithMeta('folder/note.md', false, false);
+    const tab: Note = {
+      ...dailyTab(markdownToHtml('my edit')),
+      id: 'notes/folder/note.md',
+      title: 'note',
+      isDaily: false,
+      date: undefined,
+    };
+    useNoteStore.setState({ openTabs: [tab], activeTabId: tab.id, currentNote: tab });
+    const unregisterProbe = registerAutosavePendingProbe(() => null);
+
+    await reconcileExternalNoteChange('notes/folder/note.md');
+
+    expect(useNoteStore.getState().currentNote?.content).toBe(tab.content);
+    expect(useNoteStore.getState().externallyChanged.has(tab.id)).toBe(true);
+    expect(getLastPersistedMarkdown('folder/note.md', false, false)).toBe('old body');
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    unregisterProbe();
+  });
+
+  it('treats a queued debounce as dirty even when HTML matches persisted Markdown', async () => {
+    invokeMock.mockResolvedValueOnce({
+      content: 'same body',
+      color: null,
+      contentHash: 'same-hash',
+    });
+    await readNoteWithMeta('2026-W31.md', false, true);
+    const tab: Note = {
+      ...dailyTab(markdownToHtml('same body')),
+      id: 'weekly/2026-W31.md',
+      isDaily: false,
+      isWeekly: true,
+      date: undefined,
+      week: '2026-W31',
+    };
+    useNoteStore.setState({ openTabs: [tab], activeTabId: tab.id, currentNote: tab });
+    const unregisterProbe = registerAutosavePendingProbe(() => tab.id);
+
+    await reconcileExternalNoteChange('weekly/2026-W31.md');
+
+    expect(useNoteStore.getState().externallyChanged.has(tab.id)).toBe(true);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    unregisterProbe();
+  });
+});

--- a/src/hooks/useForgeWatcher.ts
+++ b/src/hooks/useForgeWatcher.ts
@@ -1,13 +1,23 @@
 /**
  * Frontend reconciliation for external Forge filesystem events.
- * Event bursts coalesce into a note-list refresh; the active note body is never
- * reloaded here because doing so could overwrite unsaved editor state.
+ * Event bursts coalesce into a note-list refresh. Open note bodies reconcile
+ * independently: clean buffers reload, while dirty buffers remain untouched
+ * and surface an explicit external-change decision.
  */
 
 import { useEffect, useRef } from 'react';
 import { listen } from '@tauri-apps/api/event';
-import { listNotes } from '@/lib';
+import {
+  getLastPersistedMarkdown,
+  htmlToMarkdown,
+  isHtmlContent,
+  listNotes,
+  markdownToHtml,
+  readNoteWithMeta,
+} from '@/lib';
+import { getPendingAutosaveNoteId, resetAutosaveBaseline } from '@/lib/autosaveFlush';
 import { useNoteStore } from '@/stores';
+import type { Note } from '@/types';
 
 /**
  * Payload emitted by the backend `forge:changed` event.
@@ -21,13 +31,72 @@ interface ForgeChangePayload {
   relPath: string;
 }
 
+interface NoteAddress {
+  filename: string;
+  isDaily: boolean;
+  isWeekly: boolean;
+  stem?: string;
+}
+
+function noteAddress(relPath: string): NoteAddress | null {
+  const daily = relPath.match(/^daily\/([^/]+)\.md$/);
+  if (daily) {
+    return { filename: `${daily[1]}.md`, isDaily: true, isWeekly: false, stem: daily[1] };
+  }
+  const weekly = relPath.match(/^weekly\/([^/]+)\.md$/);
+  if (weekly) {
+    return { filename: `${weekly[1]}.md`, isDaily: false, isWeekly: true, stem: weekly[1] };
+  }
+  if (relPath.startsWith('notes/') && relPath.endsWith('.md')) {
+    return {
+      filename: relPath.slice('notes/'.length),
+      isDaily: false,
+      isWeekly: false,
+    };
+  }
+  return null;
+}
+
+function matchingOpenTab(relPath: string, address: NoteAddress, tabs: Note[]): Note | undefined {
+  if (address.isDaily) {
+    return tabs.find((tab) => tab.isDaily && tab.date === address.stem);
+  }
+  if (address.isWeekly) {
+    return tabs.find((tab) => tab.isWeekly && tab.week === address.stem);
+  }
+  return tabs.find((tab) => !tab.isDaily && !tab.isWeekly && tab.id === relPath);
+}
+
+export async function reconcileExternalNoteChange(relPath: string): Promise<void> {
+  const address = noteAddress(relPath);
+  if (!address) return;
+
+  const state = useNoteStore.getState();
+  const tab = matchingOpenTab(relPath, address, state.openTabs);
+  if (!tab) return;
+
+  const lastPersisted = getLastPersistedMarkdown(
+    address.filename,
+    address.isDaily,
+    address.isWeekly
+  );
+  const dirty =
+    getPendingAutosaveNoteId() === tab.id || htmlToMarkdown(tab.content) !== (lastPersisted ?? '');
+  if (dirty) {
+    state.markExternallyChanged(tab.id);
+    return;
+  }
+
+  const result = await readNoteWithMeta(address.filename, address.isDaily, address.isWeekly);
+  const html = isHtmlContent(result.content) ? result.content : markdownToHtml(result.content);
+  useNoteStore.getState().applyExternalContent(tab.id, html);
+  resetAutosaveBaseline(tab.id, html);
+}
+
 /**
  * Subscribes to backend `forge:changed` events. When something on disk
  * changes outside of Moldavite (Obsidian, an editor, a script…), we
- * reconcile by re-listing notes. We deliberately don't reload the active
- * note's body here — that would clobber unsaved edits — but the path is
- * available in the payload if a future enhancement wants to surface a
- * "this note changed externally" prompt.
+ * reconcile the list and any semantically matching open tab.
  */
 export function useForgeWatcher(): void {
   const setNotes = useNoteStore((s) => s.setNotes);
@@ -39,7 +108,10 @@ export function useForgeWatcher(): void {
 
     const subscribe = async () => {
       try {
-        const off = await listen<ForgeChangePayload>('forge:changed', () => {
+        const off = await listen<ForgeChangePayload>('forge:changed', (event) => {
+          void reconcileExternalNoteChange(event.payload.relPath).catch((err) => {
+            console.error('[useForgeWatcher] note reconciliation failed:', err);
+          });
           // Coalesce bursts: a folder rename can fan out to many events.
           if (refreshTimer.current !== null) {
             clearTimeout(refreshTimer.current);

--- a/src/hooks/useNotes.externalWrites.test.tsx
+++ b/src/hooks/useNotes.externalWrites.test.tsx
@@ -1,0 +1,93 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getLastPersistedMarkdown } from '@/lib/fileSystem';
+import { useNoteStore } from '@/stores/noteStore';
+import { useTemplateStore } from '@/stores/templateStore';
+
+const invokeMock = vi.fn();
+
+vi.mock('@/lib/ipc', () => ({
+  safeInvoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { useNotes } from './useNotes';
+
+beforeEach(() => {
+  localStorage.clear();
+  invokeMock.mockReset();
+  invokeMock.mockImplementation(async (command: string) => {
+    if (command === 'list_notes') return [];
+    if (command === 'read_note') {
+      return { content: '', color: null, contentHash: 'empty-hash' };
+    }
+    if (command === 'create_note') return 'created.md';
+    return undefined;
+  });
+  useTemplateStore.setState({ defaultDailyTemplate: null });
+  useNoteStore.setState({
+    notes: [],
+    openTabs: [],
+    activeTabId: null,
+    currentNote: null,
+    recentNoteIds: [],
+    unlockedNotes: new Set(),
+    externallyChanged: new Set(),
+    isLoading: false,
+    isSaving: false,
+  });
+});
+
+describe('useNotes external-write bases', () => {
+  it('reads a missing daily note before opening its virtual buffer', async () => {
+    const hook = renderHook(() => useNotes());
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith('list_notes'));
+
+    await act(() => hook.result.current.loadDailyNote(new Date(2026, 6, 31)));
+
+    expect(invokeMock).toHaveBeenCalledWith('read_note', {
+      filename: '2026-07-31.md',
+      isDaily: true,
+      isWeekly: false,
+    });
+    expect(getLastPersistedMarkdown('2026-07-31.md', true, false)).toBe('');
+    expect(useNoteStore.getState().currentNote?.id).toBe('2026-07-31.md');
+  });
+
+  it('opens a raced daily file as a real note when the list was stale', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'list_notes') return [];
+      if (command === 'read_note') {
+        return { content: '# Agent update', color: null, contentHash: 'agent-hash' };
+      }
+      return undefined;
+    });
+    const hook = renderHook(() => useNotes());
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith('list_notes'));
+
+    await act(() => hook.result.current.loadDailyNote(new Date(2026, 6, 31)));
+
+    expect(useNoteStore.getState().currentNote).toMatchObject({
+      id: 'daily/2026-07-31.md',
+      isDaily: true,
+      date: '2026-07-31',
+    });
+    expect(useNoteStore.getState().currentNote?.content).toContain('Agent update');
+    expect(useNoteStore.getState().notes).toContainEqual(
+      expect.objectContaining({ path: 'daily/2026-07-31.md' })
+    );
+  });
+
+  it('primes the empty base after creating a standalone note', async () => {
+    const hook = renderHook(() => useNotes());
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith('list_notes'));
+
+    await act(() => hook.result.current.createNote('Created'));
+
+    expect(invokeMock).toHaveBeenCalledWith('read_note', {
+      filename: 'created.md',
+      isDaily: false,
+      isWeekly: false,
+    });
+    expect(getLastPersistedMarkdown('created.md', false, false)).toBe('');
+  });
+});

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -22,6 +22,7 @@ import {
   ensureDirectories,
   listNotes,
   readNote,
+  readNoteWithMeta,
   writeNote,
   deleteNote,
   createNote as createNoteFile,
@@ -86,7 +87,7 @@ export function useNotes() {
       if (isEmpty) {
         if (existsInList) {
           try {
-            await deleteNote(filename, true, false);
+            await deleteNote(filename, true, false, { guarded: true });
             const updatedNotes = freshNotes.filter((n) => !(n.isDaily && n.date === dateStr));
             setNotes(updatedNotes);
           } catch (error) {
@@ -116,7 +117,7 @@ export function useNotes() {
       if (isEmpty) {
         if (existsInList) {
           try {
-            await deleteNote(filename, false, true);
+            await deleteNote(filename, false, true, { guarded: true });
             const updatedNotes = freshNotes.filter((n) => !(n.isWeekly && n.week === weekStr));
             setNotes(updatedNotes);
           } catch (error) {
@@ -256,6 +257,32 @@ export function useNotes() {
       // Get fresh notes from store to avoid stale closure
       const currentNotes = getState().notes;
 
+      const openVirtualOrRacedNote = async () => {
+        const result = await readNoteWithMeta(filename, true, false);
+        const virtualFile: NoteFile = {
+          name: filename,
+          path: filename,
+          isDaily: true,
+          isWeekly: false,
+          date: dateStr,
+          isLocked: false,
+        };
+        if (!result.content) {
+          setCurrentNote(filenameToNote(virtualFile, ''));
+          return;
+        }
+
+        const realFile = { ...virtualFile, path: `daily/${filename}` };
+        const latestNotes = getState().notes;
+        if (!latestNotes.some((note) => note.isDaily && note.date === dateStr)) {
+          setNotes([...latestNotes, realFile]);
+        }
+        const htmlContent = isHtmlContent(result.content)
+          ? result.content
+          : markdownToHtml(result.content);
+        setCurrentNote(filenameToNote(realFile, htmlContent));
+      };
+
       // Check if note exists
       const existingNote = currentNotes.find((n) => n.isDaily && n.date === dateStr);
 
@@ -290,31 +317,10 @@ export function useNotes() {
             await loadNote(noteFile);
           } catch (error) {
             console.error('[useNotes] Failed to create daily note from template:', error);
-            // Fall back to creating virtual note
-            const noteFile: NoteFile = {
-              name: filename,
-              path: filename,
-              isDaily: true,
-              isWeekly: false,
-              date: dateStr,
-              isLocked: false,
-            };
-            const note = filenameToNote(noteFile, '');
-            setCurrentNote(note);
+            await openVirtualOrRacedNote();
           }
         } else {
-          // Create virtual note in memory (don't create file yet)
-          // File will be created by auto-save when user types content
-          const noteFile: NoteFile = {
-            name: filename,
-            path: filename,
-            isDaily: true,
-            isWeekly: false,
-            date: dateStr,
-            isLocked: false,
-          };
-          const note = filenameToNote(noteFile, '');
-          setCurrentNote(note);
+          await openVirtualOrRacedNote();
         }
       }
     },
@@ -338,6 +344,32 @@ export function useNotes() {
 
       // Get fresh notes from store to avoid stale closure
       const currentNotes = getState().notes;
+
+      const openVirtualOrRacedNote = async () => {
+        const result = await readNoteWithMeta(filename, false, true);
+        const virtualFile: NoteFile = {
+          name: filename,
+          path: `weekly/${filename}`,
+          isDaily: false,
+          isWeekly: true,
+          week: weekStr,
+          isLocked: false,
+        };
+        if (!result.content) {
+          setCurrentNote(filenameToNote(virtualFile, ''));
+          return;
+        }
+
+        const realFile = { ...virtualFile, path: `weekly/${filename}` };
+        const latestNotes = getState().notes;
+        if (!latestNotes.some((note) => note.isWeekly && note.week === weekStr)) {
+          setNotes([...latestNotes, realFile]);
+        }
+        const htmlContent = isHtmlContent(result.content)
+          ? result.content
+          : markdownToHtml(result.content);
+        setCurrentNote(filenameToNote(realFile, htmlContent));
+      };
 
       // Check if note exists
       const existingNote = currentNotes.find((n) => n.isWeekly && n.week === weekStr);
@@ -376,31 +408,10 @@ export function useNotes() {
             await loadNote(noteFile);
           } catch (error) {
             console.error('[useNotes] Failed to create weekly note from template:', error);
-            // Fall back to creating virtual note
-            const noteFile: NoteFile = {
-              name: filename,
-              path: `weekly/${filename}`,
-              isDaily: false,
-              isWeekly: true,
-              week: weekStr,
-              isLocked: false,
-            };
-            const note = filenameToNote(noteFile, '');
-            setCurrentNote(note);
+            await openVirtualOrRacedNote();
           }
         } else {
-          // Create virtual note in memory (don't create file yet)
-          // File will be created by auto-save when user types content
-          const noteFile: NoteFile = {
-            name: filename,
-            path: `weekly/${filename}`,
-            isDaily: false,
-            isWeekly: true,
-            week: weekStr,
-            isLocked: false,
-          };
-          const note = filenameToNote(noteFile, '');
-          setCurrentNote(note);
+          await openVirtualOrRacedNote();
         }
       }
     },
@@ -418,6 +429,7 @@ export function useNotes() {
       try {
         setIsLoading(true);
         const filename = await createNoteFile(title, folderPath || undefined);
+        await readNoteWithMeta(filename, false, false);
         const noteFile: NoteFile = {
           name: filename.split('/').pop() || filename,
           path: `notes/${filename}`,

--- a/src/lib/autosaveFlush.ts
+++ b/src/lib/autosaveFlush.ts
@@ -8,8 +8,12 @@
  */
 
 type Flush = () => Promise<void>;
+type PendingProbe = () => string | null;
+type ResetBaseline = (noteId: string, content: string) => void;
 
 let flush: Flush | null = null;
+let pendingProbe: PendingProbe | null = null;
+let resetBaseline: ResetBaseline | null = null;
 
 /** Register the active flush. Returns an unregister function for cleanup. */
 export function registerAutosaveFlush(fn: Flush): () => void {
@@ -27,4 +31,26 @@ export async function flushPendingAutosave(): Promise<void> {
     // Never block navigation on a failed write; the hook already surfaces it.
     console.error('[autosaveFlush] flush failed:', error);
   }
+}
+
+export function registerAutosavePendingProbe(fn: PendingProbe): () => void {
+  pendingProbe = fn;
+  return () => {
+    if (pendingProbe === fn) pendingProbe = null;
+  };
+}
+
+export function getPendingAutosaveNoteId(): string | null {
+  return pendingProbe?.() ?? null;
+}
+
+export function registerAutosaveBaselineReset(fn: ResetBaseline): () => void {
+  resetBaseline = fn;
+  return () => {
+    if (resetBaseline === fn) resetBaseline = null;
+  };
+}
+
+export function resetAutosaveBaseline(noteId: string, content: string): void {
+  resetBaseline?.(noteId, content);
 }

--- a/src/lib/fileSystem.conflict.test.ts
+++ b/src/lib/fileSystem.conflict.test.ts
@@ -15,6 +15,8 @@ vi.mock('./ipc', () => ({
 }));
 
 import {
+  deleteNote,
+  getLastPersistedMarkdown,
   lockNote,
   readNote,
   readNoteWithMeta,
@@ -104,6 +106,52 @@ describe('external-edit conflict hash threading', () => {
 
     await writeNote('meta.md', 'edited', false, false);
     expect(lastCallArgs('write_note').baseHash).toBe('hash-meta');
+  });
+
+  it('tracks the last persisted Markdown after reads and writes', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'read_note') {
+        return { content: 'disk body', color: null, contentHash: 'hash-disk' };
+      }
+      return { contentHash: 'hash-written', conflictCopy: null };
+    });
+
+    await readNote('persisted.md', false, false);
+    expect(getLastPersistedMarkdown('persisted.md', false, false)).toBe('disk body');
+
+    await writeNote('persisted.md', 'saved body', false, false);
+    expect(getLastPersistedMarkdown('persisted.md', false, false)).toBe('saved body');
+  });
+
+  it('passes the last-read hash for guarded deletes and forgets it only on success', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'read_note') {
+        return { content: 'body', color: null, contentHash: 'delete-base' };
+      }
+      return undefined;
+    });
+
+    await readNote('guarded-delete.md', true, false);
+    await deleteNote('guarded-delete.md', true, false, { guarded: true });
+
+    expect(lastCallArgs('delete_note').baseHash).toBe('delete-base');
+    expect(getLastPersistedMarkdown('guarded-delete.md', true, false)).toBeUndefined();
+  });
+
+  it('keeps persisted bookkeeping when a guarded delete is refused', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'read_note') {
+        return { content: 'body', color: null, contentHash: 'refused-base' };
+      }
+      if (command === 'delete_note') throw new Error('changed on disk');
+      return undefined;
+    });
+
+    await readNote('refused-delete.md', false, true);
+    await expect(deleteNote('refused-delete.md', false, true, { guarded: true })).rejects.toThrow(
+      'changed on disk'
+    );
+    expect(getLastPersistedMarkdown('refused-delete.md', false, true)).toBe('body');
   });
 
   it('surfaces the conflict copy returned by the backend', async () => {

--- a/src/lib/fileSystem.ts
+++ b/src/lib/fileSystem.ts
@@ -591,6 +591,7 @@ export interface NoteWriteResult {
  * `noteWritesInFlight` lets that transition drain already-started writes.
  */
 const noteBaseHashes = new Map<string, string>();
+const lastPersistedMarkdown = new Map<string, string>();
 const lockedNoteWrites = new Set<string>();
 const noteWritesInFlight = new Map<string, Set<Promise<NoteWriteResult>>>();
 
@@ -607,7 +608,17 @@ function noteHashKey(filename: string, isDaily: boolean, isWeekly: boolean): str
 
 /** Drop the recorded base hash for a note (after delete/rename/move). */
 function forgetNoteBaseHash(filename: string, isDaily: boolean, isWeekly: boolean): void {
-  noteBaseHashes.delete(noteHashKey(filename, isDaily, isWeekly));
+  const key = noteHashKey(filename, isDaily, isWeekly);
+  noteBaseHashes.delete(key);
+  lastPersistedMarkdown.delete(key);
+}
+
+export function getLastPersistedMarkdown(
+  filename: string,
+  isDaily: boolean,
+  isWeekly: boolean = false
+): string | undefined {
+  return lastPersistedMarkdown.get(noteHashKey(filename, isDaily, isWeekly));
 }
 
 /**
@@ -647,7 +658,9 @@ export async function readNoteWithMeta(
 ): Promise<NoteReadResult> {
   const result = await invoke<NoteReadResult>('read_note', { filename, isDaily, isWeekly });
   // Remember what we read so the next save can detect external edits.
-  noteBaseHashes.set(noteHashKey(filename, isDaily, isWeekly), result.contentHash);
+  const key = noteHashKey(filename, isDaily, isWeekly);
+  noteBaseHashes.set(key, result.contentHash);
+  lastPersistedMarkdown.set(key, result.content);
   return result;
 }
 
@@ -696,6 +709,7 @@ export async function writeNote(
     const result = await write;
     // What we just wrote is the new base for the next conflict check.
     noteBaseHashes.set(key, result.contentHash);
+    lastPersistedMarkdown.set(key, content);
     return result;
   } finally {
     writes.delete(write);
@@ -712,10 +726,26 @@ export async function writeNote(
 export async function deleteNote(
   filename: string,
   isDaily: boolean,
-  isWeekly: boolean = false
+  isWeekly: boolean = false,
+  opts?: { guarded?: boolean }
 ): Promise<void> {
-  await invoke('delete_note', { filename, isDaily, isWeekly });
+  const key = noteHashKey(filename, isDaily, isWeekly);
+  await invoke('delete_note', {
+    filename,
+    isDaily,
+    isWeekly,
+    baseHash: opts?.guarded ? (noteBaseHashes.get(key) ?? null) : null,
+  });
   forgetNoteBaseHash(filename, isDaily, isWeekly);
+}
+
+export async function preserveBufferCopy(
+  filename: string,
+  content: string,
+  isDaily: boolean,
+  isWeekly: boolean = false
+): Promise<string> {
+  return await invoke('preserve_buffer_copy', { filename, content, isDaily, isWeekly });
 }
 
 /**
@@ -994,6 +1024,14 @@ export async function getNotesDirectory(): Promise<string> {
  */
 export async function setNotesDirectory(newPath: string): Promise<void> {
   await invoke('set_notes_directory', { newPath });
+}
+
+export async function setForgesRoot(path: string): Promise<string> {
+  return await invoke('set_forges_root', { path });
+}
+
+export async function setActiveForge(name: string): Promise<string> {
+  return await invoke('set_active_forge', { name });
 }
 
 /**

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -31,6 +31,7 @@ interface NoteState {
 
   // Security - tracks temporarily unlocked notes for auto-lock feature
   unlockedNotes: Set<string>;
+  externallyChanged: Set<string>;
 
   // Actions
   setNotes: (notes: NoteFile[]) => void;
@@ -46,6 +47,9 @@ interface NoteState {
   closeTab: (noteId: string) => void;
   switchTab: (noteId: string) => void;
   updateTabContent: (noteId: string, content: string) => void;
+  applyExternalContent: (noteId: string, content: string) => void;
+  markExternallyChanged: (noteId: string) => void;
+  clearExternallyChanged: (noteId: string) => void;
   renameNoteReferences: (oldPath: string, newPath: string, newTitle: string) => void;
   removeTabByPath: (notePath: string) => void;
   pinTab: (noteId: string) => { success: boolean; message?: string };
@@ -85,6 +89,7 @@ export const useNoteStore = create<NoteState>((set, get) => ({
   selectedWeek: null,
   recentNoteIds: loadRecentNotes(),
   unlockedNotes: new Set<string>(),
+  externallyChanged: new Set<string>(),
 
   /**
    * Replaces the entire notes list.
@@ -236,6 +241,8 @@ export const useNoteStore = create<NoteState>((set, get) => ({
       if (tabIndex < 0) return state;
 
       const newTabs = state.openTabs.filter((t) => t.id !== noteId);
+      const externallyChanged = new Set(state.externallyChanged);
+      externallyChanged.delete(noteId);
 
       let newActiveId: string | null = null;
       let newCurrentNote: Note | null = null;
@@ -255,6 +262,7 @@ export const useNoteStore = create<NoteState>((set, get) => ({
         openTabs: newTabs,
         activeTabId: newActiveId,
         currentNote: newCurrentNote,
+        externallyChanged,
       };
     }),
 
@@ -292,6 +300,45 @@ export const useNoteStore = create<NoteState>((set, get) => ({
       };
     }),
 
+  applyExternalContent: (noteId, content) =>
+    set((state) => {
+      const openTabs = state.openTabs.map((tab) =>
+        tab.id === noteId
+          ? {
+              ...tab,
+              content,
+              updatedAt: new Date(),
+              externalRev: (tab.externalRev ?? 0) + 1,
+            }
+          : tab
+      );
+      const externallyChanged = new Set(state.externallyChanged);
+      externallyChanged.delete(noteId);
+      return {
+        openTabs,
+        currentNote:
+          state.activeTabId === noteId
+            ? openTabs.find((tab) => tab.id === noteId) || null
+            : state.currentNote,
+        externallyChanged,
+      };
+    }),
+
+  markExternallyChanged: (noteId) =>
+    set((state) => {
+      const externallyChanged = new Set(state.externallyChanged);
+      externallyChanged.add(noteId);
+      return { externallyChanged };
+    }),
+
+  clearExternallyChanged: (noteId) =>
+    set((state) => {
+      if (!state.externallyChanged.has(noteId)) return state;
+      const externallyChanged = new Set(state.externallyChanged);
+      externallyChanged.delete(noteId);
+      return { externallyChanged };
+    }),
+
   /** Moves every persisted/in-memory reference from a note's old path to its new path. */
   renameNoteReferences: (oldPath, newPath, newTitle) =>
     set((state) => {
@@ -302,6 +349,9 @@ export const useNoteStore = create<NoteState>((set, get) => ({
       const recentNoteIds = state.recentNoteIds.map((id) => (id === oldPath ? newPath : id));
       const unlockedNotes = new Set(
         [...state.unlockedNotes].map((id) => (id === oldPath ? newPath : id))
+      );
+      const externallyChanged = new Set(
+        [...state.externallyChanged].map((id) => (id === oldPath ? newPath : id))
       );
       const activeTabId = state.activeTabId === oldPath ? newPath : state.activeTabId;
       const currentNote = activeTabId
@@ -328,6 +378,7 @@ export const useNoteStore = create<NoteState>((set, get) => ({
         currentNote,
         recentNoteIds,
         unlockedNotes,
+        externallyChanged,
       };
     }),
 

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -9,6 +9,7 @@ export interface Note {
   date?: string; // YYYY-MM-DD format for daily notes
   week?: string; // YYYY-Www format for weekly notes (e.g., "2024-W52")
   isPinned?: boolean; // Whether the tab is pinned
+  externalRev?: number; // Bumped when disk content replaces an open buffer
 }
 
 export interface NoteFile {


### PR DESCRIPTION
## Problem

**1. Fresh install → no Forge → MCP dead.** Migration wrote `activeForge: "Default"` + `forgesRoot` into config without ever creating the directory; onboarding only called the legacy `set_notes_directory`. The GUI masked it (`get_notes_dir` silently fell back to the Forges root, littering stray `daily/ notes/ weekly/` there), while `moldavite --mcp` exited 1 with `Forge 'Default' does not exist` before the JSON-RPC handshake.

**2. External (MCP/agent) writes clobbered by the open editor.** Three holes:
- A daily note opened before it existed on disk was a *virtual* buffer with no base hash → autosave sent `baseHash: null` → conflict detection skipped → silent full overwrite of agent-written content, zero trace.
- The Forge watcher only refreshed the note list — an open buffer never absorbed external changes even when clean.
- The empty-buffer autosave branch hard-deleted (`fs::remove_file`) a daily file it had never read — deleting agent-created notes.

## Fix

**Forge bootstrap**
- `ensure_active_forge()` scaffolds the configured active Forge at startup (symlink-refusing); migration fresh-install branches scaffold too.
- MCP unpinned resolution self-heals (scaffolds the configured Forge, stderr note only); explicit `--forge X` on a missing name still errors (typo guard). Pinned resolver stays strict mid-session.
- `get_notes_dir` returns the configured Forge path unconditionally — no more silent root fallback.
- One-time adoption migration moves stray root-level `daily/notes/weekly/templates/images/.trash/.note-metadata.json` into the active Forge, only when its dir doesn't exist yet; rename-only, per-entry logged, idempotent, sibling Forges untouched.
- Onboarding Forge step now uses `set_forges_root` + `set_active_forge('Default')` (no mid-onboarding reload) instead of the legacy single-vault path.

**External-write safety**
- Virtual/new notes prime a base hash on open (`sha256("")` for absent files) — an externally created file now triggers the conflict path instead of silent overwrite; if the file appeared meanwhile, it opens as a real note.
- Watcher reconciliation: `forge:changed` for an open tab (matched semantically — daily by date, weekly by week, standalone by path) reloads clean buffers (and re-seeds the autosave baseline) or flags dirty ones.
- Dirty buffers get a non-blocking banner: **Keep my version** (disk version conflict-copied via existing path) or **Use disk version** (buffer preserved via new `preserve_buffer_copy` command, then reload). Both lossless.
- `delete_note` gained an optional `base_hash` guard; the four empty-buffer autosave branches pass it — a file changed on disk since last read is never deleted. Explicit user deletes unchanged.
- MCP `write_note` now preserves frontmatter (color/extra) instead of destroying it.

## Testing

- `cargo test`: 220 passed (incl. stress tests); `cargo clippy --all-targets -- -D warnings` clean
- `npm test`: 379 passed (47 files); `npm run build` + lint clean
- MCP smoke: initialize handshake succeeds; `--forge Nope` errors correctly
- New tests: stray-adoption (moved/untouched/idempotent/sibling-safe), scaffold + symlink refusal, MCP resolve (pinned strict / unpinned heals), delete guard, `preserve_buffer_copy` naming, MCP frontmatter preservation, watcher clean/dirty reconciliation, virtual-note hash priming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2xNUhDhsXVVw7MsipxDu7