### PR TITLE
chore: release v1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+## [1.7.4] - 2026-08-07
+
 ### Fixed
 
 - **Notes an agent writes to no longer ask which version to keep.** A note you had merely opened, without typing a word, could show the "changed on disk" banner on every external write. Moldavite compared the editor's copy against the raw file in a way that made ordinary Markdown — a `_word_` here, a list marker there — look like an unsaved edit forever. Untouched notes now reload quietly, and the banner is back to meaning what it says: you have edits of your own that would conflict.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.7.3"
+version = "1.7.4"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump across `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, plus the dated CHANGELOG heading that becomes the GitHub release body and the in-app "What's New" popup.

## What ships

Both entries land from #42:

- Notes an agent writes to no longer ask which version to keep. A note you had merely opened could show the "changed on disk" banner on every external write, because the reconciler compared a round-tripped copy of the buffer against the raw file — so ordinary Markdown looked like an unsaved edit forever.
- An external edit no longer throws away your place in the note. Scroll position and cursor now survive the update.

## Verification at 1.7.4

- `npm test` — 380 passing
- `cargo test` — 221 passing
- `npx tsc --noEmit`, `cargo clippy --all-targets -- -D warnings`, `npm run build` all clean

One flaky `cargo test` failure occurred during verification and did not reproduce across six subsequent runs. Traced to wall-clock assertions in the stress tests and filed as #44 — unrelated to this release, which touches no Rust at all.