### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-07
+
 ### Added
 
 - **Google Calendar, alongside Apple Calendar.** Connect a Google account in Settings → Calendar and its events appear in the timeline next to your notes. Access is read-only and asks for the narrowest scope Google offers; Moldavite never creates or changes an event. Consent happens in your browser and the token is kept in your system keychain, never in a note or a settings file, and **Disconnect** removes it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.7.4"
+version = "1.8.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.7.4"
+version = "1.8.0"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump across `package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, plus the dated CHANGELOG heading that becomes the GitHub release body and the in-app "What's New" popup.

Minor bump rather than patch: this adds a feature and reaches two new platforms.

## What ships

From #43:
- Google Calendar as a second read-only source, with per-calendar selection across both accounts and a user-set refresh interval
- The calendar feature reaches Windows and Linux for the first time
- `docs/privacy.html`, a new page listing every network connection the app makes

From #48:
- Sidebar folder and note counts no longer disappear behind a stuck `⋯` button

## Review trail

Both a security review and an independent correctness review ran against #43 before merge. What they caught, all fixed on the branch:

- OAuth callback loop acted on any local request regardless of `state`, and its 300s timeout was unenforceable because `accept()` blocked
- Selecting only a Google calendar still returned every Apple calendar — the two branches disagreed on what an empty per-source selection meant
- Timeline view bucketed events by string prefix, so evening events vanished for any user not on UTC
- Cancelling Google consent wrote into `eventsError`, blanking the whole timeline behind an error pane
- Plus: per-calendar Google failures no longer drop all Google events, DST-midnight zones no longer error, merged events sort by instant rather than text, the calendar list degrades instead of emptying, stale fetches can't overwrite newer ones, and partial results aren't cached

CI also caught a Linux-only `dead_code` break under `-D warnings` that local macOS clippy could not see.

## Verification at 1.8.0

- `npm test` — 383 passing
- `cargo test` — 247 passing
- `tsc`, `cargo clippy --all-targets -- -D warnings`, `npm run build`, `npm run check:size` all clean

## Post-release

Google brand verification can now proceed: `privacy.html` goes live with this release, which is the prerequisite. Until it completes, consent shows the unverified-app interstitial and there is a 100-user cap.