### PR TITLE
feat(calendar): add Google Calendar as a second read-only source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Google Calendar, alongside Apple Calendar.** Connect a Google account in Settings → Calendar and its events appear in the timeline next to your notes. Access is read-only and asks for the narrowest scope Google offers; Moldavite never creates or changes an event. Consent happens in your browser and the token is kept in your system keychain, never in a note or a settings file, and **Disconnect** removes it.
+- **Pick exactly which calendars you see.** The single calendar dropdown is now a checkbox list covering every connected account, with a refresh interval you control. If one account fails, the timeline still shows the other and says what went wrong instead of going blank.
+- **The calendar works beyond macOS.** Google Calendar brings the timeline and calendar settings to Windows and Linux, which previously had no calendar at all.
+- **A privacy policy on the website**, listing every network connection the app can make.
+
 ## [1.7.4] - 2026-08-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -206,13 +206,16 @@ Writing one? See [docs/PLUGINS.md](docs/PLUGINS.md).
   agent tool
 - Encrypted whole-vault export, plus settings export as JSON
 - Trash holds deleted notes for 7 days with read-only previews
-- Apple Calendar access is read-only and permission-gated
+- Calendar access is read-only for both sources: Apple is permission-gated
+  through EventKit, Google through a `calendar.readonly` OAuth scope you grant
+  and can revoke. Events are drawn and discarded, never written to disk
 
 **Every network call Moldavite makes:** a signed update check ~15 seconds after
 launch and once a day while open; the plugin registry from GitHub when you press
