### PR TITLE
chore: release v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-07-31
+
 ### Fixed
 
 - **Fresh installs always have a usable Default Forge.** Startup now scaffolds a missing active Forge, adopts note folders accidentally created at the Forges root, and lets an unpinned MCP session repair a missing active Forge without weakening strict `--forge` selection.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.7.2"
+version = "1.7.3"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump + changelog for v1.7.3 (forge bootstrap fix + external-write safety, PR #34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2xNUhDhsXVVw7MsipxDu7