### PR TITLE
fix(sidebar): stop the row options button sticking after hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Folder and note counts come back after you hover a row.** Hovering a sidebar row once left its `⋯` options button stuck on screen, and since that button sits on top of the count badge, the count stayed hidden for the rest of the session.
+
 ## [1.7.4] - 2026-08-07
 
 ### Fixed

--- a/src/components/sidebar/DraggableNoteItem.tsx
+++ b/src/components/sidebar/DraggableNoteItem.tsx
@@ -144,6 +144,9 @@ function DraggableNoteItemImpl({
         }}
         onMouseLeave={(e) => {
           e.currentTarget.style.backgroundColor = 'transparent';
+          // Clear the inline opacity set on enter; an inline style outranks the
+          // classes above, so leaving it behind pins the button visible.
+          e.currentTarget.style.opacity = '';
         }}
         aria-label="Note options"
       >

--- a/src/components/sidebar/FolderItem.tsx
+++ b/src/components/sidebar/FolderItem.tsx
@@ -213,6 +213,11 @@ export function FolderItem({
           }}
           onMouseLeave={(e) => {
             e.currentTarget.style.backgroundColor = 'transparent';
+            // Clear the inline opacity set on enter. An inline style outranks
+            // the classes above, so leaving it behind pins the button visible
+            // for good — and since it sits on top of the note count, the count
+            // is never seen again either.
+            e.currentTarget.style.opacity = '';
           }}
           aria-label="Folder options"
         >


### PR DESCRIPTION
Closes #47.

## The bug

Hover a folder in the sidebar once and its `⋯` options button never disappears again. Because that button is absolutely positioned on top of the note-count badge, the count stays hidden for the rest of the session — which is how this got noticed ("the three dots stay there fixed instead of showing how many notes there's inside").

## Cause

`FolderItem.tsx:210-216` — `onMouseEnter` writes `opacity: 1` as an **inline style**, which outranks the `opacity-0 group-hover:opacity-60` classes on the same element. `onMouseLeave` resets `backgroundColor` but never clears `opacity`, so the inline value survives the pointer leaving.

`DraggableNoteItem.tsx:141-147` has the identical defect for note rows.

## Fix

Clear the inline value on leave so the classes take over again. Setting `''` rather than a number matters here: the resting opacity is class-driven and differs between a hovered row (`0.6`) and an unhovered one (`0`).

## Checked, not affected

- `Toast.tsx:106-111` resets to its `0.7` resting value correctly.
- `Timeline.tsx:150-151` and `:188-189` use the inverse pattern — enter dims to `0.8`, leave restores `1` — which is correct.

## Verification

`npm test` 380 passing, `tsc` and Prettier clean. Visual check: hover a folder, move away, count reappears; hover again, button returns.

No test added — this is a CSS-precedence bug in a hover handler, and the sidebar has no interaction-test harness that would catch it. Verified by hand.