### PR TITLE
fix(site): stop squeezing four landscape screenshots into one row

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -2000,13 +2000,11 @@ main:focus {
     gap: clamp(1.5rem, 3vw, 3.5rem);
   }
 
+  /* Deliberately no column override here. These are 1760x1124 landscape
+     captures of the app; four across squeezes each into an illegible
+     sliver. The base 12-column rule keeps them two per row at every width. */
   .screenshot-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: clamp(1rem, 1.5vw, 1.75rem);
-  }
-
-  .screenshot-card:nth-child(n) {
-    grid-column: auto;
   }
 
   .network-list {
@@ -2171,7 +2169,7 @@ main:focus {
   }
 
   .screenshot-card:nth-child(n) {
-    grid-column: span 6;
+    grid-column: 1 / -1;
   }
 
   .plugin-footer {


### PR DESCRIPTION
A `min-width: 1360px` block overrode `.screenshot-grid` to `repeat(4, minmax(0, 1fr))` and reset every card's `grid-column` to `auto`. On any display 1360px or wider the four 1760x1124 app captures were crushed into narrow slivers, so the UI inside them was illegible.

The base twelve-column rule already lays them out two per row (spans 7+5, 5+7). The override is removed, with a comment explaining why it must not return. Below 900px they now go one per row rather than two, since two landscape shots at roughly 410px each were no more readable than four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gSM4ADsmF2Vrnra6GaNbD