### PR TITLE
fix(site): unsquash the screenshots and widen the install section

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -100,6 +100,7 @@ video,
 svg {
   display: block;
   max-width: 100%;
+  height: auto;
 }
 
 button,
@@ -1998,8 +1999,6 @@ main:focus {
 
 @media (min-width: 1360px) {
   .install-grid {
-    max-width: 90rem;
-    margin-inline: auto;
     gap: clamp(1.5rem, 3vw, 3.5rem);
   }
 


### PR DESCRIPTION
Two separate causes behind the screenshots still looking squished.

**Aspect ratio.** The base `img` rule set `max-width: 100%` with no `height: auto`. The `width`/`height` attributes added earlier for layout stability therefore won on height, so every screenshot rendered at its CSS width but its natural pixel height. Measured on the live layout, a 1760x1124 capture rendered as 1256x1124 and 884x1124, aspect ratios of 1.12 and 0.79 against a natural 1.566. With `height: auto` they measure 1.564 and 1.565.

This affected every image on the site, not just the screenshots. Fixed once at the base rule.

**Install section width.** `.install-grid` was capped at `90rem` (1440px) inside a 2200px container, so that section rendered about 760px narrower than the sections above and below it, which is what made the page look like it was not using the full width. The cap is gone; it now measures 2200 like its neighbours.

Verified by measuring `getBoundingClientRect` on the rendered page, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gSM4ADsmF2Vrnra6GaNbD