-Browse; a semantic model from Hugging Face after you opt in; and plugin requests
-to hosts you approved by name. Publishing a note to WordPress is an action you
-take, not a background behaviour.
+Browse; a semantic model from Hugging Face after you opt in; Google Calendar
+while a Google account is connected; and plugin requests to hosts you approved
+by name. Publishing a note to WordPress is an action you take, not a background
+behaviour. Full detail: [Privacy Policy](https://mauropereiira.github.io/Moldavite/privacy.html).
 
 ## Architecture
 
@@ -228,16 +231,18 @@ flowchart TB
         PS["persist::write_atomic"]
         VA["validation · wiki · backlinks index"]
     end
-    subgraph OS["macOS"]
-        SW["Swift bridge → EventKit"]
-        KC["Keychain"]
+    subgraph OS["Operating system"]
+        SW["Swift bridge → EventKit<br/>macOS only"]
+        KC["Keychain / credential store"]
     end
+    GC["Google Calendar API<br/>read-only, OAuth"]
     DISK[("Your Forge<br/>plain Markdown")]
 
     FE -- "Tauri IPC (invoke)" --> BE
     BE --> PS --> DISK
     BE --> SW
     BE --> KC
+    BE -- "HTTPS, when connected" --> GC
 
     MCP["Same binary + --mcp<br/>headless, no GUI"] --> VA
     WORKER["Plugin Workers<br/>plugin:// scheme"] -. "host-enforced RPC" .-> CM
@@ -262,6 +267,8 @@ src-tauri/
 ├── src/persist.rs       # config/trash IO + write_atomic
 ├── src/validation.rs    # path-safety checks
 ├── src/encryption.rs    # AES-GCM + Argon2 note locking
+├── src/secrets.rs       # OS credential store (plugins + calendar accounts)
+├── src/calendar/        # source dispatch, apple (EventKit), google (REST + OAuth)
 └── src-swift/           # Swift bridge for Calendar
 ```
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -32,7 +32,7 @@
 - Built-in MCP stdio server (v1.6): the single app binary switches to headless MCP mode with the exact `--mcp` flag, defaults to the active Forge (`--forge <name>` override), exposes four read tools plus three explicitly gated write tools, validates all client paths, refuses locked notes, and uses atomic writes + semantic-index change hooks
 
 ### Platform
-- Apple Calendar (EventKit, read-only, permission-gated) in right panel + timeline
+- Calendar in right panel + timeline, read-only, from two sources: Apple (EventKit, permission-gated, macOS only) and Google (Calendar API v3 over PKCE loopback OAuth, all platforms, refresh token in the OS keychain). Per-source failures are reported without blanking the other source; Google needs `MOLDAVITE_GOOGLE_CLIENT_ID`/`_SECRET` at build time or it reports unavailable
 - Signed + notarized releases and minisign-verified auto-updates. Checks run about 15 seconds after launch, every 24 hours while open, and on focus after 24 hours without a successful check; automatic network/404 failures stay silent and retry, while pending versions add accent dots to Settings and About plus the existing install action. Manual checks retain explicit errors, and completed upgrades show the CHANGELOG-backed "What's New" popup (see docs/RELEASING.md)
 - Themes/presets, keyboard shortcut overlay (⌘?), settings modal with focus trap
 

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -115,10 +115,11 @@
       </p>
       <ul>
         <li>
-          Daily-note settings from <code>.obsidian/daily-notes.json</code> are detected when present.
-          Formats made from <code>YYYY</code>, <code>MM</code>, and <code>DD</code> with
-          <code>-</code>, <code>_</code>, <code>.</code>, or <code>/</code> separators are normalized to
-          <code>daily/YYYY-MM-DD.md</code>; names that do not parse remain standalone notes.
+          Daily-note settings from <code>.obsidian/daily-notes.json</code> are detected when
+          present. Formats made from <code>YYYY</code>, <code>MM</code>, and <code>DD</code> with
+          <code>-</code>, <code>_</code>, <code>.</code>, or <code>/</code> separators are
+          normalized to <code>daily/YYYY-MM-DD.md</code>; names that do not parse remain standalone
+          notes.
         </li>
         <li>
           Other Markdown notes retain their folder structure with filesystem-safe, collision-deduped
@@ -131,9 +132,9 @@
           <code>images/</code> and rewritten to relative Markdown image paths.
         </li>
         <li>
-          <code>.obsidian/</code>, <code>.trash/</code>, hidden items, Canvas files, and symlinks are
-          never imported. Unreferenced attachments and unresolved embeds remain listed in the final
-          report; unresolved embed text is left in the note.
+          <code>.obsidian/</code>, <code>.trash/</code>, hidden items, Canvas files, and symlinks
+          are never imported. Unreferenced attachments and unresolved embeds remain listed in the
+          final report; unresolved embed text is left in the note.
         </li>
       </ul>
 
@@ -374,11 +375,31 @@
         overwriting one another.
       </p>
 
-      <h3>Apple Calendar</h3>
+      <h3>Calendars</h3>
       <p>
-        The right panel can show a month and Apple Calendar events through native EventKit. macOS
-        asks for permission first. Calendar access is read-only: Moldavite does not create or edit
-        events, and it does not upload them.
+        The right panel can show a month and your events from two sources. Both are read-only:
+        Moldavite never creates, edits, or deletes an event, and never writes one into a note by
+        itself. Connect either or both in <strong>Settings → Calendar</strong>, then tick the
+        individual calendars you want on the timeline.
+      </p>
+      <ul>
+        <li>
+          <strong>Apple Calendar</strong> — native EventKit, macOS only. macOS asks for permission
+          the first time, and nothing leaves your machine.
+        </li>
+        <li>
+          <strong>Google Calendar</strong> — available on every platform. Connecting opens your
+          browser for Google's consent screen and returns to a local port; Moldavite asks only for
+          the read-only calendar scope. The refresh token is stored in your system keychain, never
+          in a note or a settings file. <strong>Disconnect</strong> removes it, and you can also
+          revoke access from your
+          <a href="https://myaccount.google.com/permissions">Google Account permissions page</a>.
+        </li>
+      </ul>
+      <p>
+        If one source fails — expired Google access, say — the timeline still shows the other and
+        reports the failure above the grid rather than going blank. What each connection sends is
+        listed in the <a href="privacy.html">Privacy Policy</a>.
       </p>
 
       <h2 id="updates">Staying up to date</h2>
@@ -629,6 +650,7 @@
           <a href="index.html">Home</a>
           <a href="guide.html">User Guide</a>
           <a href="plugins.html">Plugin Development</a>
+          <a href="privacy.html">Privacy</a>
           <a href="https://github.com/mauropereiira/Moldavite/releases/latest">Download</a>
         </nav>
         <p class="footer-meta">

--- a/docs/index.html
+++ b/docs/index.html
@@ -623,7 +623,7 @@ Related: <span class="lk">[[Mental Models]]</span> · <span class="lk">[[Systems
               <h3>Timeline and Calendar</h3>
               <p>
                 A chronological feed bucketed by Today, Yesterday, This Week, and Earlier, with your
-                Apple Calendar events read-only alongside it.
+                Apple and Google Calendar events read-only alongside it.
               </p>
             </article>
             <article class="feature-card liquid-glass">
@@ -703,6 +703,7 @@ Related: <span class="lk">[[Mental Models]]</span> · <span class="lk">[[Systems
           <a href="index.html">Home</a>
           <a href="guide.html">User Guide</a>
           <a href="plugins.html">Plugin Development</a>
+          <a href="privacy.html">Privacy</a>
           <a href="https://github.com/mauropereiira/Moldavite/releases/latest">Download</a>
         </nav>
         <p class="footer-meta">

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -868,6 +868,7 @@ api.commands.<span class="f">add</span>({
           <a href="index.html">Home</a>
           <a href="guide.html">User Guide</a>
           <a href="plugins.html">Plugin Development</a>
+          <a href="privacy.html">Privacy</a>
           <a href="https://github.com/mauropereiira/Moldavite/releases/latest">Download</a>
         </nav>
         <p class="footer-meta">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy — Moldavite</title>
+    <meta
+      name="description"
+      content="How Moldavite handles your data: notes stay on your device, there is no account or telemetry, and every network connection the app can make is listed."
+    />
+    <link rel="icon" type="image/png" href="icon.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script>
+      document.documentElement.classList.add('has-js');
+    </script>
+    <script src="site.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+      <div class="nav-inner">
+        <div class="brand-wrap">
+          <a href="index.html" class="brand">
+            <img src="icon.png" alt="" aria-hidden="true" width="30" height="30" />
+            Moldavite
+          </a>
+          <span class="version-badge">Open source</span>
+        </div>
+        <button
+          class="nav-toggle"
+          type="button"
+          aria-label="Toggle navigation"
+          aria-expanded="false"
+          aria-controls="nav"
+        >
+          Menu
+        </button>
+        <nav class="nav-links" id="nav" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="guide.html">User Guide</a>
+          <a href="plugins.html">Plugins</a>
+          <a href="https://github.com/mauropereiira/Moldavite">GitHub</a>
+          <a href="https://github.com/mauropereiira/Moldavite/releases/latest" class="nav-cta"
+            >Download</a
+          >
+        </nav>
+      </div>
+    </header>
+
+    <section class="docs-hero">
+      <span class="version-badge">Privacy</span>
+      <h1>Privacy Policy</h1>
+      <p>
+        Moldavite is a local-first desktop app. Your notes live in ordinary files on your own
+        computer, and there is no Moldavite account, server, or analytics to send them to.
+      </p>
+    </section>
+
+    <main class="docs-body" id="main">
+      <nav class="docs-toc" aria-label="On this page">
+        <strong>On this page</strong>
+        <a href="#summary">Summary</a>
+        <a href="#what-we-collect">What Moldavite collects</a>
+        <a href="#your-notes">Your notes and where they live</a>
+        <a href="#network">Every network connection</a>
+        <a href="#calendar">Calendar access</a>
+        <a href="#google-limited-use">Google API Limited Use</a>
+        <a href="#credentials">Credentials and secrets</a>
+        <a href="#plugins">Plugins</a>
+        <a href="#children">Children</a>
+        <a href="#changes">Changes to this policy</a>
+        <a href="#contact">Contact</a>
+      </nav>
+
+      <h2 id="summary">Summary</h2>
+      <p>
+        Moldavite does not operate a service that receives your data. There is no sign-up, no hosted
+        sync, no analytics, and no telemetry. The developer has no access to your notes, your
+        calendar, or any credential you give the app. Everything below is detail on that one fact.
+      </p>
+      <div class="callout">
+        <span class="callout-title">No data controller relationship for your content</span>
+        <p>
+          Because your notes and connected-account data never reach a server operated by Moldavite,
+          the developer never becomes a processor or controller of that content. The services you
+          connect to — Google, WordPress.com, your own hosts — handle data under their own policies.
+        </p>
+      </div>
+
+      <h2 id="what-we-collect">What Moldavite collects</h2>
+      <p>Nothing. Specifically, the app does not collect, transmit, or store on any server:</p>
+      <ul>
+        <li>the contents, titles, tags, or file names of your notes</li>
+        <li>usage analytics, event tracking, crash reports, or feature telemetry</li>
+        <li>your IP address, device identifiers, or an advertising profile</li>
+        <li>your calendar events, or the account they came from</li>
+        <li>any password, token, or application password you enter</li>
+      </ul>
+      <p>
+        Moldavite has no account system, so there is nothing to sign up for and no profile to
+        delete.
+      </p>
+
+      <h2 id="your-notes">Your notes and where they live</h2>
+      <p>
+        Notes are plain Markdown files with optional YAML frontmatter, written inside a Forge
+        directory you choose — by default under <code>~/Documents/Moldavite/</code>. You can open,
+        move, back up, or delete them with any other tool, with or without Moldavite installed.
+      </p>
+      <ul>
+        <li>
+          <strong>Note locking</strong> encrypts individual notes on disk with AES-256-GCM and
+          Argon2 key derivation. The passphrase is never stored and never leaves your machine; if
+          you lose it, the note cannot be recovered by anyone, including the developer.
+        </li>
+        <li>
+          <strong>Local semantic search</strong> is opt-in. After a one-time model download it runs
+          entirely offline; note text is embedded on your own machine and the index stays inside the
+          Forge.
+        </li>
+        <li>
+          <strong>Trash</strong> retains deleted notes locally for 7 days before permanent removal.
+        </li>
+        <li>
+          <strong>Exports and backups</strong> are written where you point them. Encrypted exports
+          use a passphrase only you hold.
+        </li>
+      </ul>
+      <p>
+        If you place a Forge inside a folder synchronised by iCloud Drive, Dropbox, or a similar
+        service, that service receives your files under its own privacy policy. That is your choice
+        to make, and Moldavite is not involved in it.
+      </p>
+
+      <h2 id="network">Every network connection</h2>
+      <p>
+        This is the complete list of outbound connections the app can make. Each is either triggered
+        by an action you take or, in the case of update checks, disclosed here and limited to
+        version information.
+      </p>
+      <div class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th>Connection</th>
+              <th>When</th>
+              <th>What is sent</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Update check (GitHub)</td>
+              <td>About 15 seconds after launch and once a day while open</td>
+              <td>A request for the signed release manifest. No note data, no identifier.</td>
+            </tr>
+            <tr>
+              <td>Plugin registry (GitHub)</td>
+              <td>Only when you press Browse in the plugin settings</td>
+              <td>A request for the registry file and the plugin you choose to install.</td>
+            </tr>
+            <tr>
+              <td>Semantic model download (Hugging Face)</td>
+              <td>Once, after you opt in to semantic search</td>
+              <td>A request for the model files. No note data.</td>
+            </tr>
+            <tr>
+              <td>Google Calendar</td>
+              <td>Only while a Google account is connected</td>
+              <td>An access token and a date range. See below.</td>
+            </tr>
+            <tr>
+              <td>Plugin requests</td>
+              <td>When a plugin you installed runs</td>
+              <td>
+                Only to hosts named in the plugin manifest and approved by you, and only what that
+                plugin sends.
+              </td>
+            </tr>
+            <tr>
+              <td>Publishing to WordPress</td>
+              <td>Only when you publish a note</td>
+              <td>The note you chose to publish, to the site you configured.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2 id="calendar">Calendar access</h2>
+      <p>
+        Moldavite can display events from Apple Calendar and from Google Calendar alongside your
+        notes. Both are <strong>read-only</strong>. The app never creates, edits, or deletes an
+        event, and it never writes calendar content into your notes on its own.
+      </p>
+      <ul>
+        <li>
+          <strong>Apple Calendar</strong> is read through macOS EventKit after you grant permission
+          in the system dialog. Nothing leaves your machine.
+        </li>
+        <li>
+          <strong>Google Calendar</strong> is read through the Google Calendar API after you
+          explicitly connect an account. Moldavite requests one scope,
+          <code>https://www.googleapis.com/auth/calendar.readonly</code>, which is the narrowest
+          scope that allows reading events.
+        </li>
+      </ul>
+      <p>
+        Google calendar data is fetched for the date range you are viewing, held in memory to draw
+        the timeline, and discarded. It is not written to disk, not indexed for search, not included
+        in exports, and not sent anywhere other than between your computer and Google.
+      </p>
+      <p>
+        You can disconnect at any time from <strong>Settings → Calendar</strong>, which deletes the
+        stored token from your system keychain. You can also revoke Moldavite's access from your
+        <a href="https://myaccount.google.com/permissions">Google Account permissions page</a>,
+        which invalidates it regardless of what is on your machine.
+      </p>
+
+      <h2 id="google-limited-use">Google API Limited Use</h2>
+      <p>
+        Moldavite's use of information received from Google APIs adheres to the
+        <a
+          href="https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes"
+          >Google API Services User Data Policy</a
+        >, including the Limited Use requirements. Concretely:
+      </p>
+      <ul>
+        <li>Google Calendar data is used only to display your events inside the app.</li>
+        <li>It is never transferred to anyone, because it never leaves your device.</li>
+        <li>It is never used for advertising, and never sold.</li>
+        <li>
+          No human reads it. There is no server-side component and the developer has no way to
+          access it.
+        </li>
+        <li>It is not used to train any machine learning or AI model.</li>
+      </ul>
+
+      <h2 id="credentials">Credentials and secrets</h2>
+      <p>
+        Tokens and passwords are stored in your operating system's credential store — the Keychain
+        on macOS, Credential Manager on Windows, the Secret Service on Linux — under the service
+        name <code>Moldavite</code>. They are never written into notes, settings files, exports, or
+        logs.
+      </p>
+      <p>
+        The Google connection stores a refresh token there and keeps the short-lived access token in
+        memory only. Disconnecting removes the refresh token.
+      </p>
+
+      <h2 id="plugins">Plugins</h2>
+      <p>
+        Plugins run in a sandboxed worker with no network access and no direct system access by
+        default. A plugin must declare the exact hosts it wants to reach and the capabilities it
+        wants to use, and you approve that list before it runs. Consent is bound to a hash of the
+        plugin's code, so any change re-prompts.
+      </p>
+      <p>
+        A plugin you approve can send data to the hosts you approved. Moldavite enforces the
+        boundary; it does not vet what a third-party plugin does inside it. Install plugins you
+        trust, and read the permission sheet.
+      </p>
+
+      <h2 id="children">Children</h2>
+      <p>
+        Moldavite is a general-purpose notes application and is not directed at children. It
+        collects no personal information from anyone, including children.
+      </p>
+
+      <h2 id="changes">Changes to this policy</h2>
+      <p>
+        If the app gains a capability that changes what leaves your device, this page changes in the
+        same release, and the network table above is kept exhaustive. Material changes are also
+        noted in the changelog.
+      </p>
+      <p><strong>Last updated:</strong> 7 August 2026</p>
+
+      <h2 id="contact">Contact</h2>
+      <p>
+        Questions about this policy, or about how the app handles something not covered here, can be
+        raised as an issue on
+        <a href="https://github.com/mauropereiira/Moldavite/issues">GitHub</a>. Moldavite is open
+        source under the MIT License, so every claim on this page can be checked against the
+        <a href="https://github.com/mauropereiira/Moldavite">source code</a>.
+      </p>
+
+      <div class="next-links">
+        <a href="guide.html">
+          <span class="label">More detail</span>
+          <span class="title">Read the user guide →</span>
+        </a>
+        <a href="https://github.com/mauropereiira/Moldavite">
+          <span class="label">Verify it</span>
+          <span class="title">Read the source on GitHub →</span>
+        </a>
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <nav aria-label="Footer">
+          <a href="index.html">Home</a>
+          <a href="guide.html">User Guide</a>
+          <a href="plugins.html">Plugin Development</a>
+          <a href="privacy.html">Privacy</a>
+          <a href="https://github.com/mauropereiira/Moldavite/releases/latest">Download</a>
+        </nav>
+        <p class="footer-meta">
+          Documentation · Made by
+          <a href="https://github.com/mauropereiira">Mauro Pereira</a> · MIT License ·
+          <a href="https://github.com/mauropereiira/Moldavite">GitHub</a>
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2868,6 +2868,7 @@ dependencies = [
  "notify-debouncer-mini",
  "rand 0.8.5",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,13 @@ tauri-plugin-deep-link = "2"
 
 bincode = "1.3"
 
+# Google Calendar REST + OAuth token exchange. rustls keeps this off the system
+# TLS stack; this is the only outbound HTTP the Rust process makes.
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
+
 [target.'cfg(not(all(target_os = "macos", target_arch = "x86_64")))'.dependencies]
 # Semantic (vector) search — fully local ONNX inference. ort-sys does not
 # publish prebuilt ONNX Runtime binaries for Intel macOS, so that target keeps

--- a/src-tauri/src/calendar/apple.rs
+++ b/src-tauri/src/calendar/apple.rs
@@ -1,9 +1,13 @@
 //! Safe Rust wrappers around the macOS EventKit Swift bridge.
 //!
-//! This module owns the FFI boundary and JSON decoding for calendar data.
-//! Swift owns returned C strings; every non-null pointer is reclaimed exactly
-//! once with `CString::from_raw`, and malformed bridge output becomes an error
-//! rather than crossing into the command layer.
+//! This module owns the FFI boundary and JSON decoding for Apple calendar
+//! data. Swift owns returned C strings; every non-null pointer is reclaimed
+//! exactly once with `CString::from_raw`, and malformed bridge output becomes
+//! an error rather than crossing into the command layer.
+//!
+//! The types here mirror the Swift payload exactly. Mapping them onto the
+//! source-agnostic shapes — including id namespacing — is `super`'s job, so
+//! the FFI contract stays readable next to the Swift that produces it.
 
 use serde::{Deserialize, Serialize};
 use std::ffi::{CStr, CString};
@@ -44,9 +48,10 @@ impl From<i32> for CalendarPermission {
     }
 }
 
+/// One calendar exactly as the Swift bridge reports it.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct CalendarInfo {
+pub struct RawCalendar {
     pub id: String,
     pub title: String,
     pub color: String,
@@ -56,9 +61,10 @@ pub struct CalendarInfo {
     pub allows_modify: bool,
 }
 
+/// One event exactly as the Swift bridge reports it.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct CalendarEvent {
+pub struct RawEvent {
     pub id: String,
     pub title: String,
     pub start: String,
@@ -75,21 +81,17 @@ pub struct CalendarEvent {
     pub url: String,
 }
 
-/// Get current calendar permission status
 /// Return the current EventKit authorization state reported by Swift.
 pub fn get_permission_status() -> CalendarPermission {
     let status = unsafe { check_calendar_permission() };
     CalendarPermission::from(status)
 }
 
-/// Request calendar access permission
-/// Returns true if permission was granted
 /// Request EventKit access and return whether the resulting state is authorized.
 pub fn request_permission() -> bool {
     unsafe { request_calendar_permission() }
 }
 
-/// Check if calendar access is authorized
 /// Return whether calendar access is currently authorized without prompting.
 pub fn is_authorized() -> bool {
     matches!(
@@ -118,9 +120,8 @@ fn parse_swift_json<T: serde::de::DeserializeOwned>(json_str: &str, what: &str) 
     }
 }
 
-/// Fetch all available calendars
 /// Fetch all visible calendars, rejecting null or malformed bridge responses.
-pub fn get_calendars() -> Result<Vec<CalendarInfo>, String> {
+pub fn get_calendars() -> Result<Vec<RawCalendar>, String> {
     let json_ptr = unsafe { fetch_calendars() };
     if json_ptr.is_null() {
         return Err("Failed to fetch calendars".to_string());
@@ -136,32 +137,25 @@ pub fn get_calendars() -> Result<Vec<CalendarInfo>, String> {
     parse_swift_json(&json_str, "calendars")
 }
 
-/// Fetch events for a date range
 /// Fetch events in the date range understood by the Swift bridge.
 pub fn get_events(
     start_date: &str,
     end_date: &str,
     calendar_id: Option<&str>,
-) -> Result<Vec<CalendarEvent>, String> {
+) -> Result<Vec<RawEvent>, String> {
     let start_cstring =
         CString::new(start_date).map_err(|e| format!("Invalid start date: {}", e))?;
     let end_cstring = CString::new(end_date).map_err(|e| format!("Invalid end date: {}", e))?;
 
-    let calendar_id_cstring = calendar_id
-        .and_then(|id| CString::new(id).ok());
+    let calendar_id_cstring = calendar_id.and_then(|id| CString::new(id).ok());
 
     let calendar_id_ptr = calendar_id_cstring
         .as_ref()
         .map(|cs| cs.as_ptr())
         .unwrap_or(std::ptr::null());
 
-    let json_ptr = unsafe {
-        fetch_events(
-            start_cstring.as_ptr(),
-            end_cstring.as_ptr(),
-            calendar_id_ptr,
-        )
-    };
+    let json_ptr =
+        unsafe { fetch_events(start_cstring.as_ptr(), end_cstring.as_ptr(), calendar_id_ptr) };
 
     if json_ptr.is_null() {
         return Err("Failed to fetch events".to_string());

--- a/src-tauri/src/calendar/google.rs
+++ b/src-tauri/src/calendar/google.rs
@@ -1,0 +1,378 @@
+//! Google Calendar v3, read-only.
+//!
+//! Recurrence is expanded server-side via `singleEvents=true`, which is why
+//! there is no RRULE or VTIMEZONE handling anywhere in this file — Google
+//! returns concrete instances with resolved offsets and we map them straight
+//! across.
+//!
+//! Access tokens are cached in memory for the process lifetime; only the
+//! refresh token is persisted, and that lives in the OS keychain.
+
+use serde::Deserialize;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use super::oauth::{self, AccessToken};
+
+const CALENDAR_LIST_URL: &str = "https://www.googleapis.com/calendar/v3/users/me/calendarList";
+const EVENTS_BASE: &str = "https://www.googleapis.com/calendar/v3/calendars";
+const PAGE_SIZE: u32 = 250;
+
+/// Distinguishes "the token expired, retry" from "the user must reconnect", so
+/// the UI can prompt for consent instead of showing a dead-end error.
+#[derive(Debug)]
+pub enum GoogleError {
+    NeedsReauth(String),
+    Other(String),
+}
+
+impl GoogleError {
+    pub fn message(self) -> String {
+        match self {
+            GoogleError::NeedsReauth(m) | GoogleError::Other(m) => m,
+        }
+    }
+}
+
+impl std::fmt::Display for GoogleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GoogleError::NeedsReauth(m) | GoogleError::Other(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+static ACCESS_TOKEN: Mutex<Option<AccessToken>> = Mutex::new(None);
+
+pub fn cache_token(token: AccessToken) {
+    if let Ok(mut guard) = ACCESS_TOKEN.lock() {
+        *guard = Some(token);
+    }
+}
+
+pub fn clear_token() {
+    if let Ok(mut guard) = ACCESS_TOKEN.lock() {
+        *guard = None;
+    }
+}
+
+/// Return a usable access token, refreshing when the cached one is missing or
+/// close enough to expiry that it would likely die mid-request.
+async fn token() -> Result<String, GoogleError> {
+    let cached = ACCESS_TOKEN
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone())
+        .filter(|t| t.is_usable(Instant::now()));
+
+    if let Some(token) = cached {
+        return Ok(token.value);
+    }
+
+    let refreshed = oauth::refresh().await.map_err(GoogleError::NeedsReauth)?;
+    let value = refreshed.value.clone();
+    cache_token(refreshed);
+    Ok(value)
+}
+
+async fn get_json(url: &str) -> Result<serde_json::Value, GoogleError> {
+    let client = reqwest::Client::new();
+
+    for attempt in 0..2 {
+        let bearer = token().await?;
+        let response = client
+            .get(url)
+            .bearer_auth(&bearer)
+            .send()
+            .await
+            .map_err(|e| GoogleError::Other(format!("could not reach Google Calendar: {e}")))?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            // First 401: the cached token is stale despite the expiry check
+            // (revoked, password change). Drop it and let the retry refresh.
+            clear_token();
+            if attempt == 0 {
+                continue;
+            }
+            return Err(GoogleError::NeedsReauth(
+                "Google access expired. Reconnect your account in Settings → Calendar.".into(),
+            ));
+        }
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(GoogleError::Other(format!(
+                "Google Calendar returned {status}: {body}"
+            )));
+        }
+
+        return response
+            .json::<serde_json::Value>()
+            .await
+            .map_err(|e| GoogleError::Other(format!("could not read Google's response: {e}")));
+    }
+
+    Err(GoogleError::NeedsReauth(
+        "Google access expired. Reconnect your account in Settings → Calendar.".into(),
+    ))
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleCalendar {
+    pub id: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub background_color: String,
+    #[serde(default)]
+    pub access_role: String,
+    #[serde(default)]
+    pub primary: bool,
+}
+
+impl GoogleCalendar {
+    pub fn allows_modify(&self) -> bool {
+        self.access_role == "owner" || self.access_role == "writer"
+    }
+}
+
+pub fn parse_calendar_list(value: &serde_json::Value) -> Vec<GoogleCalendar> {
+    value
+        .get("items")
+        .and_then(|items| items.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| serde_json::from_value::<GoogleCalendar>(item.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub async fn list_calendars() -> Result<Vec<GoogleCalendar>, GoogleError> {
+    let body = get_json(CALENDAR_LIST_URL).await?;
+    Ok(parse_calendar_list(&body))
+}
+
+/// The connected account's own address, which doubles as the id of the primary
+/// calendar. Avoids asking for a profile scope just to label the UI.
+pub async fn account_email() -> Result<Option<String>, GoogleError> {
+    Ok(list_calendars()
+        .await?
+        .into_iter()
+        .find(|c| c.primary)
+        .map(|c| c.id))
+}
+
+/// One event as it arrives from Google, before mapping to the shared shape.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleEvent {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub location: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub html_link: Option<String>,
+    pub start: Option<GoogleEventTime>,
+    pub end: Option<GoogleEventTime>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleEventTime {
+    /// Present for all-day events.
+    #[serde(default)]
+    pub date: Option<String>,
+    /// Present for timed events.
+    #[serde(default)]
+    pub date_time: Option<String>,
+}
+
+impl GoogleEventTime {
+    fn value(&self) -> Option<&str> {
+        self.date_time.as_deref().or(self.date.as_deref())
+    }
+}
+
+impl GoogleEvent {
+    pub fn is_all_day(&self) -> bool {
+        self.start
+            .as_ref()
+            .map(|s| s.date_time.is_none() && s.date.is_some())
+            .unwrap_or(false)
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.status == "cancelled"
+    }
+
+    pub fn start_value(&self) -> Option<&str> {
+        self.start.as_ref().and_then(|s| s.value())
+    }
+
+    pub fn end_value(&self) -> Option<&str> {
+        self.end.as_ref().and_then(|e| e.value())
+    }
+}
+
+pub fn parse_events_page(value: &serde_json::Value) -> (Vec<GoogleEvent>, Option<String>) {
+    let events = value
+        .get("items")
+        .and_then(|items| items.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| serde_json::from_value::<GoogleEvent>(item.clone()).ok())
+                .filter(|e: &GoogleEvent| !e.is_cancelled())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let next = value
+        .get("nextPageToken")
+        .and_then(|t| t.as_str())
+        .map(str::to_string);
+
+    (events, next)
+}
+
+/// Percent-encode a path segment. Calendar ids are email addresses, so `@` and
+/// `.` have to survive as data rather than path structure.
+fn encode_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+/// Fetch every event in `[time_min, time_max]` for one calendar, following
+/// pagination to the end.
+pub async fn list_events(
+    calendar_id: &str,
+    time_min: &str,
+    time_max: &str,
+) -> Result<Vec<GoogleEvent>, GoogleError> {
+    let mut all = Vec::new();
+    let mut page_token: Option<String> = None;
+
+    loop {
+        let mut url = format!(
+            "{EVENTS_BASE}/{}/events?timeMin={}&timeMax={}&singleEvents=true&orderBy=startTime&maxResults={PAGE_SIZE}",
+            encode_segment(calendar_id),
+            encode_segment(time_min),
+            encode_segment(time_max),
+        );
+        if let Some(token) = &page_token {
+            url.push_str(&format!("&pageToken={}", encode_segment(token)));
+        }
+
+        let body = get_json(&url).await?;
+        let (events, next) = parse_events_page(&body);
+        all.extend(events);
+
+        match next {
+            Some(token) => page_token = Some(token),
+            None => break,
+        }
+    }
+
+    Ok(all)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_calendar_list_and_finds_the_primary() {
+        let body = serde_json::json!({
+            "items": [
+                {"id": "work@example.com", "summary": "Work", "backgroundColor": "#123456",
+                 "accessRole": "reader"},
+                {"id": "me@example.com", "summary": "Me", "backgroundColor": "#abcdef",
+                 "accessRole": "owner", "primary": true}
+            ]
+        });
+        let calendars = parse_calendar_list(&body);
+        assert_eq!(calendars.len(), 2);
+        assert!(!calendars[0].allows_modify());
+        assert!(calendars[1].allows_modify());
+        assert_eq!(
+            calendars.iter().find(|c| c.primary).map(|c| c.id.as_str()),
+            Some("me@example.com")
+        );
+    }
+
+    #[test]
+    fn distinguishes_all_day_from_timed_events() {
+        let body = serde_json::json!({
+            "items": [
+                {"id": "a", "summary": "Timed", "status": "confirmed",
+                 "start": {"dateTime": "2026-08-07T09:00:00+01:00"},
+                 "end": {"dateTime": "2026-08-07T10:00:00+01:00"}},
+                {"id": "b", "summary": "Holiday", "status": "confirmed",
+                 "start": {"date": "2026-08-07"}, "end": {"date": "2026-08-08"}}
+            ]
+        });
+        let (events, next) = parse_events_page(&body);
+        assert!(next.is_none());
+        assert_eq!(events.len(), 2);
+        assert!(!events[0].is_all_day());
+        assert_eq!(events[0].start_value(), Some("2026-08-07T09:00:00+01:00"));
+        assert!(events[1].is_all_day());
+        assert_eq!(events[1].start_value(), Some("2026-08-07"));
+    }
+
+    #[test]
+    fn drops_cancelled_events() {
+        let body = serde_json::json!({
+            "items": [
+                {"id": "a", "status": "cancelled", "start": {"date": "2026-08-07"}},
+                {"id": "b", "status": "confirmed", "start": {"date": "2026-08-07"}}
+            ]
+        });
+        let (events, _) = parse_events_page(&body);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "b");
+    }
+
+    #[test]
+    fn surfaces_the_page_token_so_pagination_can_continue() {
+        let body = serde_json::json!({ "items": [], "nextPageToken": "tok2" });
+        let (_, next) = parse_events_page(&body);
+        assert_eq!(next.as_deref(), Some("tok2"));
+    }
+
+    #[test]
+    fn tolerates_an_event_with_no_title_or_times() {
+        let body = serde_json::json!({ "items": [{"id": "a", "status": "confirmed"}] });
+        let (events, _) = parse_events_page(&body);
+        assert_eq!(events.len(), 1);
+        assert!(events[0].summary.is_none());
+        assert!(events[0].start_value().is_none());
+    }
+
+    #[test]
+    fn encodes_an_email_calendar_id_for_the_path() {
+        assert_eq!(encode_segment("me@example.com"), "me%40example.com");
+        assert_eq!(
+            encode_segment("2026-08-07T00:00:00+01:00"),
+            "2026-08-07T00%3A00%3A00%2B01%3A00"
+        );
+    }
+}

--- a/src-tauri/src/calendar/google.rs
+++ b/src-tauri/src/calendar/google.rs
@@ -17,6 +17,8 @@ use super::oauth::{self, AccessToken};
 const CALENDAR_LIST_URL: &str = "https://www.googleapis.com/calendar/v3/users/me/calendarList";
 const EVENTS_BASE: &str = "https://www.googleapis.com/calendar/v3/calendars";
 const PAGE_SIZE: u32 = 250;
+/// Backstop on the pagination loop; see `list_events`.
+const MAX_PAGES: u32 = 40;
 
 /// Distinguishes "the token expired, retry" from "the user must reconnect", so
 /// the UI can prompt for consent instead of showing a dead-end error.
@@ -76,7 +78,7 @@ async fn token() -> Result<String, GoogleError> {
 }
 
 async fn get_json(url: &str) -> Result<serde_json::Value, GoogleError> {
-    let client = reqwest::Client::new();
+    let client = super::http_client();
 
     for attempt in 0..2 {
         let bearer = token().await?;
@@ -269,6 +271,10 @@ pub async fn list_events(
 ) -> Result<Vec<GoogleEvent>, GoogleError> {
     let mut all = Vec::new();
     let mut page_token: Option<String> = None;
+    // A page token that never changes, or a server that keeps handing one back,
+    // would otherwise loop until the process dies. At 250 events per page this
+    // covers a range far larger than the timeline ever requests.
+    let mut pages_left = MAX_PAGES;
 
     loop {
         let mut url = format!(
@@ -285,9 +291,12 @@ pub async fn list_events(
         let (events, next) = parse_events_page(&body);
         all.extend(events);
 
+        pages_left -= 1;
         match next {
-            Some(token) => page_token = Some(token),
-            None => break,
+            Some(token) if pages_left > 0 && Some(&token) != page_token.as_ref() => {
+                page_token = Some(token)
+            }
+            _ => break,
         }
     }
 

--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -213,12 +213,21 @@ fn apple_events(
         })
         .collect();
 
+    // "Nothing selected" and "nothing of ours selected" are different answers.
+    // Keying the everything-case off `wanted` conflated them, so ticking only a
+    // Google calendar still returned every Apple calendar. Match the rule
+    // `google_events` uses: an empty selection means all, a selection that
+    // excludes this source means none.
+    if !calendar_ids.is_empty() && wanted.is_empty() {
+        return Ok(Vec::new());
+    }
+
     let single = if wanted.len() == 1 { Some(wanted[0]) } else { None };
     let raw = apple::get_events(start_date, end_date, single)?;
 
     Ok(raw
         .into_iter()
-        .filter(|e| wanted.is_empty() || wanted.contains(&e.calendar_id.as_str()))
+        .filter(|e| calendar_ids.is_empty() || wanted.contains(&e.calendar_id.as_str()))
         .map(|e| CalendarEvent {
             id: namespace_id(CalendarSource::Apple, &e.id),
             source: CalendarSource::Apple,
@@ -300,13 +309,23 @@ fn local_day_bounds(start_date: &str, end_date: &str) -> Result<(String, String)
     let start = parse(start_date)?;
     let end = parse(end_date)?;
 
-    let start_dt = Local
-        .from_local_datetime(&start.and_hms_opt(0, 0, 0).unwrap())
-        .earliest()
+    // Local midnight does not exist on a spring-forward that lands at 00:00 —
+    // Santiago, Asunción, Beirut, Tehran and Havana all do this. Erroring there
+    // would cost the user every Google event for that day, so walk forward to
+    // the first hour that does exist. The Swift bridge already rolls forward
+    // the same way, so the two sources stay aligned.
+    let start_dt = (0..=3)
+        .find_map(|hour| {
+            start
+                .and_hms_opt(hour, 0, 0)
+                .and_then(|naive| Local.from_local_datetime(&naive).earliest())
+        })
         .ok_or_else(|| format!("Invalid local start time for {start_date}"))?;
-    let end_dt = Local
-        .from_local_datetime(&end.and_hms_opt(23, 59, 59).unwrap())
-        .latest()
+    let end_dt = (0..=3)
+        .find_map(|back| {
+            end.and_hms_opt(23 - back, 59, 59)
+                .and_then(|naive| Local.from_local_datetime(&naive).latest())
+        })
         .ok_or_else(|| format!("Invalid local end time for {end_date}"))?;
 
     Ok((start_dt.to_rfc3339(), end_dt.to_rfc3339()))
@@ -341,10 +360,24 @@ async fn google_events(
     };
 
     let mut events = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
     for calendar in selected {
-        let page = google::list_events(&calendar.id, &time_min, &time_max)
-            .await
-            .map_err(|e| e.message())?;
+        // One calendar that 404s or 403s — a shared calendar the owner deleted,
+        // a subscription that lost access — must not cost the user every other
+        // Google calendar. Collect and carry on, the same way a failing source
+        // does not take the other source down.
+        let page = match google::list_events(&calendar.id, &time_min, &time_max).await {
+            Ok(page) => page,
+            Err(e) => {
+                let name = if calendar.summary.is_empty() {
+                    calendar.id.clone()
+                } else {
+                    calendar.summary.clone()
+                };
+                failures.push(format!("{name}: {}", e.message()));
+                continue;
+            }
+        };
         for e in page {
             let (Some(start), Some(end)) = (e.start_value(), e.end_value()) else {
                 continue;
@@ -374,6 +407,12 @@ async fn google_events(
         }
     }
 
+    // Every calendar failed and none produced events: report it rather than
+    // pretending the account is simply empty.
+    if events.is_empty() && !failures.is_empty() {
+        return Err(failures.join("; "));
+    }
+
     Ok(events)
 }
 
@@ -392,9 +431,29 @@ pub async fn list_sources() -> Vec<CalendarSourceStatus> {
     vec![apple_status(), google]
 }
 
+/// Absolute instant for ordering, across the formats the two sources use:
+/// RFC3339 with any offset, or a bare `yyyy-MM-dd` for an all-day event.
+/// Anything unparseable sorts last rather than panicking.
+fn event_instant(start: &str) -> i64 {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(start) {
+        return dt.timestamp();
+    }
+    NaiveDate::parse_from_str(start, "%Y-%m-%d")
+        .ok()
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
+        .and_then(|naive| Local.from_local_datetime(&naive).earliest())
+        .map(|dt| dt.timestamp())
+        .unwrap_or(i64::MAX)
+}
+
+/// Merge the calendar lists. A source that fails is left out rather than
+/// failing the call: propagating meant one transient Google error emptied the
+/// whole list, and on a fresh launch that hides the calendar picker entirely.
 pub async fn list_all_calendars() -> Result<Vec<CalendarInfo>, String> {
-    let mut calendars = apple_calendars()?;
-    calendars.extend(google_calendars().await?);
+    let mut calendars = apple_calendars().unwrap_or_default();
+    if let Ok(google) = google_calendars().await {
+        calendars.extend(google);
+    }
     Ok(calendars)
 }
 
@@ -424,7 +483,11 @@ pub async fn fetch_events(
         }),
     }
 
-    events.sort_by(|a, b| a.start.cmp(&b.start));
+    // Sort on the instant, not the text. Apple emits UTC (`…Z`) and Google
+    // emits the calendar's own offset, so comparing the strings puts an 09:00
+    // event in +03:00 after a 07:00Z event even though it happens two hours
+    // earlier. All-day values are bare dates, which parse as local midnight.
+    events.sort_by_key(|e| event_instant(&e.start));
     CalendarFetchResult { events, errors }
 }
 
@@ -483,6 +546,39 @@ mod tests {
         let (min, max) = local_day_bounds("2026-08-07", "2026-08-08").unwrap();
         assert!(min.starts_with("2026-08-07T00:00:00"));
         assert!(max.starts_with("2026-08-08T23:59:59"));
+    }
+
+    #[test]
+    fn orders_across_the_two_time_formats_by_instant() {
+        // Apple emits UTC, Google emits the calendar's own offset. Compared as
+        // text the +03:00 event looks later; it is actually two hours earlier.
+        let apple = event_instant("2026-08-07T07:00:00Z");
+        let google = event_instant("2026-08-07T09:00:00+03:00");
+        assert!(google < apple, "instant ordering should ignore the offset text");
+        assert!("2026-08-07T07:00:00Z" < "2026-08-07T09:00:00+03:00");
+    }
+
+    #[test]
+    fn an_all_day_value_orders_as_local_midnight() {
+        let all_day = event_instant("2026-08-07");
+        let same_day_morning = event_instant(
+            &Local
+                .from_local_datetime(
+                    &NaiveDate::from_ymd_opt(2026, 8, 7)
+                        .unwrap()
+                        .and_hms_opt(9, 0, 0)
+                        .unwrap(),
+                )
+                .earliest()
+                .unwrap()
+                .to_rfc3339(),
+        );
+        assert!(all_day < same_day_morning);
+    }
+
+    #[test]
+    fn an_unparseable_start_sorts_last_instead_of_panicking() {
+        assert_eq!(event_instant("not a date"), i64::MAX);
     }
 
     #[test]

--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -128,6 +128,24 @@ pub struct CalendarFetchResult {
 
 const NO_TITLE: &str = "(No title)";
 
+/// One shared HTTP client for every Google call.
+///
+/// `reqwest::Client` owns the connection pool, so building one per request —
+/// which a paginated fetch across several calendars does a lot of — throws away
+/// keep-alive and pays a fresh TLS handshake every time. A request timeout
+/// belongs here too: without one a stalled connection hangs the fetch forever.
+fn http_client() -> reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_default()
+        })
+        .clone()
+}
+
 // ---------------------------------------------------------------- Apple
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -1,0 +1,483 @@
+//! Calendar events from more than one source, behind one shape.
+//!
+//! Apple (EventKit, macOS only) and Google (REST, everywhere) have nothing in
+//! common structurally: one is a local FFI call with an OS permission, the
+//! other a remote API with an OAuth connection. This module owns what the rest
+//! of the app sees — a merged event list, per-source status, and per-source
+//! failures that never take the whole fetch down with them.
+//!
+//! Ids from the two sources can collide, so every event and calendar id is
+//! prefixed with its source here and split back apart here. Nothing above this
+//! boundary should ever parse an id.
+
+#[cfg(target_os = "macos")]
+pub mod apple;
+pub mod google;
+pub mod oauth;
+
+use chrono::{Local, NaiveDate, TimeZone};
+use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "macos")]
+pub use apple::CalendarPermission;
+
+/// Non-macOS builds still need the type for the shared status shape, even
+/// though nothing ever produces a value other than `NotDetermined`.
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub enum CalendarPermission {
+    NotDetermined,
+    Restricted,
+    Denied,
+    Authorized,
+    FullAccess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CalendarSource {
+    Apple,
+    Google,
+}
+
+impl CalendarSource {
+    fn prefix(&self) -> &'static str {
+        match self {
+            CalendarSource::Apple => "apple",
+            CalendarSource::Google => "google",
+        }
+    }
+
+    fn from_prefix(value: &str) -> Option<Self> {
+        match value {
+            "apple" => Some(CalendarSource::Apple),
+            "google" => Some(CalendarSource::Google),
+            _ => None,
+        }
+    }
+}
+
+/// `apple:<uid>` / `google:<id>`.
+pub fn namespace_id(source: CalendarSource, id: &str) -> String {
+    format!("{}:{}", source.prefix(), id)
+}
+
+/// Split a namespaced id back into its source and native id. Returns `None`
+/// for anything without a known prefix, so a malformed id from the frontend
+/// cannot be silently treated as belonging to some source.
+pub fn split_id(namespaced: &str) -> Option<(CalendarSource, &str)> {
+    let (prefix, rest) = namespaced.split_once(':')?;
+    if rest.is_empty() {
+        return None;
+    }
+    CalendarSource::from_prefix(prefix).map(|source| (source, rest))
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarInfo {
+    pub id: String,
+    pub source: CalendarSource,
+    pub title: String,
+    pub color: String,
+    pub is_subscribed: bool,
+    pub allows_modify: bool,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarEvent {
+    pub id: String,
+    pub source: CalendarSource,
+    pub title: String,
+    pub start: String,
+    pub end: String,
+    pub is_all_day: bool,
+    pub location: String,
+    pub notes: String,
+    pub calendar_id: String,
+    pub calendar_title: String,
+    pub calendar_color: String,
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarSourceStatus {
+    pub source: CalendarSource,
+    pub available: bool,
+    pub connected: bool,
+    pub account: Option<String>,
+    pub permission: Option<CalendarPermission>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarSourceError {
+    pub source: CalendarSource,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarFetchResult {
+    pub events: Vec<CalendarEvent>,
+    pub errors: Vec<CalendarSourceError>,
+}
+
+const NO_TITLE: &str = "(No title)";
+
+// ---------------------------------------------------------------- Apple
+
+#[cfg(target_os = "macos")]
+fn apple_status() -> CalendarSourceStatus {
+    let permission = apple::get_permission_status();
+    CalendarSourceStatus {
+        source: CalendarSource::Apple,
+        available: true,
+        connected: apple::is_authorized(),
+        account: None,
+        permission: Some(permission),
+        error: None,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apple_status() -> CalendarSourceStatus {
+    CalendarSourceStatus {
+        source: CalendarSource::Apple,
+        available: false,
+        connected: false,
+        account: None,
+        permission: None,
+        error: Some("Apple Calendar is only available on macOS.".into()),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn apple_calendars() -> Result<Vec<CalendarInfo>, String> {
+    Ok(apple::get_calendars()?
+        .into_iter()
+        .map(|c| CalendarInfo {
+            id: namespace_id(CalendarSource::Apple, &c.id),
+            source: CalendarSource::Apple,
+            title: c.title,
+            color: c.color,
+            is_subscribed: c.is_subscribed,
+            allows_modify: c.allows_modify,
+        })
+        .collect())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apple_calendars() -> Result<Vec<CalendarInfo>, String> {
+    Ok(Vec::new())
+}
+
+#[cfg(target_os = "macos")]
+fn apple_events(
+    start_date: &str,
+    end_date: &str,
+    calendar_ids: &[String],
+) -> Result<Vec<CalendarEvent>, String> {
+    // EventKit filters by at most one calendar, so a multi-calendar selection
+    // is fetched whole and narrowed here. Selecting nothing means everything.
+    let wanted: Vec<&str> = calendar_ids
+        .iter()
+        .filter_map(|id| match split_id(id) {
+            Some((CalendarSource::Apple, native)) => Some(native),
+            _ => None,
+        })
+        .collect();
+
+    let single = if wanted.len() == 1 { Some(wanted[0]) } else { None };
+    let raw = apple::get_events(start_date, end_date, single)?;
+
+    Ok(raw
+        .into_iter()
+        .filter(|e| wanted.is_empty() || wanted.contains(&e.calendar_id.as_str()))
+        .map(|e| CalendarEvent {
+            id: namespace_id(CalendarSource::Apple, &e.id),
+            source: CalendarSource::Apple,
+            title: e.title,
+            start: e.start,
+            end: e.end,
+            is_all_day: e.is_all_day,
+            location: e.location,
+            notes: e.notes,
+            calendar_id: namespace_id(CalendarSource::Apple, &e.calendar_id),
+            calendar_title: e.calendar_title,
+            calendar_color: e.calendar_color,
+            url: e.url,
+        })
+        .collect())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apple_events(
+    _start_date: &str,
+    _end_date: &str,
+    _calendar_ids: &[String],
+) -> Result<Vec<CalendarEvent>, String> {
+    Ok(Vec::new())
+}
+
+// --------------------------------------------------------------- Google
+
+fn google_status() -> CalendarSourceStatus {
+    if !oauth::is_configured() {
+        return CalendarSourceStatus {
+            source: CalendarSource::Google,
+            available: false,
+            connected: false,
+            account: None,
+            permission: None,
+            error: Some(oauth::not_configured_message()),
+        };
+    }
+    CalendarSourceStatus {
+        source: CalendarSource::Google,
+        available: true,
+        connected: oauth::has_stored_refresh_token(),
+        account: None,
+        permission: None,
+        error: None,
+    }
+}
+
+async fn google_calendars() -> Result<Vec<CalendarInfo>, String> {
+    if !oauth::is_configured() || !oauth::has_stored_refresh_token() {
+        return Ok(Vec::new());
+    }
+    let calendars = google::list_calendars().await.map_err(|e| e.message())?;
+    Ok(calendars
+        .into_iter()
+        .map(|c| CalendarInfo {
+            id: namespace_id(CalendarSource::Google, &c.id),
+            source: CalendarSource::Google,
+            title: if c.summary.is_empty() {
+                c.id.clone()
+            } else {
+                c.summary.clone()
+            },
+            color: c.background_color.clone(),
+            is_subscribed: !c.primary,
+            allows_modify: c.allows_modify(),
+        })
+        .collect())
+}
+
+/// Google wants RFC3339 bounds; the app speaks `yyyy-MM-dd`. Widen to the whole
+/// local day on both ends so the range matches what the Swift bridge does.
+fn local_day_bounds(start_date: &str, end_date: &str) -> Result<(String, String), String> {
+    let parse = |value: &str| {
+        NaiveDate::parse_from_str(value, "%Y-%m-%d")
+            .map_err(|e| format!("Invalid date {value}: {e}"))
+    };
+    let start = parse(start_date)?;
+    let end = parse(end_date)?;
+
+    let start_dt = Local
+        .from_local_datetime(&start.and_hms_opt(0, 0, 0).unwrap())
+        .earliest()
+        .ok_or_else(|| format!("Invalid local start time for {start_date}"))?;
+    let end_dt = Local
+        .from_local_datetime(&end.and_hms_opt(23, 59, 59).unwrap())
+        .latest()
+        .ok_or_else(|| format!("Invalid local end time for {end_date}"))?;
+
+    Ok((start_dt.to_rfc3339(), end_dt.to_rfc3339()))
+}
+
+async fn google_events(
+    start_date: &str,
+    end_date: &str,
+    calendar_ids: &[String],
+) -> Result<Vec<CalendarEvent>, String> {
+    if !oauth::is_configured() || !oauth::has_stored_refresh_token() {
+        return Ok(Vec::new());
+    }
+
+    let (time_min, time_max) = local_day_bounds(start_date, end_date)?;
+
+    let all = google::list_calendars().await.map_err(|e| e.message())?;
+    let wanted: Vec<&str> = calendar_ids
+        .iter()
+        .filter_map(|id| match split_id(id) {
+            Some((CalendarSource::Google, native)) => Some(native),
+            _ => None,
+        })
+        .collect();
+
+    // An empty selection means every calendar; a selection with no Google
+    // entries means the user deliberately excluded Google.
+    let selected: Vec<&google::GoogleCalendar> = if calendar_ids.is_empty() {
+        all.iter().collect()
+    } else {
+        all.iter().filter(|c| wanted.contains(&c.id.as_str())).collect()
+    };
+
+    let mut events = Vec::new();
+    for calendar in selected {
+        let page = google::list_events(&calendar.id, &time_min, &time_max)
+            .await
+            .map_err(|e| e.message())?;
+        for e in page {
+            let (Some(start), Some(end)) = (e.start_value(), e.end_value()) else {
+                continue;
+            };
+            events.push(CalendarEvent {
+                id: namespace_id(CalendarSource::Google, &e.id),
+                source: CalendarSource::Google,
+                title: e
+                    .summary
+                    .clone()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| NO_TITLE.to_string()),
+                start: start.to_string(),
+                end: end.to_string(),
+                is_all_day: e.is_all_day(),
+                location: e.location.clone().unwrap_or_default(),
+                notes: e.description.clone().unwrap_or_default(),
+                calendar_id: namespace_id(CalendarSource::Google, &calendar.id),
+                calendar_title: if calendar.summary.is_empty() {
+                    calendar.id.clone()
+                } else {
+                    calendar.summary.clone()
+                },
+                calendar_color: calendar.background_color.clone(),
+                url: e.html_link.clone().unwrap_or_default(),
+            });
+        }
+    }
+
+    Ok(events)
+}
+
+// ------------------------------------------------------------- Dispatch
+
+pub async fn list_sources() -> Vec<CalendarSourceStatus> {
+    let mut google = google_status();
+    // Only ask Google who the user is when there is something to ask about;
+    // a failure here is a label problem, not a connection problem.
+    if google.connected {
+        match google::account_email().await {
+            Ok(email) => google.account = email,
+            Err(e) => google.error = Some(e.message()),
+        }
+    }
+    vec![apple_status(), google]
+}
+
+pub async fn list_all_calendars() -> Result<Vec<CalendarInfo>, String> {
+    let mut calendars = apple_calendars()?;
+    calendars.extend(google_calendars().await?);
+    Ok(calendars)
+}
+
+/// Fetch across every source. A source that fails contributes an entry to
+/// `errors` and nothing to `events`; it never aborts the other source.
+pub async fn fetch_events(
+    start_date: &str,
+    end_date: &str,
+    calendar_ids: &[String],
+) -> CalendarFetchResult {
+    let mut events = Vec::new();
+    let mut errors = Vec::new();
+
+    match apple_events(start_date, end_date, calendar_ids) {
+        Ok(mut e) => events.append(&mut e),
+        Err(message) => errors.push(CalendarSourceError {
+            source: CalendarSource::Apple,
+            message,
+        }),
+    }
+
+    match google_events(start_date, end_date, calendar_ids).await {
+        Ok(mut e) => events.append(&mut e),
+        Err(message) => errors.push(CalendarSourceError {
+            source: CalendarSource::Google,
+            message,
+        }),
+    }
+
+    events.sort_by(|a, b| a.start.cmp(&b.start));
+    CalendarFetchResult { events, errors }
+}
+
+pub async fn connect_google(app: &tauri::AppHandle) -> Result<CalendarSourceStatus, String> {
+    let token = oauth::connect(app).await?;
+    google::cache_token(token);
+    let mut status = google_status();
+    if status.connected {
+        status.account = google::account_email().await.ok().flatten();
+    }
+    Ok(status)
+}
+
+pub fn disconnect_google() -> Result<(), String> {
+    google::clear_token();
+    oauth::forget_refresh_token()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespaced_ids_round_trip() {
+        let id = namespace_id(CalendarSource::Google, "me@example.com");
+        assert_eq!(id, "google:me@example.com");
+        assert_eq!(
+            split_id(&id),
+            Some((CalendarSource::Google, "me@example.com"))
+        );
+
+        let apple = namespace_id(CalendarSource::Apple, "ABC-123");
+        assert_eq!(split_id(&apple), Some((CalendarSource::Apple, "ABC-123")));
+    }
+
+    #[test]
+    fn rejects_ids_without_a_known_source() {
+        assert!(split_id("outlook:abc").is_none());
+        assert!(split_id("no-prefix").is_none());
+        assert!(split_id("apple:").is_none());
+        assert!(split_id("").is_none());
+    }
+
+    #[test]
+    fn an_id_containing_colons_keeps_everything_after_the_first() {
+        // Google ids are addresses, but a calendar id with a colon in it must
+        // not be truncated.
+        assert_eq!(
+            split_id("google:a:b:c"),
+            Some((CalendarSource::Google, "a:b:c"))
+        );
+    }
+
+    #[test]
+    fn day_bounds_cover_the_whole_local_range() {
+        let (min, max) = local_day_bounds("2026-08-07", "2026-08-08").unwrap();
+        assert!(min.starts_with("2026-08-07T00:00:00"));
+        assert!(max.starts_with("2026-08-08T23:59:59"));
+    }
+
+    #[test]
+    fn day_bounds_reject_a_malformed_date() {
+        assert!(local_day_bounds("not-a-date", "2026-08-08").is_err());
+        assert!(local_day_bounds("2026-08-07", "07/08/2026").is_err());
+    }
+
+    #[test]
+    fn source_serialises_lowercase_for_the_frontend() {
+        assert_eq!(
+            serde_json::to_string(&CalendarSource::Google).unwrap(),
+            "\"google\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CalendarSource::Apple).unwrap(),
+            "\"apple\""
+        );
+    }
+}

--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -21,9 +21,13 @@ use serde::{Deserialize, Serialize};
 #[cfg(target_os = "macos")]
 pub use apple::CalendarPermission;
 
-/// Non-macOS builds still need the type for the shared status shape, even
-/// though nothing ever produces a value other than `NotDetermined`.
+/// Non-macOS builds still need the type so `CalendarSourceStatus` keeps one
+/// shape across platforms, but nothing off macOS ever constructs a variant —
+/// `permission` is always `None` there. The variants exist to keep the wire
+/// format identical for the frontend's `CalendarPermission` union, so
+/// `dead_code` is expected rather than a sign of something unused.
 #[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 pub enum CalendarPermission {
     NotDetermined,

--- a/src-tauri/src/calendar/oauth.rs
+++ b/src-tauri/src/calendar/oauth.rs
@@ -34,6 +34,10 @@ const CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
 /// round trip and an error the user would see.
 const EXPIRY_MARGIN: Duration = Duration::from_secs(60);
 
+/// How often the non-blocking accept loop re-checks for a connection. Short
+/// enough that consent feels instant, long enough not to spin a core.
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
 pub const CLIENT_ID: Option<&str> = option_env!("MOLDAVITE_GOOGLE_CLIENT_ID");
 pub const CLIENT_SECRET: Option<&str> = option_env!("MOLDAVITE_GOOGLE_CLIENT_SECRET");
 
@@ -209,9 +213,19 @@ const CALLBACK_PAGE: &str = "<!doctype html><meta charset=\"utf-8\"><title>Molda
 
 /// Bind a loopback listener and wait for Google to redirect the browser to it.
 /// Returns the parsed callback, or an error on timeout.
-fn await_callback(listener: TcpListener) -> Result<Callback, String> {
+///
+/// Anything on the machine can connect to a loopback port, so a request is only
+/// treated as our redirect when it carries the `state` we generated. Without
+/// that check any local process could end the flow early by sending a bare
+/// `?error=`, and the user would see a failure they did not cause. Google
+/// echoes `state` on success and on error alike, so requiring it costs nothing.
+///
+/// The accept loop is non-blocking because a blocking `accept()` would park
+/// here forever when the user abandons the consent tab — the deadline below is
+/// only enforceable if we get to re-check it.
+fn await_callback(listener: TcpListener, expected_state: &str) -> Result<Callback, String> {
     listener
-        .set_nonblocking(false)
+        .set_nonblocking(true)
         .map_err(|e| format!("could not configure callback listener: {e}"))?;
 
     let deadline = Instant::now() + CALLBACK_TIMEOUT;
@@ -221,12 +235,19 @@ fn await_callback(listener: TcpListener) -> Result<Callback, String> {
         if Instant::now() >= deadline {
             return Err("Timed out waiting for Google to redirect back.".into());
         }
-        let (mut stream, _) = listener
-            .accept()
-            .map_err(|e| format!("callback connection failed: {e}"))?;
-        stream
-            .set_read_timeout(Some(Duration::from_secs(10)))
-            .ok();
+
+        let (mut stream, _) = match listener.accept() {
+            Ok(pair) => pair,
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(ACCEPT_POLL_INTERVAL);
+                continue;
+            }
+            Err(e) => return Err(format!("callback connection failed: {e}")),
+        };
+        // The accepted socket can inherit the listener's non-blocking flag, and
+        // the read below expects to block until the request line arrives.
+        stream.set_nonblocking(false).ok();
+        stream.set_read_timeout(Some(Duration::from_secs(10))).ok();
 
         let mut line = String::new();
         if BufReader::new(
@@ -241,6 +262,9 @@ fn await_callback(listener: TcpListener) -> Result<Callback, String> {
         }
 
         let callback = parse_callback(&line);
+        if callback.state.as_deref() != Some(expected_state) {
+            continue;
+        }
         if callback.code.is_none() && callback.error.is_none() {
             continue;
         }
@@ -257,7 +281,7 @@ fn await_callback(listener: TcpListener) -> Result<Callback, String> {
 }
 
 async fn post_token(params: &[(&str, &str)]) -> Result<TokenResponse, String> {
-    let response = reqwest::Client::new()
+    let response = super::http_client()
         .post(TOKEN_ENDPOINT)
         .form(params)
         .send()
@@ -298,15 +322,29 @@ pub async fn connect(app: &tauri::AppHandle) -> Result<AccessToken, String> {
     // shell plugin is already a dependency and the opener plugin would add one
     // plus a capability entry for a single call site. Revisit if the app adopts
     // the opener plugin for other reasons.
+    //
+    // Known residual exposure: this shells out to `/usr/bin/open <url>` on
+    // macOS, so the authorization URL — including `state` and `code_challenge`
+    // — is briefly visible in the process argument list to any process running
+    // as the same user. An attacker who already has same-user code execution
+    // could race that window and complete consent against their own Google
+    // account, leaving this app connected to it. The payoff is arbitrary text
+    // in the timeline (the account address is shown in Settings, event links
+    // are Google-generated, and nothing of the user's is exposed), and such an
+    // attacker can already write directly into the vault. Closing it properly
+    // means launching the browser without a child process — NSWorkspace via
+    // the existing Swift bridge is the likely route.
     #[allow(deprecated)]
     app.shell()
         .open(&url, None)
         .map_err(|e| format!("could not open your browser: {e}"))?;
 
-    // Blocking accept on a worker thread so the async runtime stays free.
-    let callback = tauri::async_runtime::spawn_blocking(move || await_callback(listener))
-        .await
-        .map_err(|e| format!("callback task failed: {e}"))??;
+    // Accept on a worker thread so the async runtime stays free.
+    let expected_state = state.clone();
+    let callback =
+        tauri::async_runtime::spawn_blocking(move || await_callback(listener, &expected_state))
+            .await
+            .map_err(|e| format!("callback task failed: {e}"))??;
 
     if let Some(error) = callback.error {
         return Err(if error == "access_denied" {
@@ -415,6 +453,33 @@ mod tests {
     fn ignores_a_request_with_no_query() {
         assert_eq!(parse_callback("GET / HTTP/1.1"), Callback::default());
         assert_eq!(parse_callback("garbage"), Callback::default());
+    }
+
+    /// The accept loop only acts on a request whose `state` matches the one we
+    /// generated. Anything on the machine can reach a loopback port, so without
+    /// this a stray `?error=` would abort a flow the user did not cancel.
+    #[test]
+    fn a_foreign_request_is_not_mistaken_for_our_redirect() {
+        let ours = "expected-state";
+
+        let forged_error = parse_callback("GET /?error=access_denied HTTP/1.1");
+        assert_ne!(forged_error.state.as_deref(), Some(ours));
+
+        let forged_code = parse_callback("GET /?code=attacker&state=wrong HTTP/1.1");
+        assert_ne!(forged_code.state.as_deref(), Some(ours));
+
+        let real = parse_callback("GET /?code=ours&state=expected-state HTTP/1.1");
+        assert_eq!(real.state.as_deref(), Some(ours));
+        assert_eq!(real.code.as_deref(), Some("ours"));
+    }
+
+    #[test]
+    fn a_cancelled_consent_still_carries_our_state() {
+        // Google echoes `state` on the error redirect too, which is what makes
+        // requiring it safe rather than a way to miss a real cancellation.
+        let cb = parse_callback("GET /?error=access_denied&state=expected-state HTTP/1.1");
+        assert_eq!(cb.state.as_deref(), Some("expected-state"));
+        assert_eq!(cb.error.as_deref(), Some("access_denied"));
     }
 
     #[test]

--- a/src-tauri/src/calendar/oauth.rs
+++ b/src-tauri/src/calendar/oauth.rs
@@ -1,0 +1,462 @@
+//! Google OAuth for an installed app: PKCE plus a loopback redirect.
+//!
+//! The whole flow lives in Rust on purpose. No token ever reaches the webview,
+//! so the CSP in `tauri.conf.json` needs no `accounts.google.com` exception and
+//! a compromised plugin cannot read the calendar credentials.
+//!
+//! The client secret Google issues for a "Desktop app" client is not
+//! confidential — it ships inside every copy of the binary, which is why PKCE
+//! carries the actual security here. It is still read from the environment at
+//! build time rather than committed, so it stays out of a public repository.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use rand::RngCore;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+use tauri_plugin_shell::ShellExt;
+
+use crate::secrets::{KeychainSecretStore, SecretStore};
+
+const AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+const SCOPE: &str = "https://www.googleapis.com/auth/calendar.readonly";
+const REFRESH_TOKEN_ACCOUNT: &str = "calendar:google:refresh_token";
+
+/// How long to wait for the user to finish consent before giving up, so an
+/// abandoned browser tab cannot block a thread for the life of the process.
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Refresh slightly before real expiry; a token that dies mid-request costs a
+/// round trip and an error the user would see.
+const EXPIRY_MARGIN: Duration = Duration::from_secs(60);
+
+pub const CLIENT_ID: Option<&str> = option_env!("MOLDAVITE_GOOGLE_CLIENT_ID");
+pub const CLIENT_SECRET: Option<&str> = option_env!("MOLDAVITE_GOOGLE_CLIENT_SECRET");
+
+/// Whether this build carries Google credentials at all. A local build without
+/// them must still compile and run — the source simply reports unavailable.
+pub fn is_configured() -> bool {
+    CLIENT_ID.is_some_and(|v| !v.is_empty()) && CLIENT_SECRET.is_some_and(|v| !v.is_empty())
+}
+
+pub fn not_configured_message() -> String {
+    "Google Calendar is not configured in this build.".to_string()
+}
+
+#[derive(Debug, Clone)]
+pub struct AccessToken {
+    pub value: String,
+    pub expires_at: Instant,
+}
+
+impl AccessToken {
+    /// Treat a token inside the margin as already expired.
+    pub fn is_usable(&self, now: Instant) -> bool {
+        self.expires_at
+            .checked_duration_since(now)
+            .map(|left| left > EXPIRY_MARGIN)
+            .unwrap_or(false)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub expires_in: u64,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+}
+
+impl TokenResponse {
+    pub fn into_access_token(self, now: Instant) -> (AccessToken, Option<String>) {
+        (
+            AccessToken {
+                value: self.access_token,
+                expires_at: now + Duration::from_secs(self.expires_in),
+            },
+            self.refresh_token,
+        )
+    }
+}
+
+/// A PKCE verifier and its S256 challenge.
+pub struct Pkce {
+    pub verifier: String,
+    pub challenge: String,
+}
+
+pub fn generate_pkce() -> Pkce {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    let verifier = URL_SAFE_NO_PAD.encode(bytes);
+    Pkce {
+        challenge: challenge_for(&verifier),
+        verifier,
+    }
+}
+
+/// S256: base64url(sha256(verifier)), unpadded.
+pub fn challenge_for(verifier: &str) -> String {
+    let digest = Sha256::digest(verifier.as_bytes());
+    URL_SAFE_NO_PAD.encode(digest)
+}
+
+fn random_state() -> String {
+    let mut bytes = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Percent-encode a query parameter value. Small by hand rather than pulling in
+/// a URL crate for six call sites.
+fn encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+pub fn authorize_url(client_id: &str, redirect_uri: &str, challenge: &str, state: &str) -> String {
+    format!(
+        "{AUTH_ENDPOINT}?client_id={}&redirect_uri={}&response_type=code&scope={}\
+         &access_type=offline&prompt=consent&code_challenge={}&code_challenge_method=S256&state={}",
+        encode(client_id),
+        encode(redirect_uri),
+        encode(SCOPE),
+        encode(challenge),
+        encode(state),
+    )
+}
+
+/// The `code` / `error` / `state` triple carried on the redirect.
+#[derive(Debug, Default, PartialEq)]
+pub struct Callback {
+    pub code: Option<String>,
+    pub state: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Parse the query out of an HTTP request line such as
+/// `GET /?code=abc&state=xyz HTTP/1.1`.
+pub fn parse_callback(request_line: &str) -> Callback {
+    let mut callback = Callback::default();
+    let Some(target) = request_line.split_whitespace().nth(1) else {
+        return callback;
+    };
+    let Some((_, query)) = target.split_once('?') else {
+        return callback;
+    };
+    for pair in query.split('&') {
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        let value = percent_decode(value);
+        match key {
+            "code" => callback.code = Some(value),
+            "state" => callback.state = Some(value),
+            "error" => callback.error = Some(value),
+            _ => {}
+        }
+    }
+    callback
+}
+
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        i += 3;
+                    }
+                    Err(_) => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
+                }
+            }
+            other => {
+                out.push(other);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+const CALLBACK_PAGE: &str = "<!doctype html><meta charset=\"utf-8\"><title>Moldavite</title>\
+<body style=\"font-family:system-ui;padding:3rem;text-align:center\">\
+<h1>Moldavite is connected</h1><p>You can close this tab and return to the app.</p>";
+
+/// Bind a loopback listener and wait for Google to redirect the browser to it.
+/// Returns the parsed callback, or an error on timeout.
+fn await_callback(listener: TcpListener) -> Result<Callback, String> {
+    listener
+        .set_nonblocking(false)
+        .map_err(|e| format!("could not configure callback listener: {e}"))?;
+
+    let deadline = Instant::now() + CALLBACK_TIMEOUT;
+    // A browser may open speculative connections that send nothing. Keep
+    // accepting until one actually carries the redirect or the deadline passes.
+    loop {
+        if Instant::now() >= deadline {
+            return Err("Timed out waiting for Google to redirect back.".into());
+        }
+        let (mut stream, _) = listener
+            .accept()
+            .map_err(|e| format!("callback connection failed: {e}"))?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .ok();
+
+        let mut line = String::new();
+        if BufReader::new(
+            stream
+                .try_clone()
+                .map_err(|e| format!("callback connection failed: {e}"))?,
+        )
+        .read_line(&mut line)
+        .is_err()
+        {
+            continue;
+        }
+
+        let callback = parse_callback(&line);
+        if callback.code.is_none() && callback.error.is_none() {
+            continue;
+        }
+
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            CALLBACK_PAGE.len(),
+            CALLBACK_PAGE
+        );
+        let _ = stream.flush();
+        return Ok(callback);
+    }
+}
+
+async fn post_token(params: &[(&str, &str)]) -> Result<TokenResponse, String> {
+    let response = reqwest::Client::new()
+        .post(TOKEN_ENDPOINT)
+        .form(params)
+        .send()
+        .await
+        .map_err(|e| format!("could not reach Google: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("Google rejected the token request ({status}): {body}"));
+    }
+
+    response
+        .json::<TokenResponse>()
+        .await
+        .map_err(|e| format!("could not read Google's token response: {e}"))
+}
+
+/// Run the full consent flow and persist the resulting refresh token.
+pub async fn connect(app: &tauri::AppHandle) -> Result<AccessToken, String> {
+    let (Some(client_id), Some(client_secret)) = (CLIENT_ID, CLIENT_SECRET) else {
+        return Err(not_configured_message());
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| format!("could not open a local callback port: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("could not read the callback port: {e}"))?
+        .port();
+    let redirect_uri = format!("http://127.0.0.1:{port}");
+
+    let pkce = generate_pkce();
+    let state = random_state();
+    let url = authorize_url(client_id, &redirect_uri, &pkce.challenge, &state);
+
+    // `Shell::open` is deprecated in favour of tauri-plugin-opener, but the
+    // shell plugin is already a dependency and the opener plugin would add one
+    // plus a capability entry for a single call site. Revisit if the app adopts
+    // the opener plugin for other reasons.
+    #[allow(deprecated)]
+    app.shell()
+        .open(&url, None)
+        .map_err(|e| format!("could not open your browser: {e}"))?;
+
+    // Blocking accept on a worker thread so the async runtime stays free.
+    let callback = tauri::async_runtime::spawn_blocking(move || await_callback(listener))
+        .await
+        .map_err(|e| format!("callback task failed: {e}"))??;
+
+    if let Some(error) = callback.error {
+        return Err(if error == "access_denied" {
+            "Connection cancelled.".to_string()
+        } else {
+            format!("Google returned an error: {error}")
+        });
+    }
+    // A mismatched state means the redirect did not come from the request we
+    // started; refusing it is the whole point of sending one.
+    if callback.state.as_deref() != Some(state.as_str()) {
+        return Err("The Google redirect did not match this request.".into());
+    }
+    let code = callback
+        .code
+        .ok_or_else(|| "Google did not return an authorization code.".to_string())?;
+
+    let response = post_token(&[
+        ("client_id", client_id),
+        ("client_secret", client_secret),
+        ("code", &code),
+        ("code_verifier", &pkce.verifier),
+        ("grant_type", "authorization_code"),
+        ("redirect_uri", &redirect_uri),
+    ])
+    .await?;
+
+    let (token, refresh) = response.into_access_token(Instant::now());
+    let refresh = refresh.ok_or_else(|| {
+        "Google did not return a refresh token. Remove Moldavite from your Google account \
+         permissions and connect again."
+            .to_string()
+    })?;
+    KeychainSecretStore.set(REFRESH_TOKEN_ACCOUNT, &refresh)?;
+
+    Ok(token)
+}
+
+/// Exchange the stored refresh token for a fresh access token.
+pub async fn refresh() -> Result<AccessToken, String> {
+    let (Some(client_id), Some(client_secret)) = (CLIENT_ID, CLIENT_SECRET) else {
+        return Err(not_configured_message());
+    };
+    let refresh_token = KeychainSecretStore
+        .get(REFRESH_TOKEN_ACCOUNT)?
+        .ok_or_else(|| "No Google account is connected.".to_string())?;
+
+    let response = post_token(&[
+        ("client_id", client_id),
+        ("client_secret", client_secret),
+        ("refresh_token", &refresh_token),
+        ("grant_type", "refresh_token"),
+    ])
+    .await?;
+
+    Ok(response.into_access_token(Instant::now()).0)
+}
+
+pub fn has_stored_refresh_token() -> bool {
+    KeychainSecretStore
+        .get(REFRESH_TOKEN_ACCOUNT)
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+pub fn forget_refresh_token() -> Result<(), String> {
+    KeychainSecretStore.delete(REFRESH_TOKEN_ACCOUNT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn s256_challenge_matches_the_rfc7636_example() {
+        // RFC 7636 appendix B.
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assert_eq!(challenge_for(verifier), "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    }
+
+    #[test]
+    fn generated_verifier_and_challenge_agree() {
+        let pkce = generate_pkce();
+        assert_eq!(challenge_for(&pkce.verifier), pkce.challenge);
+        // RFC 7636 requires 43-128 characters.
+        assert!((43..=128).contains(&pkce.verifier.len()));
+    }
+
+    #[test]
+    fn parses_a_successful_callback() {
+        let cb = parse_callback("GET /?code=abc123&state=xyz&scope=https%3A%2F%2Fx HTTP/1.1");
+        assert_eq!(cb.code.as_deref(), Some("abc123"));
+        assert_eq!(cb.state.as_deref(), Some("xyz"));
+        assert!(cb.error.is_none());
+    }
+
+    #[test]
+    fn parses_a_denied_callback() {
+        let cb = parse_callback("GET /?error=access_denied&state=xyz HTTP/1.1");
+        assert_eq!(cb.error.as_deref(), Some("access_denied"));
+        assert!(cb.code.is_none());
+    }
+
+    #[test]
+    fn ignores_a_request_with_no_query() {
+        assert_eq!(parse_callback("GET / HTTP/1.1"), Callback::default());
+        assert_eq!(parse_callback("garbage"), Callback::default());
+    }
+
+    #[test]
+    fn authorize_url_encodes_and_pins_the_scope() {
+        let url = authorize_url("id.apps.googleusercontent.com", "http://127.0.0.1:5000", "chal", "st");
+        assert!(url.contains("code_challenge=chal"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("access_type=offline"));
+        assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A5000"));
+        assert!(url.contains("calendar.readonly"));
+        assert!(url.contains("state=st"));
+    }
+
+    #[test]
+    fn token_is_unusable_once_inside_the_refresh_margin() {
+        let now = Instant::now();
+        let fresh = AccessToken { value: "t".into(), expires_at: now + Duration::from_secs(3600) };
+        assert!(fresh.is_usable(now));
+
+        let nearly_done = AccessToken { value: "t".into(), expires_at: now + Duration::from_secs(30) };
+        assert!(!nearly_done.is_usable(now));
+
+        let expired = AccessToken { value: "t".into(), expires_at: now };
+        assert!(!expired.is_usable(now));
+    }
+
+    #[test]
+    fn token_response_carries_the_refresh_token_through() {
+        let parsed: TokenResponse = serde_json::from_str(
+            r#"{"access_token":"at","expires_in":3599,"refresh_token":"rt","token_type":"Bearer"}"#,
+        )
+        .unwrap();
+        let (token, refresh) = parsed.into_access_token(Instant::now());
+        assert_eq!(token.value, "at");
+        assert_eq!(refresh.as_deref(), Some("rt"));
+    }
+
+    #[test]
+    fn a_refresh_response_without_a_new_refresh_token_is_fine() {
+        let parsed: TokenResponse =
+            serde_json::from_str(r#"{"access_token":"at2","expires_in":3599}"#).unwrap();
+        let (_, refresh) = parsed.into_access_token(Instant::now());
+        assert!(refresh.is_none());
+    }
+}

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -13,9 +13,8 @@ use std::path::{Path, PathBuf};
 
 use crate::paths::get_notes_dir;
 use crate::persist::write_atomic;
+use crate::secrets::{KeychainSecretStore, SecretStore};
 use crate::validation::validate_path_within_base;
-
-const KEYRING_SERVICE: &str = "Moldavite";
 
 /// Absolute path to the active Forge's `.plugins` directory.
 pub(crate) fn plugins_dir() -> PathBuf {
@@ -51,46 +50,8 @@ fn secret_account(plugin_id: &str, key: &str) -> Result<String, String> {
     Ok(format!("plugin:{plugin_id}:{key}"))
 }
 
-trait PluginSecretStore {
-    fn get(&self, account: &str) -> Result<Option<String>, String>;
-    fn set(&self, account: &str, value: &str) -> Result<(), String>;
-    fn delete(&self, account: &str) -> Result<(), String>;
-}
-
-struct KeychainSecretStore;
-
-impl KeychainSecretStore {
-    fn entry(account: &str) -> Result<keyring::Entry, String> {
-        keyring::Entry::new(KEYRING_SERVICE, account)
-            .map_err(|e| format!("could not access plugin secret: {e}"))
-    }
-}
-
-impl PluginSecretStore for KeychainSecretStore {
-    fn get(&self, account: &str) -> Result<Option<String>, String> {
-        match Self::entry(account)?.get_password() {
-            Ok(value) => Ok(Some(value)),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => Err(format!("could not read plugin secret: {e}")),
-        }
-    }
-
-    fn set(&self, account: &str, value: &str) -> Result<(), String> {
-        Self::entry(account)?
-            .set_password(value)
-            .map_err(|e| format!("could not save plugin secret: {e}"))
-    }
-
-    fn delete(&self, account: &str) -> Result<(), String> {
-        match Self::entry(account)?.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(e) => Err(format!("could not delete plugin secret: {e}")),
-        }
-    }
-}
-
 fn secret_get_with(
-    store: &impl PluginSecretStore,
+    store: &impl SecretStore,
     plugin_id: &str,
     key: &str,
 ) -> Result<Option<String>, String> {
@@ -98,7 +59,7 @@ fn secret_get_with(
 }
 
 fn secret_set_with(
-    store: &impl PluginSecretStore,
+    store: &impl SecretStore,
     plugin_id: &str,
     key: &str,
     value: &str,
@@ -107,7 +68,7 @@ fn secret_set_with(
 }
 
 fn secret_delete_with(
-    store: &impl PluginSecretStore,
+    store: &impl SecretStore,
     plugin_id: &str,
     key: &str,
 ) -> Result<(), String> {
@@ -527,7 +488,7 @@ mod tests {
     #[derive(Default)]
     struct MemorySecretStore(RefCell<HashMap<String, String>>);
 
-    impl PluginSecretStore for MemorySecretStore {
+    impl SecretStore for MemorySecretStore {
         fn get(&self, account: &str) -> Result<Option<String>, String> {
             Ok(self.0.borrow().get(account).cloned())
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,9 +17,11 @@
 // MODULE DECLARATIONS
 // =============================================================================
 
-/// macOS calendar integration (EventKit)
-#[cfg(target_os = "macos")]
+/// Calendar integration: Apple (EventKit, macOS) and Google (REST, all platforms)
 mod calendar;
+
+/// OS credential store, shared by plugins and calendar accounts
+mod secrets;
 
 /// Core encryption logic (AES-256-GCM)
 mod encryption;
@@ -57,8 +59,9 @@ pub(crate) mod wiki;
 #[cfg(test)]
 mod stress_test;
 
+use calendar::{CalendarFetchResult, CalendarInfo, CalendarSourceStatus};
 #[cfg(target_os = "macos")]
-use calendar::{CalendarEvent, CalendarInfo, CalendarPermission};
+use calendar::CalendarPermission;
 
 use commands::backlinks::{create_note_from_link, get_backlinks, scan_note_links};
 use commands::export_import::{
@@ -103,40 +106,57 @@ use commands::trash::{
     restore_note, restore_note_from_folder, trash_folder, trash_note,
 };
 
-// Apple Calendar (EventKit) Commands - macOS only
+// Calendar Commands
+//
+// The three EventKit permission commands stay macOS-only because they wrap an
+// Apple-specific authorization model. Everything else dispatches across sources
+// and compiles everywhere, so Google Calendar works on Windows and Linux too.
 
 #[cfg(target_os = "macos")]
 #[tauri::command]
 fn get_calendar_permission() -> CalendarPermission {
-    calendar::get_permission_status()
+    calendar::apple::get_permission_status()
 }
 
 #[cfg(target_os = "macos")]
 #[tauri::command]
 fn request_calendar_permission() -> bool {
-    calendar::request_permission()
+    calendar::apple::request_permission()
 }
 
 #[cfg(target_os = "macos")]
 #[tauri::command]
 fn is_calendar_authorized() -> bool {
-    calendar::is_authorized()
+    calendar::apple::is_authorized()
 }
 
-#[cfg(target_os = "macos")]
 #[tauri::command]
-fn fetch_calendar_events(
+async fn list_calendar_sources() -> Result<Vec<CalendarSourceStatus>, String> {
+    Ok(calendar::list_sources().await)
+}
+
+#[tauri::command]
+async fn fetch_calendar_events(
     start_date: String,
     end_date: String,
-    calendar_id: Option<String>,
-) -> Result<Vec<CalendarEvent>, String> {
-    calendar::get_events(&start_date, &end_date, calendar_id.as_deref())
+    calendar_ids: Vec<String>,
+) -> Result<CalendarFetchResult, String> {
+    Ok(calendar::fetch_events(&start_date, &end_date, &calendar_ids).await)
 }
 
-#[cfg(target_os = "macos")]
 #[tauri::command]
-fn list_calendars() -> Result<Vec<CalendarInfo>, String> {
-    calendar::get_calendars()
+async fn list_calendars() -> Result<Vec<CalendarInfo>, String> {
+    calendar::list_all_calendars().await
+}
+
+#[tauri::command]
+async fn google_calendar_connect(app: tauri::AppHandle) -> Result<CalendarSourceStatus, String> {
+    calendar::connect_google(&app).await
+}
+
+#[tauri::command]
+fn google_calendar_disconnect() -> Result<(), String> {
+    calendar::disconnect_google()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -367,17 +387,18 @@ pub fn run() {
             import_settings_json,
             // Image handling
             save_image,
-            // Apple Calendar (EventKit) commands - macOS only
+            // Calendar: EventKit permission is macOS-only, the rest is cross-platform
             #[cfg(target_os = "macos")]
             get_calendar_permission,
             #[cfg(target_os = "macos")]
             request_calendar_permission,
             #[cfg(target_os = "macos")]
             is_calendar_authorized,
-            #[cfg(target_os = "macos")]
+            list_calendar_sources,
             fetch_calendar_events,
-            #[cfg(target_os = "macos")]
-            list_calendars
+            list_calendars,
+            google_calendar_connect,
+            google_calendar_disconnect
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/secrets.rs
+++ b/src-tauri/src/secrets.rs
@@ -1,0 +1,46 @@
+//! OS credential-store access, shared by every feature that holds a secret.
+//!
+//! Accounts are namespaced by the caller (`plugin:<id>:<key>`,
+//! `calendar:google:refresh_token`) so one feature can never read another's
+//! secret by guessing a key. Nothing here ever logs a value.
+
+const KEYRING_SERVICE: &str = "Moldavite";
+
+/// Indirection so callers can be tested without touching the real keychain.
+pub(crate) trait SecretStore {
+    fn get(&self, account: &str) -> Result<Option<String>, String>;
+    fn set(&self, account: &str, value: &str) -> Result<(), String>;
+    fn delete(&self, account: &str) -> Result<(), String>;
+}
+
+pub(crate) struct KeychainSecretStore;
+
+impl KeychainSecretStore {
+    fn entry(account: &str) -> Result<keyring::Entry, String> {
+        keyring::Entry::new(KEYRING_SERVICE, account)
+            .map_err(|e| format!("could not access secret: {e}"))
+    }
+}
+
+impl SecretStore for KeychainSecretStore {
+    fn get(&self, account: &str) -> Result<Option<String>, String> {
+        match Self::entry(account)?.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(format!("could not read secret: {e}")),
+        }
+    }
+
+    fn set(&self, account: &str, value: &str) -> Result<(), String> {
+        Self::entry(account)?
+            .set_password(value)
+            .map_err(|e| format!("could not save secret: {e}"))
+    }
+
+    fn delete(&self, account: &str) -> Result<(), String> {
+        match Self::entry(account)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(format!("could not delete secret: {e}")),
+        }
+    }
+}

--- a/src/components/calendar/CalendarOnboardingModal.tsx
+++ b/src/components/calendar/CalendarOnboardingModal.tsx
@@ -3,7 +3,10 @@ import { Calendar, Settings, ChevronRight, X } from 'lucide-react';
 import { useCalendarStore } from '@/stores/calendarStore';
 
 export function CalendarOnboardingModal() {
-  const { isAuthorized, hasSeenOnboarding, setHasSeenOnboarding } = useCalendarStore();
+  const { sources, hasSeenOnboarding, setHasSeenOnboarding } = useCalendarStore();
+  // Any connected source earns the walkthrough, not just EventKit — on
+  // Windows and Linux, Google is the only source there is.
+  const isAuthorized = sources.some((s) => s.available && s.connected);
   const [step, setStep] = useState(0);
 
   // Only show if authorized and hasn't seen onboarding
@@ -20,7 +23,7 @@ export function CalendarOnboardingModal() {
       icon: <Settings className="w-12 h-12 text-blue-500" />,
       title: 'Customize Your Calendar',
       description:
-        'Go to Settings → Calendar to choose which calendar to display, toggle all-day events, and more.',
+        'Go to Settings → Calendar to connect accounts, choose which calendars to display, toggle all-day events, and more.',
     },
   ];
 

--- a/src/components/calendar/Timeline.tsx
+++ b/src/components/calendar/Timeline.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useMemo } from 'react';
 import { format, isToday } from 'date-fns';
 import { useCalendarStore } from '@/stores/calendarStore';
-import { useNoteStore } from '@/stores';
+import { useNoteStore, useSettingsStore } from '@/stores';
 import type { CalendarEvent } from '@/types';
 import { Clock, RefreshCw, AlertCircle, Lock, ExternalLink } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-shell';
@@ -195,15 +195,32 @@ function PermissionDeniedState() {
   );
 }
 
-// Connect prompt for unauthenticated state
+// Connect prompt for the no-source-connected state
 export function ConnectCalendarPrompt() {
-  const { requestPermission, isRequestingPermission, permissionStatus } = useCalendarStore();
+  const { requestPermission, isRequestingPermission, permissionStatus, sources } =
+    useCalendarStore();
+  const setIsSettingsOpen = useSettingsStore((s) => s.setIsSettingsOpen);
+  const setActiveSettingsTab = useSettingsStore((s) => s.setActiveSettingsTab);
 
-  const handleEnableAccess = async () => {
-    await requestPermission();
-  };
+  const apple = sources.find((s) => s.source === 'apple');
 
-  // Show denied state if permission was denied
+  // The System Settings deep link and the EventKit permission dance are Apple's
+  // alone. Where EventKit does not exist — Windows, Linux — the only way to get
+  // events is to connect an account, so send the user to Settings instead.
+  if (!apple?.available) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center p-2">
+        <ConnectCalendarEmptyState
+          onConnect={() => {
+            setActiveSettingsTab('calendar');
+            setIsSettingsOpen(true);
+          }}
+          isConnecting={false}
+        />
+      </div>
+    );
+  }
+
   if (permissionStatus === 'Denied' || permissionStatus === 'Restricted') {
     return <PermissionDeniedState />;
   }
@@ -211,7 +228,9 @@ export function ConnectCalendarPrompt() {
   return (
     <div className="flex-1 flex flex-col items-center justify-center p-2">
       <ConnectCalendarEmptyState
-        onConnect={handleEnableAccess}
+        onConnect={() => {
+          void requestPermission();
+        }}
         isConnecting={isRequestingPermission}
       />
     </div>
@@ -329,30 +348,48 @@ function TimeGrid({ events, selectedDate }: TimeGridProps) {
 export function Timeline() {
   const { selectedDate } = useNoteStore();
   const {
-    isAuthorized,
+    sources,
     events,
     isLoadingEvents,
     eventsError,
+    sourceErrors,
     lastSynced,
     calendarEnabled,
+    refreshIntervalMinutes,
     fetchEvents,
     checkPermission,
   } = useCalendarStore();
 
-  // Check permission status on mount
+  const anyConnected = sources.some((s) => s.available && s.connected);
+
+  // Check source state on mount
   useEffect(() => {
     checkPermission();
   }, [checkPermission]);
 
-  // Fetch events when date changes
+  // Fetch events when the date or the set of connected sources changes
   useEffect(() => {
-    if (isAuthorized && calendarEnabled) {
+    if (anyConnected && calendarEnabled) {
       fetchEvents(selectedDate);
     }
-  }, [selectedDate, isAuthorized, calendarEnabled, fetchEvents]);
+  }, [selectedDate, anyConnected, calendarEnabled, fetchEvents]);
 
-  // Not authorized - show connect prompt
-  if (!isAuthorized) {
+  // Poll while the app is open. EventKit is local and cheap, but Google is a
+  // rate-limited remote API, so the interval is a user setting rather than a
+  // constant.
+  useEffect(() => {
+    if (!anyConnected || !calendarEnabled) return;
+    const id = window.setInterval(
+      () => {
+        void fetchEvents(selectedDate, undefined, { force: true });
+      },
+      refreshIntervalMinutes * 60 * 1000
+    );
+    return () => window.clearInterval(id);
+  }, [anyConnected, calendarEnabled, refreshIntervalMinutes, selectedDate, fetchEvents]);
+
+  // Nothing connected - show connect prompt
+  if (!anyConnected) {
     return <ConnectCalendarPrompt />;
   }
 
@@ -371,7 +408,7 @@ export function Timeline() {
   }
 
   const handleRefresh = () => {
-    fetchEvents(selectedDate);
+    fetchEvents(selectedDate, undefined, { force: true });
   };
 
   // Format the header date
@@ -410,6 +447,21 @@ export function Timeline() {
           <RefreshCw className={`w-3.5 h-3.5 ${isLoadingEvents ? 'animate-spin' : ''}`} />
         </button>
       </div>
+
+      {/* One source failing must not hide the events that did load, so this is
+          a notice above the grid rather than a replacement for it. */}
+      {sourceErrors.length > 0 && (
+        <div
+          className="px-3 py-1.5 text-[10px]"
+          style={{ color: 'var(--error)', borderBottom: '1px solid var(--border-default)' }}
+        >
+          {sourceErrors.map((e) => (
+            <div key={e.source}>
+              {e.source === 'google' ? 'Google Calendar' : 'Apple Calendar'}: {e.message}
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Content */}
       {isLoadingEvents && events.length === 0 ? (

--- a/src/components/calendar/Timeline.tsx
+++ b/src/components/calendar/Timeline.tsx
@@ -382,6 +382,8 @@ export function Timeline() {
     lastSynced,
     calendarEnabled,
     refreshIntervalMinutes,
+    selectedCalendarIds,
+    showAllDayEvents,
     fetchEvents,
     checkPermission,
   } = useCalendarStore();
@@ -393,12 +395,23 @@ export function Timeline() {
     checkPermission();
   }, [checkPermission]);
 
-  // Fetch events when the date or the set of connected sources changes
+  // Refetch when the date, the connected sources, the calendar selection, or
+  // the all-day preference changes. Leaving the last two out meant ticking a
+  // calendar in Settings did nothing visible until the next poll — up to the
+  // full refresh interval away. Both re-reads usually hit the range cache, so
+  // this is instant rather than another round trip.
   useEffect(() => {
     if (anyConnected && calendarEnabled) {
       fetchEvents(selectedDate);
     }
-  }, [selectedDate, anyConnected, calendarEnabled, fetchEvents]);
+  }, [
+    selectedDate,
+    anyConnected,
+    calendarEnabled,
+    selectedCalendarIds,
+    showAllDayEvents,
+    fetchEvents,
+  ]);
 
   // Poll while the app is open. EventKit is local and cheap, but Google is a
   // rate-limited remote API, so the interval is a user setting rather than a

--- a/src/components/calendar/Timeline.tsx
+++ b/src/components/calendar/Timeline.tsx
@@ -197,42 +197,68 @@ function PermissionDeniedState() {
 
 // Connect prompt for the no-source-connected state
 export function ConnectCalendarPrompt() {
-  const { requestPermission, isRequestingPermission, permissionStatus, sources } =
-    useCalendarStore();
+  const {
+    requestPermission,
+    isRequestingPermission,
+    permissionStatus,
+    sources,
+    connectGoogle,
+    isConnectingGoogle,
+  } = useCalendarStore();
   const setIsSettingsOpen = useSettingsStore((s) => s.setIsSettingsOpen);
   const setActiveSettingsTab = useSettingsStore((s) => s.setActiveSettingsTab);
 
   const apple = sources.find((s) => s.source === 'apple');
+  const google = sources.find((s) => s.source === 'google');
+  const appleBlocked = permissionStatus === 'Denied' || permissionStatus === 'Restricted';
 
-  // The System Settings deep link and the EventKit permission dance are Apple's
-  // alone. Where EventKit does not exist — Windows, Linux — the only way to get
-  // events is to connect an account, so send the user to Settings instead.
-  if (!apple?.available) {
-    return (
-      <div className="flex-1 flex flex-col items-center justify-center p-2">
-        <ConnectCalendarEmptyState
-          onConnect={() => {
-            setActiveSettingsTab('calendar');
-            setIsSettingsOpen(true);
-          }}
-          isConnecting={false}
-        />
-      </div>
-    );
+  // Offer every source this build actually has rather than assuming Apple.
+  // Picking one for the user was wrong on macOS (where both exist) and
+  // impossible on Windows and Linux (where only Google does).
+  const actions: { label: string; onClick: () => void; variant?: 'primary' | 'secondary' }[] = [];
+
+  if (apple?.available && !apple.connected && !appleBlocked) {
+    actions.push({
+      label: isRequestingPermission ? 'Connecting…' : 'Connect Apple Calendar',
+      onClick: () => void requestPermission(),
+      variant: 'primary',
+    });
+  }
+  if (google?.available && !google.connected) {
+    actions.push({
+      label: isConnectingGoogle ? 'Waiting for your browser…' : 'Connect Google Calendar',
+      onClick: () => void connectGoogle(),
+      variant: actions.length === 0 ? 'primary' : 'secondary',
+    });
   }
 
-  if (permissionStatus === 'Denied' || permissionStatus === 'Restricted') {
+  // Apple denied at the OS level and nothing else to offer: the only way out is
+  // System Settings, so keep the dedicated instructions for that case.
+  if (actions.length === 0 && appleBlocked) {
     return <PermissionDeniedState />;
+  }
+
+  // Nothing connectable from here — a build with no EventKit and no Google
+  // credentials. Settings explains why rather than leaving a dead button.
+  if (actions.length === 0) {
+    actions.push({
+      label: 'Open Calendar Settings',
+      onClick: () => {
+        setActiveSettingsTab('calendar');
+        setIsSettingsOpen(true);
+      },
+      variant: 'primary',
+    });
   }
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center p-2">
-      <ConnectCalendarEmptyState
-        onConnect={() => {
-          void requestPermission();
-        }}
-        isConnecting={isRequestingPermission}
-      />
+      <ConnectCalendarEmptyState actions={actions} />
+      {appleBlocked && (
+        <p className="text-xs mt-2 text-center" style={{ color: 'var(--text-muted)' }}>
+          Apple Calendar access was denied in System Settings.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -14,7 +14,7 @@
  * - **Editor** (`EditorSection`)         — defaults, formatting, writing aids
  * - **Features** (`FeaturesSection`)     — editor / navigation / right-panel
  * - **Sidebar** (`SidebarSection`)       — visibility, sort, panel widths
- * - **Calendar** (`CalendarSection`)     — macOS Calendar.app integration
+ * - **Calendar** (`CalendarSection`)     — Apple and Google calendar sources
  * - **AI & Agents** (`AgentsSection`)    — agent-ready Forge (AGENTS.md)
  * - **Templates** (`SettingsTemplates`)  — template management
  * - **Data** (`SettingsData`)            — bulk import / export actions

--- a/src/components/settings/sections/CalendarSection.tsx
+++ b/src/components/settings/sections/CalendarSection.tsx
@@ -37,6 +37,7 @@ export function CalendarSection() {
     permissionStatus,
     sources,
     isConnectingGoogle,
+    connectError,
     calendars,
     selectedCalendarIds,
     calendarEnabled,
@@ -212,9 +213,9 @@ export function CalendarSection() {
           </>
         ) : (
           <>
-            {google.error && (
+            {(connectError || google.error) && (
               <p className="text-xs" style={{ color: 'var(--error)' }}>
-                {google.error}
+                {connectError ?? google.error}
               </p>
             )}
             <button

--- a/src/components/settings/sections/CalendarSection.tsx
+++ b/src/components/settings/sections/CalendarSection.tsx
@@ -1,143 +1,248 @@
 /**
- * CalendarSection — macOS Calendar.app integration (permission, source, display options).
+ * CalendarSection — one block per calendar source (Apple EventKit, Google),
+ * then display options and a per-calendar selection spanning both.
+ *
+ * Sources differ in kind, not just in wording: Apple is an OS permission the
+ * user grants in System Settings, Google is an account connection the app can
+ * make and break itself. Each block is rendered from `sources`, so a build
+ * without EventKit or without Google credentials simply omits that block.
  */
 
 import { useEffect } from 'react';
-import { Calendar, Check, Lock, RefreshCw } from 'lucide-react';
+import { Calendar, Check, Link2, Lock, RefreshCw, Unlink } from 'lucide-react';
 import { useCalendarStore } from '@/stores/calendarStore';
+import type { CalendarInfo, CalendarSource } from '@/types';
 import { Toggle } from '../common';
+
+const REFRESH_INTERVALS = [5, 15, 30, 60];
+
+const SOURCE_LABEL: Record<CalendarSource, string> = {
+  apple: 'Apple Calendar',
+  google: 'Google Calendar',
+};
+
+/** Group calendars under their source so the list reads as two lists. */
+function groupBySource(calendars: CalendarInfo[]): [CalendarSource, CalendarInfo[]][] {
+  const order: CalendarSource[] = ['apple', 'google'];
+  return order
+    .map((source) => [source, calendars.filter((c) => c.source === source)] as const)
+    .filter(([, list]) => list.length > 0)
+    .map(([source, list]) => [source, list]);
+}
 
 export function CalendarSection() {
   const {
     isAuthorized,
     isRequestingPermission,
     permissionStatus,
+    sources,
+    isConnectingGoogle,
     calendars,
-    selectedCalendarId,
+    selectedCalendarIds,
     calendarEnabled,
     showAllDayEvents,
+    refreshIntervalMinutes,
     requestPermission,
-    fetchCalendars,
-    setSelectedCalendarId,
+    connectGoogle,
+    disconnectGoogle,
+    toggleCalendarSelected,
     setCalendarEnabled,
     setShowAllDayEvents,
+    setRefreshIntervalMinutes,
     checkPermission,
   } = useCalendarStore();
 
-  const handleRequestPermission = async () => {
-    await requestPermission();
-  };
-
-  // Check permission and fetch calendars on mount
   useEffect(() => {
     checkPermission();
   }, [checkPermission]);
 
-  // Fetch calendars when authorized
-  useEffect(() => {
-    if (isAuthorized && calendars.length === 0) {
-      fetchCalendars();
-    }
-  }, [isAuthorized, calendars.length, fetchCalendars]);
+  const apple = sources.find((s) => s.source === 'apple');
+  const google = sources.find((s) => s.source === 'google');
+  const anyConnected = sources.some((s) => s.available && s.connected);
+  const grouped = groupBySource(calendars);
+
+  const panel = {
+    backgroundColor: 'var(--bg-panel)',
+    borderRadius: 'var(--radius-md)',
+  };
 
   return (
     <div className="space-y-6">
-      {/* Permission Status Section */}
-      <div
-        className="p-4 space-y-4"
-        style={{ backgroundColor: 'var(--bg-panel)', borderRadius: 'var(--radius-md)' }}
-      >
+      {/* Apple Calendar — OS permission, macOS only */}
+      {apple?.available && (
+        <div className="p-4 space-y-4" style={panel}>
+          <div>
+            <h3 className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+              Apple Calendar
+            </h3>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+              Display events from Calendar.app in your timeline
+            </p>
+          </div>
+
+          {isAuthorized ? (
+            <div
+              className="flex items-center gap-3 p-3"
+              style={{
+                backgroundColor: 'rgba(90, 138, 110, 0.15)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid var(--success)',
+              }}
+            >
+              <div
+                aria-hidden="true"
+                className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0"
+                style={{ backgroundColor: 'rgba(90, 138, 110, 0.2)' }}
+              >
+                <Check className="w-4 h-4" style={{ color: 'var(--success)' }} />
+              </div>
+              <div>
+                <p className="text-sm font-medium" style={{ color: 'var(--success)' }}>
+                  Calendar Access Enabled
+                </p>
+                <p className="text-xs" style={{ color: 'var(--success)', opacity: 0.8 }}>
+                  Connected to Calendar.app
+                </p>
+              </div>
+            </div>
+          ) : permissionStatus === 'Denied' || permissionStatus === 'Restricted' ? (
+            <div
+              className="p-3"
+              style={{
+                backgroundColor: 'rgba(184, 92, 92, 0.15)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid var(--error)',
+              }}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Lock aria-hidden="true" className="w-4 h-4" style={{ color: 'var(--error)' }} />
+                <p className="text-sm font-medium" style={{ color: 'var(--error)' }}>
+                  Access Denied
+                </p>
+              </div>
+              <p className="text-xs mb-2" style={{ color: 'var(--error)', opacity: 0.9 }}>
+                Calendar access was denied. To enable:
+              </p>
+              <ol
+                className="text-xs list-decimal list-inside space-y-1"
+                style={{ color: 'var(--error)', opacity: 0.9 }}
+              >
+                <li>Open System Settings</li>
+                <li>Go to Privacy &amp; Security → Calendars</li>
+                <li>Enable access for Moldavite</li>
+              </ol>
+            </div>
+          ) : (
+            <button
+              onClick={() => requestPermission()}
+              disabled={isRequestingPermission}
+              className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium text-white transition-colors disabled:opacity-50"
+              style={{ backgroundColor: 'var(--accent-primary)', borderRadius: 'var(--radius-sm)' }}
+            >
+              {isRequestingPermission ? (
+                <>
+                  <RefreshCw aria-hidden="true" className="w-4 h-4 animate-spin" />
+                  Requesting...
+                </>
+              ) : (
+                <>
+                  <Calendar aria-hidden="true" className="w-4 h-4" />
+                  Enable Calendar Access
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Google Calendar — account connection the app owns */}
+      <div className="p-4 space-y-4" style={panel}>
         <div>
           <h3 className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-            Calendar Access
+            Google Calendar
           </h3>
           <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-            Display events from Calendar.app in your timeline
+            Read-only access to your Google events. Moldavite never creates or changes them.
           </p>
         </div>
 
-        {isAuthorized ? (
-          <div
-            className="flex items-center gap-3 p-3"
-            style={{
-              backgroundColor: 'rgba(90, 138, 110, 0.15)',
-              borderRadius: 'var(--radius-sm)',
-              border: '1px solid var(--success)',
-            }}
-          >
+        {!google?.available ? (
+          <p className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+            {google?.error ?? 'Google Calendar is not available in this build.'}
+          </p>
+        ) : google.connected ? (
+          <>
             <div
-              aria-hidden="true"
-              className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0"
-              style={{ backgroundColor: 'rgba(90, 138, 110, 0.2)' }}
+              className="flex items-center gap-3 p-3"
+              style={{
+                backgroundColor: 'rgba(90, 138, 110, 0.15)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid var(--success)',
+              }}
             >
-              <Check className="w-4 h-4" style={{ color: 'var(--success)' }} />
+              <div
+                aria-hidden="true"
+                className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0"
+                style={{ backgroundColor: 'rgba(90, 138, 110, 0.2)' }}
+              >
+                <Check className="w-4 h-4" style={{ color: 'var(--success)' }} />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-medium" style={{ color: 'var(--success)' }}>
+                  Connected
+                </p>
+                <p className="text-xs truncate" style={{ color: 'var(--success)', opacity: 0.8 }}>
+                  {google.account ?? 'Google account'}
+                </p>
+              </div>
             </div>
-            <div>
-              <p className="text-sm font-medium" style={{ color: 'var(--success)' }}>
-                Calendar Access Enabled
-              </p>
-              <p className="text-xs" style={{ color: 'var(--success)', opacity: 0.8 }}>
-                Connected to Calendar.app
-              </p>
-            </div>
-          </div>
-        ) : permissionStatus === 'Denied' || permissionStatus === 'Restricted' ? (
-          <div
-            className="p-3"
-            style={{
-              backgroundColor: 'rgba(184, 92, 92, 0.15)',
-              borderRadius: 'var(--radius-sm)',
-              border: '1px solid var(--error)',
-            }}
-          >
-            <div className="flex items-center gap-2 mb-2">
-              <Lock aria-hidden="true" className="w-4 h-4" style={{ color: 'var(--error)' }} />
-              <p className="text-sm font-medium" style={{ color: 'var(--error)' }}>
-                Access Denied
-              </p>
-            </div>
-            <p className="text-xs mb-2" style={{ color: 'var(--error)', opacity: 0.9 }}>
-              Calendar access was denied. To enable:
-            </p>
-            <ol
-              className="text-xs list-decimal list-inside space-y-1"
-              style={{ color: 'var(--error)', opacity: 0.9 }}
+            <button
+              onClick={() => disconnectGoogle()}
+              className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors"
+              style={{
+                backgroundColor: 'var(--bg-elevated)',
+                border: '1px solid var(--border-default)',
+                borderRadius: 'var(--radius-sm)',
+                color: 'var(--text-secondary)',
+              }}
             >
-              <li>Open System Settings</li>
-              <li>Go to Privacy & Security → Calendars</li>
-              <li>Enable access for Moldavite</li>
-            </ol>
-          </div>
+              <Unlink aria-hidden="true" className="w-4 h-4" />
+              Disconnect
+            </button>
+          </>
         ) : (
-          <button
-            onClick={handleRequestPermission}
-            disabled={isRequestingPermission}
-            className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium text-white transition-colors disabled:opacity-50"
-            style={{ backgroundColor: 'var(--accent-primary)', borderRadius: 'var(--radius-sm)' }}
-          >
-            {isRequestingPermission ? (
-              <>
-                <RefreshCw aria-hidden="true" className="w-4 h-4 animate-spin" />
-                Requesting...
-              </>
-            ) : (
-              <>
-                <Calendar aria-hidden="true" className="w-4 h-4" />
-                Enable Calendar Access
-              </>
+          <>
+            {google.error && (
+              <p className="text-xs" style={{ color: 'var(--error)' }}>
+                {google.error}
+              </p>
             )}
-          </button>
+            <button
+              onClick={() => connectGoogle()}
+              disabled={isConnectingGoogle}
+              className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium text-white transition-colors disabled:opacity-50"
+              style={{ backgroundColor: 'var(--accent-primary)', borderRadius: 'var(--radius-sm)' }}
+            >
+              {isConnectingGoogle ? (
+                <>
+                  <RefreshCw aria-hidden="true" className="w-4 h-4 animate-spin" />
+                  Waiting for your browser...
+                </>
+              ) : (
+                <>
+                  <Link2 aria-hidden="true" className="w-4 h-4" />
+                  Connect Google Account
+                </>
+              )}
+            </button>
+          </>
         )}
       </div>
 
-      {/* Calendar Settings (only show when authorized) */}
-      {isAuthorized && (
+      {anyConnected && (
         <>
-          {/* Display Options Section */}
-          <div
-            className="p-4 space-y-1"
-            style={{ backgroundColor: 'var(--bg-panel)', borderRadius: 'var(--radius-md)' }}
-          >
+          {/* Display Options */}
+          <div className="p-4 space-y-1" style={panel}>
             <h3 className="text-sm font-medium mb-3" style={{ color: 'var(--text-primary)' }}>
               Display Options
             </h3>
@@ -168,26 +273,24 @@ export function CalendarSection() {
               </div>
               <Toggle enabled={showAllDayEvents} onChange={setShowAllDayEvents} />
             </div>
-          </div>
 
-          {/* Calendar Selection */}
-          {calendars.length > 0 && (
             <div
-              className="p-4 space-y-4"
-              style={{ backgroundColor: 'var(--bg-panel)', borderRadius: 'var(--radius-md)' }}
+              className="flex items-center justify-between py-2"
+              style={{ borderTop: '1px solid var(--border-muted)' }}
             >
               <div>
-                <h3 className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                  Calendar Source
-                </h3>
-                <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
-                  Choose which calendar to display
+                <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+                  Refresh Every
+                </span>
+                <p className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+                  How often connected accounts are checked for changes
                 </p>
               </div>
               <select
-                value={selectedCalendarId || ''}
-                onChange={(e) => setSelectedCalendarId(e.target.value || null)}
-                className="w-full px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                value={refreshIntervalMinutes}
+                onChange={(e) => setRefreshIntervalMinutes(Number(e.target.value))}
+                aria-label="Refresh interval"
+                className="px-2 py-1 text-sm focus:outline-none focus:ring-2"
                 style={{
                   backgroundColor: 'var(--bg-elevated)',
                   border: '1px solid var(--border-default)',
@@ -195,13 +298,58 @@ export function CalendarSection() {
                   color: 'var(--text-primary)',
                 }}
               >
-                <option value="">All Calendars</option>
-                {calendars.map((cal) => (
-                  <option key={cal.id} value={cal.id}>
-                    {cal.title}
+                {REFRESH_INTERVALS.map((minutes) => (
+                  <option key={minutes} value={minutes}>
+                    {minutes} min
                   </option>
                 ))}
               </select>
+            </div>
+          </div>
+
+          {/* Calendar selection across both sources */}
+          {calendars.length > 0 && (
+            <div className="p-4 space-y-4" style={panel}>
+              <div>
+                <h3 className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                  Calendars
+                </h3>
+                <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+                  {selectedCalendarIds.length === 0
+                    ? 'All calendars are shown. Tick any to narrow it down.'
+                    : `${selectedCalendarIds.length} selected`}
+                </p>
+              </div>
+
+              {grouped.map(([source, list]) => (
+                <div key={source} className="space-y-1">
+                  <p
+                    className="text-xs font-medium uppercase tracking-wide"
+                    style={{ color: 'var(--text-tertiary)' }}
+                  >
+                    {SOURCE_LABEL[source]}
+                  </p>
+                  {list.map((cal) => (
+                    <label
+                      key={cal.id}
+                      className="flex items-center gap-2 py-1 cursor-pointer text-sm"
+                      style={{ color: 'var(--text-secondary)' }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedCalendarIds.includes(cal.id)}
+                        onChange={() => toggleCalendarSelected(cal.id)}
+                      />
+                      <span
+                        aria-hidden="true"
+                        className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                        style={{ backgroundColor: cal.color || 'var(--accent-primary)' }}
+                      />
+                      <span className="truncate">{cal.title}</span>
+                    </label>
+                  ))}
+                </div>
+              ))}
             </div>
           )}
         </>

--- a/src/components/settings/sections/FeaturesSection.tsx
+++ b/src/components/settings/sections/FeaturesSection.tsx
@@ -148,7 +148,7 @@ export function FeaturesSection() {
                 <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>
                   Timeline Widget
                 </span>
-                <InfoTooltip text="Shows your daily schedule with events from Apple Calendar (requires Calendar access)." />
+                <InfoTooltip text="Shows your daily schedule with events from Apple Calendar or Google Calendar (connect a source in Settings → Calendar)." />
               </div>
               <Toggle
                 enabled={settings.showTimelineWidget}

--- a/src/components/timeline/TimelineView.tsx
+++ b/src/components/timeline/TimelineView.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Calendar, FileText, X } from 'lucide-react';
 import { format, parseISO, isValid as isValidDate } from 'date-fns';
-import { safeInvoke as invoke } from '@/lib/ipc';
 import { useNoteStore, useTimelineStore } from '@/stores';
+import { useCalendarStore } from '@/stores/calendarStore';
 import { useNotes } from '@/hooks';
 import { readNote, noteFileBackendPath } from '@/lib';
-import type { CalendarEvent, CalendarPermission, NoteFile } from '@/types';
+import { fetchCalendarEvents, listCalendarSources } from '@/lib/calendar';
+import type { CalendarEvent, NoteFile } from '@/types';
 
 type BucketId = 'today' | 'yesterday' | 'thisWeek' | 'thisMonth' | 'earlier';
 
@@ -44,17 +45,21 @@ export function TimelineView() {
   // (we don't have an fs-mtime exposed by the backend — see report).
   const buckets = useMemo(() => bucketNotes(notes), [notes]);
 
-  // Kick off calendar-event fetch. If the permission probe fails for any
-  // reason (non-macOS, user denied, etc.), stay silent — the spec explicitly
-  // forbids nagging the user from the Timeline.
+  // Kick off calendar-event fetch. This goes through the calendar library
+  // rather than invoking directly, so it sees every connected source and
+  // honours the calendar selection — a direct invoke would have shown Apple
+  // events only once Google existed. One range covers both days.
+  //
+  // Failures stay silent: the spec forbids nagging the user from the Timeline,
+  // and an unconnected or unavailable source is not an error here.
   useEffect(() => {
     let cancelled = false;
 
     const loadEvents = async () => {
       try {
-        const permission = await invoke<CalendarPermission>('get_calendar_permission');
+        const sources = await listCalendarSources();
         if (cancelled) return;
-        if (permission !== 'Authorized' && permission !== 'FullAccess') return;
+        if (!sources.some((s) => s.available && s.connected)) return;
 
         const today = new Date();
         const yesterday = new Date(today);
@@ -62,25 +67,15 @@ export function TimelineView() {
         const todayStr = format(today, 'yyyy-MM-dd');
         const yesterdayStr = format(yesterday, 'yyyy-MM-dd');
 
-        const [todays, yests] = await Promise.all([
-          invoke<CalendarEvent[]>('fetch_calendar_events', {
-            startDate: todayStr,
-            endDate: todayStr,
-            calendarId: null,
-          }),
-          invoke<CalendarEvent[]>('fetch_calendar_events', {
-            startDate: yesterdayStr,
-            endDate: yesterdayStr,
-            calendarId: null,
-          }),
-        ]);
+        const { selectedCalendarIds } = useCalendarStore.getState();
+        const { events } = await fetchCalendarEvents(yesterdayStr, todayStr, selectedCalendarIds);
 
         if (!cancelled) {
-          setTodayEvents(todays);
-          setYesterdayEvents(yests);
+          setTodayEvents(events.filter((e) => e.start.startsWith(todayStr)));
+          setYesterdayEvents(events.filter((e) => e.start.startsWith(yesterdayStr)));
         }
       } catch {
-        // Non-macOS build, or calendar plugin unavailable — silently skip.
+        // No calendar source available in this build — silently skip.
       }
     };
 

--- a/src/components/timeline/TimelineView.tsx
+++ b/src/components/timeline/TimelineView.tsx
@@ -71,8 +71,16 @@ export function TimelineView() {
         const { events } = await fetchCalendarEvents(yesterdayStr, todayStr, selectedCalendarIds);
 
         if (!cancelled) {
-          setTodayEvents(events.filter((e) => e.start.startsWith(todayStr)));
-          setYesterdayEvents(events.filter((e) => e.start.startsWith(yesterdayStr)));
+          // Bucket on the parsed instant, not the leading characters. Apple
+          // serialises in UTC and Google in the calendar's own offset, so the
+          // text prefix is not the local date: a 21:00 event in New York
+          // starts "<tomorrow>T01:00:00Z" and would vanish from both buckets,
+          // while yesterday's 21:00 would surface under Today. `parseISO`
+          // reads a bare `yyyy-MM-dd` as local midnight, so Google's all-day
+          // values still land on the right day.
+          const localDay = (e: CalendarEvent) => format(parseISO(e.start), 'yyyy-MM-dd');
+          setTodayEvents(events.filter((e) => localDay(e) === todayStr));
+          setYesterdayEvents(events.filter((e) => localDay(e) === yesterdayStr));
         }
       } catch {
         // No calendar source available in this build — silently skip.

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -245,12 +245,14 @@ export function NoEventsEmptyState() {
   );
 }
 
+/**
+ * Which sources are offered depends on the platform and the build, so the
+ * caller supplies the buttons rather than this component assuming one.
+ */
 export function ConnectCalendarEmptyState({
-  onConnect,
-  isConnecting,
+  actions,
 }: {
-  onConnect: () => void;
-  isConnecting: boolean;
+  actions: { label: string; onClick: () => void; variant?: 'primary' | 'secondary' }[];
 }) {
   return (
     <EmptyState
@@ -273,16 +275,10 @@ export function ConnectCalendarEmptyState({
       message="View your daily schedule alongside your notes"
       features={[
         'See all your events at a glance',
-        'Works with iCloud, Google & Exchange',
-        'Completely private - stays on your Mac',
+        'Read-only — Moldavite never changes an event',
+        'Add or remove sources any time in Settings',
       ]}
-      actions={[
-        {
-          label: isConnecting ? 'Connecting...' : 'Enable Calendar Access',
-          onClick: onConnect,
-          variant: 'primary',
-        },
-      ]}
+      actions={actions}
       variant="card"
       iconColor="text-blue-400 dark:text-blue-500"
     />

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,14 +1,22 @@
 /**
- * Typed IPC boundary for macOS calendar permission, calendars, and event ranges.
- * The Rust/Swift bridge owns authorization and date filtering; callers must not
- * infer authorization from an empty result set.
+ * Typed IPC boundary for calendar sources, calendars, and event ranges.
+ *
+ * The Rust layer owns authorization, source dispatch, and date filtering, and
+ * it merges Apple and Google results behind one call. Callers must not infer
+ * authorization from an empty result set, and must not assume a fetch that
+ * returned events had no failures — check `errors`.
  */
 
 import { safeInvoke as invoke } from './ipc';
-import type { CalendarEvent, CalendarInfo, CalendarPermission } from '@/types';
+import type {
+  CalendarFetchResult,
+  CalendarInfo,
+  CalendarPermission,
+  CalendarSourceStatus,
+} from '@/types';
 
 /**
- * Gets the current calendar access permission status.
+ * Gets the current macOS calendar access permission status.
  * @returns Permission status (Authorized, Denied, NotDetermined, etc.)
  */
 export async function getCalendarPermission(): Promise<CalendarPermission> {
@@ -16,7 +24,7 @@ export async function getCalendarPermission(): Promise<CalendarPermission> {
 }
 
 /**
- * Requests calendar access permission from the user.
+ * Requests macOS calendar access from the user.
  * Shows the system permission dialog on first request.
  * @returns True if permission was granted
  */
@@ -25,7 +33,7 @@ export async function requestCalendarPermission(): Promise<boolean> {
 }
 
 /**
- * Checks if calendar access has been authorized.
+ * Checks if macOS calendar access has been authorized.
  * @returns True if the app has calendar access
  */
 export async function isCalendarAuthorized(): Promise<boolean> {
@@ -33,28 +41,48 @@ export async function isCalendarAuthorized(): Promise<boolean> {
 }
 
 /**
- * Fetches calendar events for a date range.
+ * Connection state for every calendar source this build supports.
+ * @returns One status per source, including unavailable ones and why
+ */
+export async function listCalendarSources(): Promise<CalendarSourceStatus[]> {
+  return await invoke('list_calendar_sources');
+}
+
+/**
+ * Fetches calendar events for a date range across every connected source.
  * @param startDate - Start date in YYYY-MM-DD format
  * @param endDate - End date in YYYY-MM-DD format
- * @param calendarId - Optional calendar ID to filter by specific calendar
- * @returns Array of calendar events
+ * @param calendarIds - Namespaced calendar ids to include; empty means all
+ * @returns Merged events plus any per-source failures
  */
 export async function fetchCalendarEvents(
   startDate: string,
   endDate: string,
-  calendarId?: string
-): Promise<CalendarEvent[]> {
-  return await invoke('fetch_calendar_events', {
-    startDate,
-    endDate,
-    calendarId: calendarId || null,
-  });
+  calendarIds: string[] = []
+): Promise<CalendarFetchResult> {
+  return await invoke('fetch_calendar_events', { startDate, endDate, calendarIds });
 }
 
 /**
- * Lists all calendars from the user's Calendar.app.
- * @returns Array of calendar info objects with IDs and names
+ * Lists calendars from every connected source.
+ * @returns Calendar info objects with namespaced ids and their source
  */
 export async function listCalendars(): Promise<CalendarInfo[]> {
   return await invoke('list_calendars');
+}
+
+/**
+ * Runs the Google OAuth flow in the system browser and stores the resulting
+ * refresh token in the OS keychain.
+ * @returns The Google source status after connecting
+ */
+export async function connectGoogleCalendar(): Promise<CalendarSourceStatus> {
+  return await invoke('google_calendar_connect');
+}
+
+/**
+ * Removes the stored Google refresh token and disconnects the account.
+ */
+export async function disconnectGoogleCalendar(): Promise<void> {
+  return await invoke('google_calendar_disconnect');
 }

--- a/src/stores/calendarStore.test.ts
+++ b/src/stores/calendarStore.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { migrateCalendarState } from './calendarStore';
+
+describe('calendar persisted-state migration', () => {
+  it('namespaces a v0 single calendar selection as an Apple id', () => {
+    const migrated = migrateCalendarState(
+      {
+        selectedCalendarId: 'ABC-123',
+        calendarEnabled: true,
+        showAllDayEvents: false,
+        hasSeenOnboarding: true,
+      },
+      0
+    );
+
+    expect(migrated.selectedCalendarIds).toEqual(['apple:ABC-123']);
+    expect(migrated.selectedCalendarId).toBeUndefined();
+    // Unrelated preferences must survive untouched.
+    expect(migrated.calendarEnabled).toBe(true);
+    expect(migrated.showAllDayEvents).toBe(false);
+    expect(migrated.hasSeenOnboarding).toBe(true);
+  });
+
+  it('treats a v0 null selection as "all calendars"', () => {
+    expect(migrateCalendarState({ selectedCalendarId: null }, 0).selectedCalendarIds).toEqual([]);
+    expect(migrateCalendarState({}, 0).selectedCalendarIds).toEqual([]);
+    expect(migrateCalendarState({ selectedCalendarId: '' }, 0).selectedCalendarIds).toEqual([]);
+  });
+
+  it('leaves an already-migrated blob alone', () => {
+    const current = { selectedCalendarIds: ['google:me@example.com', 'apple:X'] };
+    expect(migrateCalendarState(current, 1)).toEqual(current);
+  });
+});

--- a/src/stores/calendarStore.ts
+++ b/src/stores/calendarStore.ts
@@ -45,6 +45,9 @@ function cacheKey(startDate: string, endDate: string, calendarIds: string[]): st
   return `${startDate}|${endDate}|${[...calendarIds].sort().join(',')}`;
 }
 
+/** Monotonic id so a slow fetch cannot overwrite a newer one. */
+let latestRequestId = 0;
+
 interface CalendarState {
   // Apple permission state
   permissionStatus: CalendarPermission;
@@ -54,6 +57,8 @@ interface CalendarState {
   // Source connections
   sources: CalendarSourceStatus[];
   isConnectingGoogle: boolean;
+  /** Failure from the connect flow itself. Shown in Settings, never over the timeline. */
+  connectError: string | null;
 
   // Events state
   events: CalendarEvent[];
@@ -125,6 +130,7 @@ export const useCalendarStore = create<CalendarState>()(
       isRequestingPermission: false,
       sources: [],
       isConnectingGoogle: false,
+      connectError: null,
       events: [],
       isLoadingEvents: false,
       eventsError: null,
@@ -214,14 +220,18 @@ export const useCalendarStore = create<CalendarState>()(
         try {
           const status = await connectGoogleCalendar();
           eventCache.clear();
-          set({ isConnectingGoogle: false });
+          set({ isConnectingGoogle: false, connectError: null });
           await get().refreshSources();
           return status.connected;
         } catch (error) {
           console.error('Google Calendar connection failed:', error);
+          // Deliberately not `eventsError`: that field replaces the whole
+          // timeline pane, so cancelling a Google consent used to hide every
+          // Apple event behind a red error panel. A connection problem belongs
+          // next to the connect button, in Settings.
           set({
             isConnectingGoogle: false,
-            eventsError: error instanceof Error ? error.message : String(error),
+            connectError: error instanceof Error ? error.message : String(error),
           });
           return false;
         }
@@ -265,19 +275,35 @@ export const useCalendarStore = create<CalendarState>()(
         if (!opts?.force) {
           const hit = eventCache.get(key);
           if (hit && Date.now() - hit.at < CALENDAR_EVENTS_CACHE_DURATION) {
+            // Errors belong to the range that produced them. Leaving them set
+            // would carry a failure banner from another day over a good result.
             set({
               events: showAllDayEvents ? hit.events : hit.events.filter((e) => !e.isAllDay),
+              sourceErrors: [],
+              eventsError: null,
               isLoadingEvents: false,
             });
             return;
           }
         }
 
+        // A slow network fetch must not overwrite a newer one. Clicking through
+        // dates resolves out of order easily now that a request can take
+        // seconds; without this the grid can show one day under another's
+        // header.
+        const requestId = ++latestRequestId;
         set({ isLoadingEvents: true, eventsError: null });
 
         try {
           const result = await fetchCalendarEvents(startDate, endDate, selectedCalendarIds);
-          eventCache.set(key, { events: result.events, at: Date.now() });
+          if (requestId !== latestRequestId) return;
+
+          // Only cache a complete answer. Caching a partially-failed fetch
+          // pins the gap in place for the whole TTL, so a source that recovers
+          // seconds later still looks down until the cache expires.
+          if (result.errors.length === 0) {
+            eventCache.set(key, { events: result.events, at: Date.now() });
+          }
 
           set({
             events: showAllDayEvents ? result.events : result.events.filter((e) => !e.isAllDay),
@@ -287,6 +313,7 @@ export const useCalendarStore = create<CalendarState>()(
           });
         } catch (error) {
           console.error('Failed to fetch events:', error);
+          if (requestId !== latestRequestId) return;
           set({
             eventsError: error instanceof Error ? error.message : 'Failed to fetch events',
             isLoadingEvents: false,
@@ -343,10 +370,10 @@ export const useCalendarStore = create<CalendarState>()(
        * Controls whether all-day events are displayed.
        * @param show - True to show all-day events
        */
-      setShowAllDayEvents: (show) => {
-        eventCache.clear();
-        set({ showAllDayEvents: show });
-      },
+      // The cache holds unfiltered events and both read paths apply this
+      // filter, so clearing it here would force a needless network round trip
+      // for a purely local preference.
+      setShowAllDayEvents: (show) => set({ showAllDayEvents: show }),
 
       /**
        * How often connected sources are polled while the app is open. Apple is

--- a/src/stores/calendarStore.ts
+++ b/src/stores/calendarStore.ts
@@ -1,40 +1,75 @@
 /**
- * Calendar authorization, calendar selection, event cache, and loading state.
- * Event results are keyed by the requested range and expire; permission state is
- * authoritative over cached events, while selected calendar ids are user preference.
+ * Calendar source connections, calendar selection, event cache, and loading
+ * state.
+ *
+ * Events can come from macOS EventKit and from Google, and the backend merges
+ * them behind one call. Two consequences shape this store: a fetch reports
+ * per-source failures instead of failing as a whole, so one dead source never
+ * blanks the timeline; and calendar ids are namespaced by source, so the
+ * selection is a plain list of opaque ids rather than anything Apple-shaped.
+ *
+ * `permissionStatus` / `isAuthorized` remain Apple-only — EventKit is the only
+ * source with an OS permission model. Google's state lives in `sources`.
  */
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { CalendarEvent, CalendarInfo, CalendarPermission } from '@/types';
+import type {
+  CalendarEvent,
+  CalendarInfo,
+  CalendarPermission,
+  CalendarSourceError,
+  CalendarSourceStatus,
+} from '@/types';
 import {
   isCalendarAuthorized,
   getCalendarPermission,
   requestCalendarPermission,
   fetchCalendarEvents,
   listCalendars,
+  listCalendarSources,
+  connectGoogleCalendar,
+  disconnectGoogleCalendar,
 } from '@/lib/calendar';
+import { CALENDAR_EVENTS_CACHE_DURATION } from '@/lib/constants';
 import { format } from 'date-fns';
 
+/**
+ * Range results, held outside the store because they are derived data with a
+ * TTL rather than state anyone should subscribe to. Cleared whenever the
+ * selection, a connection, or the all-day preference changes.
+ */
+const eventCache = new Map<string, { events: CalendarEvent[]; at: number }>();
+
+function cacheKey(startDate: string, endDate: string, calendarIds: string[]): string {
+  return `${startDate}|${endDate}|${[...calendarIds].sort().join(',')}`;
+}
+
 interface CalendarState {
-  // Permission state
+  // Apple permission state
   permissionStatus: CalendarPermission;
   isAuthorized: boolean;
   isRequestingPermission: boolean;
+
+  // Source connections
+  sources: CalendarSourceStatus[];
+  isConnectingGoogle: boolean;
 
   // Events state
   events: CalendarEvent[];
   isLoadingEvents: boolean;
   eventsError: string | null;
+  sourceErrors: CalendarSourceError[];
   lastSynced: Date | null;
 
   // Calendars
   calendars: CalendarInfo[];
-  selectedCalendarId: string | null;
+  selectedCalendarIds: string[];
 
   // Settings
   calendarEnabled: boolean;
   showAllDayEvents: boolean;
+  refreshIntervalMinutes: number;
 
   // Onboarding
   hasSeenOnboarding: boolean;
@@ -42,13 +77,43 @@ interface CalendarState {
   // Actions
   checkPermission: () => Promise<void>;
   requestPermission: () => Promise<boolean>;
-  fetchEvents: (date: Date) => Promise<void>;
+  refreshSources: () => Promise<void>;
+  connectGoogle: () => Promise<boolean>;
+  disconnectGoogle: () => Promise<void>;
+  fetchEvents: (start: Date, end?: Date, opts?: { force?: boolean }) => Promise<void>;
   fetchCalendars: () => Promise<void>;
-  setSelectedCalendarId: (id: string | null) => void;
+  toggleCalendarSelected: (id: string) => void;
+  setSelectedCalendarIds: (ids: string[]) => void;
   setCalendarEnabled: (enabled: boolean) => void;
   setShowAllDayEvents: (show: boolean) => void;
+  setRefreshIntervalMinutes: (minutes: number) => void;
   setHasSeenOnboarding: (seen: boolean) => void;
   clearEvents: () => void;
+}
+
+/** Any source the user has actually connected. */
+function hasConnectedSource(sources: CalendarSourceStatus[]): boolean {
+  return sources.some((s) => s.available && s.connected);
+}
+
+/**
+ * v0 stored a single `selectedCalendarId` holding a bare EventKit id, with
+ * `null` meaning "all calendars". Ids carry a source prefix now, so carry the
+ * choice forward as `apple:<id>` and let `null` become the empty list, which
+ * still means all.
+ *
+ * Exported for tests: an upgrade that silently dropped the user's calendar
+ * choice would look like the app forgetting a setting, which is exactly the
+ * kind of regression a migration is supposed to prevent.
+ */
+export function migrateCalendarState(persisted: unknown, version: number): Record<string, unknown> {
+  const state = (persisted ?? {}) as Record<string, unknown>;
+  if (version === 0) {
+    const legacy = state.selectedCalendarId;
+    state.selectedCalendarIds = typeof legacy === 'string' && legacy ? [`apple:${legacy}`] : [];
+    delete state.selectedCalendarId;
+  }
+  return state;
 }
 
 export const useCalendarStore = create<CalendarState>()(
@@ -58,45 +123,45 @@ export const useCalendarStore = create<CalendarState>()(
       permissionStatus: 'NotDetermined',
       isAuthorized: false,
       isRequestingPermission: false,
+      sources: [],
+      isConnectingGoogle: false,
       events: [],
       isLoadingEvents: false,
       eventsError: null,
+      sourceErrors: [],
       lastSynced: null,
       calendars: [],
-      selectedCalendarId: null,
+      selectedCalendarIds: [],
       calendarEnabled: true,
       showAllDayEvents: true,
+      refreshIntervalMinutes: 15,
       hasSeenOnboarding: false,
 
       /**
-       * Checks the current calendar permission status and fetches calendars if authorized.
+       * Checks the current macOS calendar permission and refreshes source state.
        */
       checkPermission: async () => {
         try {
           const status = await getCalendarPermission();
           const authorized = await isCalendarAuthorized();
           set({ permissionStatus: status, isAuthorized: authorized });
-
-          // If authorized, fetch calendars
-          if (authorized) {
-            await get().fetchCalendars();
-          }
-        } catch (error) {
-          console.error('Failed to check permission:', error);
+        } catch {
+          // Non-macOS builds have no EventKit commands at all; that is not an
+          // error, it just means Apple is not an available source here.
           set({ permissionStatus: 'NotDetermined', isAuthorized: false });
         }
+        await get().refreshSources();
       },
 
       /**
-       * Requests calendar access permission from the user.
-       * Includes a small delay to ensure the app window is focused before showing the system dialog.
-       * Fetches calendars if permission is granted.
+       * Requests macOS calendar access from the user.
+       * Includes a small delay so the app window is focused before the system
+       * dialog appears.
        * @returns True if permission was granted
        */
       requestPermission: async () => {
         set({ isRequestingPermission: true });
         try {
-          // Small delay to ensure window is focused before system dialog appears
           await new Promise((resolve) => setTimeout(resolve, 100));
 
           const granted = await requestCalendarPermission();
@@ -107,9 +172,9 @@ export const useCalendarStore = create<CalendarState>()(
             isRequestingPermission: false,
           });
 
-          // Fetch calendars if granted
           if (granted) {
-            await get().fetchCalendars();
+            eventCache.clear();
+            await get().refreshSources();
           }
 
           return granted;
@@ -121,32 +186,102 @@ export const useCalendarStore = create<CalendarState>()(
       },
 
       /**
-       * Fetches calendar events for a specific date.
-       * Respects calendar enabled setting and filters based on all-day event preference.
-       * @param date - The date to fetch events for
+       * Reloads per-source availability and connection state, and the calendar
+       * list when anything is connected.
        */
-      fetchEvents: async (date: Date) => {
-        const { calendarEnabled, selectedCalendarId, showAllDayEvents, isAuthorized } = get();
+      refreshSources: async () => {
+        try {
+          const sources = await listCalendarSources();
+          set({ sources });
+          if (hasConnectedSource(sources)) {
+            await get().fetchCalendars();
+          } else {
+            set({ calendars: [] });
+          }
+        } catch (error) {
+          console.error('Failed to list calendar sources:', error);
+          set({ sources: [] });
+        }
+      },
 
-        if (!calendarEnabled || !isAuthorized) {
+      /**
+       * Runs the Google OAuth flow. The browser handoff happens in Rust, so
+       * this resolves only once the user finishes or abandons consent.
+       * @returns True if an account was connected
+       */
+      connectGoogle: async () => {
+        set({ isConnectingGoogle: true });
+        try {
+          const status = await connectGoogleCalendar();
+          eventCache.clear();
+          set({ isConnectingGoogle: false });
+          await get().refreshSources();
+          return status.connected;
+        } catch (error) {
+          console.error('Google Calendar connection failed:', error);
+          set({
+            isConnectingGoogle: false,
+            eventsError: error instanceof Error ? error.message : String(error),
+          });
+          return false;
+        }
+      },
+
+      /**
+       * Disconnects Google and drops its calendars from the selection, so a
+       * later reconnect does not silently restore a stale choice.
+       */
+      disconnectGoogle: async () => {
+        try {
+          await disconnectGoogleCalendar();
+        } catch (error) {
+          console.error('Google Calendar disconnect failed:', error);
+        }
+        eventCache.clear();
+        set((state) => ({
+          selectedCalendarIds: state.selectedCalendarIds.filter((id) => !id.startsWith('google:')),
+          events: state.events.filter((e) => e.source !== 'google'),
+        }));
+        await get().refreshSources();
+      },
+
+      /**
+       * Fetches events for a date range across every connected source.
+       * @param start - First day of the range
+       * @param end - Last day of the range; defaults to `start`
+       * @param opts - `force` bypasses the TTL cache (the manual refresh button)
+       */
+      fetchEvents: async (start: Date, end?: Date, opts?: { force?: boolean }) => {
+        const { calendarEnabled, selectedCalendarIds, showAllDayEvents, sources } = get();
+
+        if (!calendarEnabled || !hasConnectedSource(sources)) {
           return;
+        }
+
+        const startDate = format(start, 'yyyy-MM-dd');
+        const endDate = format(end ?? start, 'yyyy-MM-dd');
+        const key = cacheKey(startDate, endDate, selectedCalendarIds);
+
+        if (!opts?.force) {
+          const hit = eventCache.get(key);
+          if (hit && Date.now() - hit.at < CALENDAR_EVENTS_CACHE_DURATION) {
+            set({
+              events: showAllDayEvents ? hit.events : hit.events.filter((e) => !e.isAllDay),
+              isLoadingEvents: false,
+            });
+            return;
+          }
         }
 
         set({ isLoadingEvents: true, eventsError: null });
 
         try {
-          const dateStr = format(date, 'yyyy-MM-dd');
-          const events = await fetchCalendarEvents(
-            dateStr,
-            dateStr,
-            selectedCalendarId || undefined
-          );
-
-          // Filter all-day events if disabled
-          const filteredEvents = showAllDayEvents ? events : events.filter((e) => !e.isAllDay);
+          const result = await fetchCalendarEvents(startDate, endDate, selectedCalendarIds);
+          eventCache.set(key, { events: result.events, at: Date.now() });
 
           set({
-            events: filteredEvents,
+            events: showAllDayEvents ? result.events : result.events.filter((e) => !e.isAllDay),
+            sourceErrors: result.errors,
             isLoadingEvents: false,
             lastSynced: new Date(),
           });
@@ -160,27 +295,43 @@ export const useCalendarStore = create<CalendarState>()(
       },
 
       /**
-       * Fetches the list of available calendars from the user's Calendar.app.
-       * Automatically selects the first calendar if none is selected.
+       * Reloads the calendar list and drops selections whose calendar no longer
+       * exists, so a removed calendar cannot silently filter everything out.
        */
       fetchCalendars: async () => {
         try {
           const calendars = await listCalendars();
-          // Select first calendar if none selected
-          set({
+          const live = new Set(calendars.map((c) => c.id));
+          set((state) => ({
             calendars,
-            selectedCalendarId: get().selectedCalendarId || calendars[0]?.id || null,
-          });
+            selectedCalendarIds: state.selectedCalendarIds.filter((id) => live.has(id)),
+          }));
         } catch (error) {
           console.error('Failed to fetch calendars:', error);
         }
       },
 
       /**
-       * Sets which calendar to display events from.
-       * @param id - Calendar ID, or null for all calendars
+       * Adds or removes one calendar from the selection.
+       * @param id - Namespaced calendar id
        */
-      setSelectedCalendarId: (id) => set({ selectedCalendarId: id }),
+      toggleCalendarSelected: (id) => {
+        eventCache.clear();
+        set((state) => ({
+          selectedCalendarIds: state.selectedCalendarIds.includes(id)
+            ? state.selectedCalendarIds.filter((c) => c !== id)
+            : [...state.selectedCalendarIds, id],
+        }));
+      },
+
+      /**
+       * Replaces the selection outright. An empty list means every calendar.
+       * @param ids - Namespaced calendar ids
+       */
+      setSelectedCalendarIds: (ids) => {
+        eventCache.clear();
+        set({ selectedCalendarIds: ids });
+      },
 
       /**
        * Enables or disables calendar integration.
@@ -192,7 +343,17 @@ export const useCalendarStore = create<CalendarState>()(
        * Controls whether all-day events are displayed.
        * @param show - True to show all-day events
        */
-      setShowAllDayEvents: (show) => set({ showAllDayEvents: show }),
+      setShowAllDayEvents: (show) => {
+        eventCache.clear();
+        set({ showAllDayEvents: show });
+      },
+
+      /**
+       * How often connected sources are polled while the app is open. Apple is
+       * local and cheap; Google is rate-limited, which is what this bounds.
+       * @param minutes - Refresh interval
+       */
+      setRefreshIntervalMinutes: (minutes) => set({ refreshIntervalMinutes: minutes }),
 
       /**
        * Marks the onboarding as seen.
@@ -201,16 +362,23 @@ export const useCalendarStore = create<CalendarState>()(
       setHasSeenOnboarding: (seen) => set({ hasSeenOnboarding: seen }),
 
       /**
-       * Clears all loaded events and sync timestamp.
+       * Clears all loaded events, cached ranges, and the sync timestamp.
        */
-      clearEvents: () => set({ events: [], lastSynced: null }),
+      clearEvents: () => {
+        eventCache.clear();
+        set({ events: [], sourceErrors: [], lastSynced: null });
+      },
     }),
     {
       name: 'moldavite-calendar',
+      version: 1,
+      migrate: (persisted, version) =>
+        migrateCalendarState(persisted, version) as unknown as CalendarState,
       partialize: (state) => ({
         calendarEnabled: state.calendarEnabled,
         showAllDayEvents: state.showAllDayEvents,
-        selectedCalendarId: state.selectedCalendarId,
+        selectedCalendarIds: state.selectedCalendarIds,
+        refreshIntervalMinutes: state.refreshIntervalMinutes,
         hasSeenOnboarding: state.hasSeenOnboarding,
       }),
     }

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,5 +1,15 @@
+/**
+ * Calendar events reach the app from more than one place: macOS EventKit and
+ * the Google Calendar API. Ids from those two namespaces can collide, so the
+ * Rust layer prefixes every event and calendar id with its source
+ * (`apple:<uid>`, `google:<id>`) and carries `source` alongside it. Treat both
+ * as opaque here — splitting them is the backend's job.
+ */
+export type CalendarSource = 'apple' | 'google';
+
 export interface CalendarEvent {
   id: string;
+  source: CalendarSource;
   title: string;
   start: string;
   end: string;
@@ -14,6 +24,7 @@ export interface CalendarEvent {
 
 export interface CalendarInfo {
   id: string;
+  source: CalendarSource;
   title: string;
   color: string;
   isSubscribed: boolean;
@@ -26,3 +37,35 @@ export type CalendarPermission =
   | 'Denied'
   | 'Authorized'
   | 'FullAccess';
+
+/**
+ * Per-source connection state. `available` is about the build and platform
+ * (Apple is macOS-only; Google needs client credentials compiled in), while
+ * `connected` is about this user having granted access.
+ */
+export interface CalendarSourceStatus {
+  source: CalendarSource;
+  available: boolean;
+  connected: boolean;
+  /** Google account email, once connected. */
+  account: string | null;
+  /** EventKit authorization state. Apple only. */
+  permission: CalendarPermission | null;
+  /** Why the source is unavailable or failing, when it is. */
+  error: string | null;
+}
+
+export interface CalendarSourceError {
+  source: CalendarSource;
+  message: string;
+}
+
+/**
+ * A fetch never fails as a whole because one source is down — Google being
+ * unreachable must not blank out Apple's events. Failures arrive in `errors`
+ * next to whatever did load.
+ */
+export interface CalendarFetchResult {
+  events: CalendarEvent[];
+  errors: CalendarSourceError[];
+}


### PR DESCRIPTION
> **Draft — blocked on credentials, not on code.** Nothing here can be exercised end to end until a Google Cloud project and Desktop OAuth client exist. See *Before this can merge* below.
>
> Stacked on #42. Base is `fix/false-conflict-prompt` so the diff shows only this feature; GitHub will retarget to `main` automatically when #42 merges.

## Why

Apple Calendar was the only source, and every calendar command was `#[cfg(target_os = "macos")]` — so Windows and Linux had no calendar at all. Linking a Google account through macOS Internet Accounts doesn't cover the need.

Google Calendar becomes a second source behind the same shape, which also unlocks the whole feature on the other two platforms.

## Backend

`src-tauri/src/calendar.rs` becomes a module directory:

| File | Role |
|---|---|
| `mod.rs` | Shared types, source dispatch, id namespacing. **Compiled unconditionally.** |
| `apple.rs` | The EventKit FFI, moved verbatim, still `cfg(macos)`. Swift bridge untouched. |
| `google.rs` | Calendar API v3, read-only. |
| `oauth.rs` | Installed-app PKCE over a loopback redirect. |

Decisions worth reviewing:

**Ids are namespaced at the module boundary** (`apple:<uid>`, `google:<id>`) because the two id spaces can collide. Nothing above that boundary parses an id — `split_id` is the only thing that does, and it rejects unknown prefixes rather than guessing.

**OAuth runs entirely in Rust.** No token reaches the webview, so the CSP in `tauri.conf.json` needs no `accounts.google.com` exception and a compromised plugin can't read calendar credentials. The loopback listener is a one-shot `TcpListener` on `127.0.0.1:0` with a fixed 200 response — no HTTP-server dependency.

**`singleEvents=true`** makes Google expand recurrence server-side, so there is no RRULE or VTIMEZONE code in this PR at all. That was the main argument against the private-ICS-feed alternative, along with Google caching those feeds for hours.

**A fetch never fails as a whole.** `fetch_calendar_events` returns per-source failures in `errors` alongside whatever loaded — a Google outage must not blank out your Apple events. The timeline renders those as a notice above the grid, not instead of it.

**Client credentials come from `option_env!`.** A build without `MOLDAVITE_GOOGLE_CLIENT_ID` / `_SECRET` still compiles and reports the source unavailable with a clear reason, so local dev works without secrets. Google's "Desktop app" client secret is not confidential by OAuth's own definition; PKCE carries the actual security. Keeping it out of the repo is still right.

**Keychain code moved** out of `commands/plugins.rs` into `secrets.rs`, generalised so the account namespace is caller-supplied. Plugin behaviour and the existing `plugin:{id}:{key}` format are unchanged; calendar uses `calendar:google:refresh_token`.

## Frontend

- `selectedCalendarId` (single, Apple-shaped) → `selectedCalendarIds`, with a **versioned migration** so an existing choice survives the upgrade. The `moldavite-calendar` persist config had no `version` before.
- `TimelineView.tsx` no longer invokes IPC directly. Left alone it would have shown Apple events only, forever, and it also ignored `calendarEnabled` and the calendar selection. Its two round-trips collapse into one range fetch.
- Settings becomes per-source blocks: Apple keeps the EventKit permission UI (including the `x-apple.systempreferences:` deep link, now behind a source check), Google gets Connect / Connected as `<email>` / Disconnect. The single `<select>` becomes a checkbox list grouped by source.
- Adds a range-keyed TTL cache and a user-set refresh interval — EventKit is local and cheap, Google is rate-limited.

## New dependency

One: `reqwest` (rustls, no default features). This is the **first outbound HTTP in the Rust process**, which is why the README's network-call inventory needed editing — that list is exhaustive by design.

## Docs

README network inventory, architecture diagram, and source tree; `PROJECT_STATUS.md`; `guide.html`; `index.html`; CHANGELOG.

Plus **`docs/privacy.html`, a new page.** Google brand verification requires a privacy policy hosted on the app's homepage domain and the site had none. Every claim in it is sourced from the code rather than boilerplate, and it includes the Limited Use disclosure the sensitive-scope review requires. **It wants a human read before it goes public** — it's a legal-ish document under your name.

Site copy shipping inside this PR is deliberate: it can't go live ahead of the feature that way.

## Verification

- `cargo test` — 242 passing (up from 206; 21 new covering PKCE, callback parsing, token expiry, Google JSON mapping, pagination, id namespacing, date bounds)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo build` passes **both with and without** the `MOLDAVITE_GOOGLE_*` env vars
- `npm test` — 383 passing, `tsc`/ESLint/Prettier clean, `npm run check:size` within budget
- Network is behind fixture-based tests; **no live Google calls in CI**

## Before this can merge

1. Google Cloud project + OAuth consent screen + **Desktop app** client; inject the id/secret in the release workflow.
2. Manual pass: connect, verify calendar list and colours, events in both timelines, multi-select filtering, disconnect removes the keychain token, revoke-externally still renders Apple events with a Google-scoped error, migration preserves an existing `selectedCalendarId`, non-macOS smoke check.
3. `calendar.readonly` is a **sensitive scope**: unverified builds show a warning screen and cap at 100 users. Fine for personal use; broad release needs brand verification, which needs `privacy.html` live. Order: ship → page goes live with it → submit.