### PR TITLE
fix(ui): anchor the update dot to the gear and keep it red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The "update available" dot sits on the Settings gear and is always red.** It used to float in the corner of the whole Settings button, far from the icon it was flagging, and it took its colour from the active theme's accent, so in some themes the alert dot was the same green, purple, or blue as everything else. It now hangs off the gear like a notification badge and stays alert red in every theme.
+
 ## [1.8.0] - 2026-08-07
 
 ### Added

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -290,7 +290,7 @@ export function SettingsModal() {
                       style={{
                         width: '7px',
                         height: '7px',
-                        backgroundColor: 'var(--accent-primary)',
+                        backgroundColor: 'var(--update-dot)',
                       }}
                     />
                   )}

--- a/src/components/sidebar/SidebarFooter.tsx
+++ b/src/components/sidebar/SidebarFooter.tsx
@@ -122,22 +122,24 @@ export function SidebarFooter({ onToday, onNewNote, onSettings, onTrash }: Sideb
         <button
           type="button"
           onClick={onSettings}
-          className="relative flex items-center justify-center gap-1.5 py-2 text-xs transition-colors"
+          className="flex items-center justify-center gap-1.5 py-2 text-xs transition-colors"
           style={iconBtnStyle}
           onMouseEnter={handleIconEnter}
           onMouseLeave={handleIconLeave}
           title="Settings (⌘,)"
           aria-label={hasPendingUpdate ? 'Open settings (update available)' : 'Open settings'}
         >
-          <SettingsIcon aria-hidden="true" className="w-4 h-4" />
+          <span className="relative flex">
+            <SettingsIcon aria-hidden="true" className="w-4 h-4" />
+            {hasPendingUpdate && (
+              <span
+                aria-hidden="true"
+                className="absolute -top-0.5 -right-0.5 rounded-full"
+                style={{ width: '6px', height: '6px', backgroundColor: 'var(--update-dot)' }}
+              />
+            )}
+          </span>
           <span>Settings</span>
-          {hasPendingUpdate && (
-            <span
-              aria-hidden="true"
-              className="absolute top-1 right-1.5 rounded-full"
-              style={{ width: '7px', height: '7px', backgroundColor: 'var(--accent-primary)' }}
-            />
-          )}
         </button>
         <button
           type="button"

--- a/src/index.css
+++ b/src/index.css
@@ -117,6 +117,9 @@
   --warning: #c9a227;
   --warning-muted: #f7f0d8;
   --status-error: #d4651a;
+  /* Pending-update dot. Defined once and never re-declared per theme so the
+     badge reads as the same alert red in every theme. */
+  --update-dot: #e5484d;
 
   /* ===== INTERACTIVE ===== */
   --hover-overlay: rgba(26, 61, 46, 0.05);


### PR DESCRIPTION
The "update available" dot looked detached and changed colour with the theme.

**Position** — the dot was `absolute top-1 right-1.5` against the entire Settings button, so it landed in the button cell's corner rather than on the gear. It is now wrapped around the icon and offset from it, reading as a notification badge.

**Colour** — both dots (sidebar gear and the Settings → About tab) used `--accent-primary`, which every theme redefines, so in some themes the alert was the same green/purple/blue as the rest of the UI. New `--update-dot: #e5484d` is declared once in `:root` and never re-declared per theme, so it stays alert red everywhere.

CHANGELOG bullet added under Unreleased. `tsc --noEmit` and eslint clean; no test harness covers `SidebarFooter`.