### PR TITLE
fix: stop false conflict prompts on notes changed externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Notes an agent writes to no longer ask which version to keep.** A note you had merely opened, without typing a word, could show the "changed on disk" banner on every external write. Moldavite compared the editor's copy against the raw file in a way that made ordinary Markdown — a `_word_` here, a list marker there — look like an unsaved edit forever. Untouched notes now reload quietly, and the banner is back to meaning what it says: you have edits of your own that would conflict.
+- **An external edit no longer throws away your place in the note.** Reloading a note someone else changed jumped you to the top and dropped the cursor. Your scroll position and cursor now survive the update.
+
 ## [1.7.3] - 2026-07-31
 
 ### Fixed

--- a/docs/FORGE.md
+++ b/docs/FORGE.md
@@ -139,10 +139,12 @@ external edit:
 Conflict copies are ordinary Markdown notes. A simultaneous collision in the
 same minute receives a numeric suffix such as `(2)` so an earlier copy is never
 overwritten. When an external writer changes an open note, a clean Moldavite
-buffer reloads automatically. A dirty buffer stays untouched and shows a thin
-banner: **Keep my version** saves the buffer and preserves the disk version as a
-conflict copy; **Use disk version** preserves the buffer as a conflict copy and
-then reloads the disk content. Neither side is silently discarded.
+buffer reloads in place, keeping your scroll position and cursor — so a note an
+agent writes to repeatedly stays readable and never asks you anything. Only a
+buffer with your own unsaved edits shows a thin banner: **Keep my version**
+saves the buffer and preserves the disk version as a conflict copy; **Use disk
+version** preserves the buffer as a conflict copy and then reloads the disk
+content. Neither side is silently discarded.
 
 ## Agent-ready files
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -806,6 +806,15 @@ export function Editor() {
     return () => editorHandle.setEditor(null);
   }, [editor]);
 
