### PR TITLE
chore: release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Moldavite are documented here.
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-08
+
 ### Fixed
 
 - **The "update available" dot sits on the Settings gear and is always red.** It used to float in the corner of the whole Settings button, far from the icon it was flagging, and it took its colour from the active theme's accent, so in some themes the alert dot was the same green, purple, or blue as everything else. It now hangs off the gear like a notification badge and stays alert red in every theme.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.8.0"
+version = "1.8.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Patch release: the "update available" dot now sits on the Settings gear and stays alert red in every theme (#51).

Version synced across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`; CHANGELOG's Unreleased bullet moved under `## [1.8.1] - 2026-08-08`.

Tag `v1.8.1` goes out after merge.