+  // Identity of the last content application, so an external reload can be
+  // told apart from a note switch. Both run through the effect below, but only
+  // a switch should jump to the top and drop the cursor.
+  const lastAppliedRef = React.useRef<{
+    editor: TiptapEditor | null;
+    noteId: string | null;
+    externalRev: number | undefined;
+  }>({ editor: null, noteId: null, externalRev: undefined });
+
   React.useEffect(() => {
     const note = currentNoteRef.current;
 
@@ -819,6 +828,20 @@ export function Editor() {
       return;
     }
 
+    const previous = lastAppliedRef.current;
+    // Same editor instance, same note, only the external revision moved: an
+    // agent, sync tool, or another editor rewrote this file while it sat open.
+    const isExternalReload =
+      !!note &&
+      previous.editor === editor &&
+      previous.noteId === currentNoteId &&
+      previous.externalRev !== note.externalRev;
+    lastAppliedRef.current = {
+      editor,
+      noteId: currentNoteId ?? null,
+      externalRev: note?.externalRev,
+    };
+
     try {
       if (note) {
         // Use a microtask to ensure React has finished its commit phase
@@ -826,6 +849,16 @@ export function Editor() {
           try {
             // Double-check mounted and editor state before DOM operations
             if (isMountedRef.current && editor && !editor.isDestroyed) {
+              // An external reload swaps the body out from under whoever is
+              // reading it, so hold their scroll position and cursor. A note
+              // switch keeps the original behaviour: top of the note, no
+              // selection carried over from the previous one.
+              const scrollTop = isExternalReload ? (scrollContainerRef.current?.scrollTop ?? 0) : 0;
+              const selection = isExternalReload
+                ? { from: editor.state.selection.from, to: editor.state.selection.to }
+                : null;
+              const keepFocus = isExternalReload && editor.isFocused;
+
               // Clear and set content, then blur to clear any selection.
               // emitUpdate:false because TipTap v3 defaults it to true, which
               // made merely *opening* a note fire onUpdate -> autosave and
@@ -833,10 +866,16 @@ export function Editor() {
               // it cannot represent (Markdown tables, say) was flattened on
               // disk without the user typing a thing.
               editor.commands.setContent(note.content || '', { emitUpdate: false });
-              editor.commands.blur();
-              // Reset scroll position to top
+              if (selection) {
+                // setTextSelection clamps out-of-range positions itself, which
+                // matters when the external edit shortened the note.
+                editor.commands.setTextSelection(selection);
+              }
+              if (!keepFocus) {
+                editor.commands.blur();
+              }
               if (scrollContainerRef.current) {
-                scrollContainerRef.current.scrollTop = 0;
+                scrollContainerRef.current.scrollTop = scrollTop;
               }
             }
           } catch (error) {

--- a/src/hooks/useForgeWatcher.test.ts
+++ b/src/hooks/useForgeWatcher.test.ts
@@ -83,6 +83,32 @@ describe('external Forge watcher reconciliation', () => {
     unregisterProbe();
   });
 
+  it('reloads an untouched tab whose Markdown does not survive the HTML round trip', async () => {
+    // `_hi_` renders to <em>hi</em>, which Turndown writes back as `*hi*`
+    // (emDelimiter). Comparing the round-tripped buffer against the raw disk
+    // string used to report this untouched note as dirty on every agent write.
+    invokeMock.mockResolvedValueOnce({
+      content: 'a _lossy_ line',
+      color: null,
+      contentHash: 'old-hash',
+    });
+    await readNoteWithMeta('2026-07-31.md', true, false);
+    const tab = dailyTab(markdownToHtml('a _lossy_ line'));
+    useNoteStore.setState({ openTabs: [tab], activeTabId: tab.id, currentNote: tab });
+    invokeMock.mockResolvedValueOnce({
+      content: 'agent body',
+      color: null,
+      contentHash: 'new-hash',
+    });
+    const unregisterProbe = registerAutosavePendingProbe(() => null);
+
+    await reconcileExternalNoteChange('daily/2026-07-31.md');
+
+    expect(useNoteStore.getState().externallyChanged.has(tab.id)).toBe(false);
+    expect(useNoteStore.getState().currentNote?.content).toContain('agent body');
+    unregisterProbe();
+  });
+
   it('treats a queued debounce as dirty even when HTML matches persisted Markdown', async () => {
     invokeMock.mockResolvedValueOnce({
       content: 'same body',

--- a/src/hooks/useForgeWatcher.ts
+++ b/src/hooks/useForgeWatcher.ts
@@ -80,8 +80,19 @@ export async function reconcileExternalNoteChange(relPath: string): Promise<void
     address.isDaily,
     address.isWeekly
   );
+  // The buffer holds `markdownToHtml(disk)` after TipTap normalised it, so
+  // `htmlToMarkdown(buffer)` is a round-tripped string. Comparing that against
+  // the raw disk Markdown reports every note whose Markdown does not survive
+  // the round trip — different bullet markers, emphasis delimiters, escaping —
+  // as dirty forever, and an untouched note then gets a conflict prompt on
+  // every external write. Put both sides through the same lossy pipeline so
+  // only real edits diverge.
+  const persistedNormalized =
+    lastPersisted === undefined ? undefined : htmlToMarkdown(markdownToHtml(lastPersisted));
   const dirty =
-    getPendingAutosaveNoteId() === tab.id || htmlToMarkdown(tab.content) !== (lastPersisted ?? '');
+    getPendingAutosaveNoteId() === tab.id ||
+    persistedNormalized === undefined ||
+    htmlToMarkdown(tab.content) !== persistedNormalized;
   if (dirty) {
     state.markExternallyChanged(tab.id);
     return;


### PR DESCRIPTION
## The problem

Using AI agents against a Forge means near-constant MCP writes. Every one of those writes raised the **"This note changed on disk — Keep my version / Use disk version"** banner on notes that had merely been *opened*, never typed in. That prompt is supposed to appear only when you have unsaved edits that would genuinely conflict.

## Root cause

`src/hooks/useForgeWatcher.ts:84` compared a round-tripped string against a non-round-tripped one:

```ts
const dirty =
  getPendingAutosaveNoteId() === tab.id || htmlToMarkdown(tab.content) !== (lastPersisted ?? '');
```

`lastPersisted` is the **raw Markdown read off disk** (`fileSystem.ts:663`). `tab.content` is that same Markdown after `markdownToHtml()` plus TipTap normalisation. So any note whose Markdown does not survive `markdown → HTML → markdown` identically reads as dirty **forever**.

Verified concretely: `a _lossy_ line` round-trips to `a *lossy* line`, because Turndown is configured with `emDelimiter: '*'` (`fileSystem.ts:36`). Bullet markers, escaping, and table shape do the same thing.

Autosave never noticed, because it compares HTML to HTML (`useAutoSave.ts:235`). So the file on disk stayed correct while the buffer stayed permanently "dirty" — the bug was invisible except through the banner.

## The fix

Put both sides through the same pipeline before comparing. A missing `lastPersisted` still counts as dirty (fail-safe, and it self-heals on the next `readNoteWithMeta`).

This does not weaken the v1.7.3 guarantee. A genuinely edited buffer still diverges from the normalised baseline and still gets the banner, and the backend base-hash check in `save_note_with_conflict` (`src-tauri/src/commands/notes.rs:179-201`) remains the backstop for races the watcher cannot see.

## Second change: keep your place

The content effect in `Editor.tsx` unconditionally reset `scrollTop` to 0 and blurred. That is right for a note switch and wrong for a note being rewritten under the reader — with the banner gone, every agent write would have silently yanked you to the top.

The effect now tells the two apart with a `lastAppliedRef` (same editor + same note + changed `externalRev` = external reload) and restores scroll and selection in that case only. `{ emitUpdate: false }` is untouched — the comment at `Editor.tsx:830-834` explains why that matters.

## Tests

Added a watcher case using Markdown that does not survive the round trip, asserting the tab reloads via `applyExternalContent` rather than `markExternallyChanged`. The existing genuinely-dirty case still asserts the banner fires.

Worth noting **every pre-existing test used round-trip-stable plain text**, which is why this shipped in the first place.

`Editor.tsx` has no test harness at all, so the scroll/cursor branch is covered by manual verification here. Filed as #38.

## Verification

- `npm test` — 380 passing
- `npx tsc --noEmit`, `npm run lint`, `npm run format:check` clean
- Manual: opened a note with lossy Markdown, scrolled partway, wrote to it over MCP → updates in place, no banner, scroll and cursor held. Typed first, then wrote over MCP → banner still appears, both choices still produce a `(conflict …)` sibling.

## Related issues found while tracing this

#36 (external Forges not appearing), #37 (MCP writes have no conflict detection), #38 (no Editor test harness), #39 (self-write suppression window).