### PR TITLE
Preserve Markdown formatting when pasting into the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Moldavite are documented here.
 
 ### Added
 
+- **Pasted Markdown keeps its formatting.** Pasting recognizable raw Markdown into the editor now inserts formatted note content through Moldavite's existing conversion pipeline, while ordinary text, rich text, and image paste keep their existing behavior.
 - **Install with Homebrew.** `brew install --cask mauropereiira/moldavite/moldavite` fetches the signed, notarized DMG for your architecture and verifies its checksum. It also links the app binary onto your `PATH`, so connecting an AI tool is now `claude mcp add moldavite -- moldavite --mcp` instead of the full bundle path. The cask is marked as self-updating, so Homebrew stays out of the way of Moldavite's own updater.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ as a timestamped conflict copy.
 ## What else it does
 
 - **Writing.** Rich-text editing over Markdown-on-disk: headings, task lists,
-  code, resizable images, slash commands, pinnable tabs.
+  code, resizable images, slash commands, pinnable tabs, and formatted paste
+  for recognizable raw Markdown.
 - **Linking.** `[[Wiki links]]` and `[[Display|target]]`. Renaming a note
   rewrites every inbound link across the vault and keeps your open tabs pointed
   at the right file.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -10,7 +10,7 @@
 
 ### Notes & Editing
 - Daily notes (auto-created per day, auto-deleted when emptied — media-only content counts as content), weekly notes, standalone notes with folders
-- TipTap rich-text editor: headings, lists, task lists, images (resizable), highlights, alignment, code, links; slash commands; tabs with pinning
+- TipTap rich-text editor: headings, lists, task lists, images (resizable), highlights, alignment, code, links; recognizable raw Markdown pastes as formatted content; slash commands; tabs with pinning
 - Wiki-links `[[Note]]` / `[[Display|target]]` with existence styling, backlinks panel, backlinks sidebar section, and a deterministic force-directed graph whose linked components cluster while orphans stay peripheral
 - Standalone note rename UI in the sidebar and editor; open state follows the new path and inbound wiki-links are rewritten vault-wide (v1.6). Unicode-safe NFC slugs are shared by frontend + backend (v1.5)
 - `#tags` with sidebar aggregation and global tag rename

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -728,11 +728,18 @@ export function Editor() {
         },
         handlePaste: (view, event) => {
           const clipboard = event.clipboardData;
-          const items = clipboard?.items;
-          if (!items) return false;
+          if (!clipboard) return false;
 
+          const items = clipboard.items;
+          let hasImage = false;
+
+          // Images are claimed before the text/html check below. Copying a
+          // picture from a browser puts both an image and its <img> markup on
+          // the clipboard, and letting the markup win would embed a remote URL
+          // instead of saving the file into the Forge.
           for (const item of items) {
             if (item.type.startsWith('image/')) {
+              hasImage = true;
               event.preventDefault();
               const file = item.getAsFile();
               if (file && handleImageFileRef.current) {
@@ -741,13 +748,29 @@ export function Editor() {
               }
             }
           }
+          // An image that produced no file is still an image paste. Falling
+          // through would hand its text flavour to the Markdown branch.
+          if (hasImage) return true;
+
+          // Rich text is ProseMirror's job. This branch is only for clipboards
+          // carrying plain text alone.
+          if (clipboard.getData('text/html')) return false;
+
+          const pasteEditor = editorRef.current;
+          if (
+            !pasteEditor ||
+            pasteEditor.isDestroyed ||
+            pasteEditor.isActive('codeBlock') ||
+            pasteEditor.isActive('code')
+          ) {
+            return false;
+          }
 
           const text = clipboard.getData('text/plain');
           if (!looksLikeMarkdown(text)) return false;
 
           const html = markdownToHtml(text);
-          const pasteEditor = editorRef.current;
-          if (!html || !pasteEditor || pasteEditor.isDestroyed) return false;
+          if (!html) return false;
 
           const { from, to } = view.state.selection;
           const inserted = pasteEditor.commands.insertContentAt({ from, to }, html, {

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -63,6 +63,7 @@ import { useAutoSave, useKeyboardShortcuts, useNotes, useTemplates } from '@/hoo
 import { getNoteBackgroundColor } from '@/components/ui/NoteColorPicker';
 import { useToast } from '@/hooks/useToast';
 import { markdownToHtml, processAndSaveImage } from '@/lib';
+import { looksLikeMarkdown } from '@/lib/markdownPaste';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { WelcomeEmptyState } from '@/components/ui/EmptyState';
 import { EmptyNoteTemplatePicker } from '@/components/templates/EmptyNoteTemplatePicker';
@@ -129,6 +130,8 @@ export function Editor() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // Ref for image file handler (to break circular dependency with useEditor)
   const handleImageFileRef = useRef<((file: File) => Promise<void>) | null>(null);
+  // Ref for paste commands, whose handler is created inside useEditor.
+  const editorRef = useRef<TiptapEditor | null>(null);
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
@@ -723,8 +726,9 @@ export function Editor() {
           class: 'prose dark:prose-invert max-w-none focus:outline-none min-h-full px-6 py-8',
           spellcheck: spellCheck ? 'true' : 'false',
         },
-        handlePaste: (_view, event) => {
-          const items = event.clipboardData?.items;
+        handlePaste: (view, event) => {
+          const clipboard = event.clipboardData;
+          const items = clipboard?.items;
           if (!items) return false;
 
           for (const item of items) {
@@ -737,7 +741,22 @@ export function Editor() {
               }
             }
           }
-          return false;
+
+          const text = clipboard.getData('text/plain');
+          if (!looksLikeMarkdown(text)) return false;
+
+          const html = markdownToHtml(text);
+          const pasteEditor = editorRef.current;
+          if (!html || !pasteEditor || pasteEditor.isDestroyed) return false;
+
+          const { from, to } = view.state.selection;
+          const inserted = pasteEditor.commands.insertContentAt({ from, to }, html, {
+            updateSelection: true,
+          });
+          if (!inserted) return false;
+
+          event.preventDefault();
+          return true;
         },
         handleDrop: (_view, event) => {
           const files = event.dataTransfer?.files;
@@ -757,6 +776,7 @@ export function Editor() {
     },
     [tagsEnabled]
   ); // Recreate editor when tagsEnabled changes
+  editorRef.current = editor;
 
   // Handle image file from paste or drop
   const handleImageFile = useCallback(

--- a/src/lib/markdownPaste.test.ts
+++ b/src/lib/markdownPaste.test.ts
@@ -1,0 +1,92 @@
+/** Markdown-paste detection and conversion regression coverage. */
+
+import { describe, expect, it } from 'vitest';
+import { markdownToHtml } from './fileSystem';
+import { looksLikeMarkdown } from './markdownPaste';
+
+describe('looksLikeMarkdown', () => {
+  it.each([
+    ['level-one heading', '# Heading'],
+    ['level-two heading', '## Heading'],
+    ['level-three heading', '### Heading'],
+    ['dash list', '- item'],
+    ['asterisk list', '* item'],
+    ['plus list', '+ item'],
+    ['ordered list', '1. item'],
+    ['unchecked task', '- [ ] task'],
+    ['checked task', '- [x] task'],
+    ['fenced code block', '```ts\nconst value = 1;\n```'],
+    ['blockquote', '> quote'],
+    ['bold', 'This is **bold** text.'],
+    ['italic', 'This is *italic* text.'],
+    ['strikethrough', 'This is ~~removed~~ text.'],
+    ['inline code', 'Use `code` here.'],
+    ['Markdown link', '[Link](https://example.com)'],
+    ['horizontal rule', '---'],
+    ['wiki link', 'See [[Note]].'],
+    ['aliased wiki link', 'See [[Display|Target]].'],
+    [
+      'representative document',
+      '# Title\n\nThis is **bold**.\n\n- one\n- two\n\n> quote\n\n[[Note]]',
+    ],
+  ])('recognizes %s', (_name, text) => {
+    expect(looksLikeMarkdown(text)).toBe(true);
+  });
+
+  it.each([
+    ['empty text', ''],
+    ['whitespace', ' \n\t '],
+    ['normal paragraph', 'This is an ordinary paragraph.'],
+    ['sentence hyphen', 'This is a normal sentence - with a dash.'],
+    ['hashtag', 'Call #support tomorrow.'],
+    ['decimal', 'Version 2.5 is installed.'],
+    ['ordinary brackets', 'Use [brackets] in the label.'],
+    ['plain URL', 'https://example.com'],
+    ['ordinary multiline prose', 'First ordinary line.\nSecond ordinary line.'],
+    ['level-four heading', '#### Heading'],
+    ['level-five heading', '##### Heading'],
+    ['level-six heading', '###### Heading'],
+  ])('rejects %s', (_name, text) => {
+    expect(looksLikeMarkdown(text)).toBe(false);
+  });
+});
+
+describe('Markdown paste conversion', () => {
+  it('produces supported TipTap-compatible HTML through the existing conversion pipeline', () => {
+    const markdown = [
+      '# Heading',
+      '',
+      'This is **bold**.',
+      '',
+      '- regular item',
+      '',
+      '- [ ] unfinished task',
+      '',
+      '[Link](https://example.com)',
+      '',
+      '[[Display|Target Note]]',
+      '',
+      '```js',
+      'console.log("hello");',
+      '```',
+    ].join('\n');
+
+    const container = document.createElement('div');
+    container.innerHTML = markdownToHtml(markdown);
+
+    expect(container.querySelector('h1')?.textContent).toBe('Heading');
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('ul:not([data-type="taskList"]) li')?.textContent?.trim()).toBe(
+      'regular item'
+    );
+    expect(container.querySelector('ul[data-type="taskList"]')).not.toBeNull();
+    expect(
+      container.querySelector('li[data-type="taskItem"][data-checked="false"]')?.textContent
+    ).toContain('unfinished task');
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com');
+    expect(container.querySelector('wiki-link')?.getAttribute('data-target')).toBe(
+      'target-note.md'
+    );
+    expect(container.querySelector('pre code')?.textContent).toContain('console.log("hello");');
+  });
+});

--- a/src/lib/markdownPaste.test.ts
+++ b/src/lib/markdownPaste.test.ts
@@ -18,11 +18,12 @@ describe('looksLikeMarkdown', () => {
     ['fenced code block', '```ts\nconst value = 1;\n```'],
     ['blockquote', '> quote'],
     ['bold', 'This is **bold** text.'],
+    ['underscore bold', 'This is __bold__ text.'],
     ['italic', 'This is *italic* text.'],
     ['strikethrough', 'This is ~~removed~~ text.'],
     ['inline code', 'Use `code` here.'],
     ['Markdown link', '[Link](https://example.com)'],
-    ['horizontal rule', '---'],
+    ['horizontal rule in a Markdown document', '**Section**\n\n---'],
     ['wiki link', 'See [[Note]].'],
     ['aliased wiki link', 'See [[Display|Target]].'],
     [
@@ -46,6 +47,12 @@ describe('looksLikeMarkdown', () => {
     ['level-four heading', '#### Heading'],
     ['level-five heading', '##### Heading'],
     ['level-six heading', '###### Heading'],
+    ['dunder method', 'def __init__(self, x):'],
+    ['JavaScript template literal', 'const greeting = `hello there`;'],
+    // A lone `---` is also Moldavite's frontmatter delimiter, so it no longer opts into conversion.
+    ['lone horizontal rule', '---'],
+    ['YAML frontmatter block', '---\ntitle: My Note\n---'],
+    ['raw Moldavite note', '---\ntitle: My Note\n---\n\n# Markdown body'],
   ])('rejects %s', (_name, text) => {
     expect(looksLikeMarkdown(text)).toBe(false);
   });

--- a/src/lib/markdownPaste.ts
+++ b/src/lib/markdownPaste.ts
@@ -1,0 +1,47 @@
+/**
+ * Conservative detection for raw Markdown pasted into the rich-text editor.
+ * A positive result opts the clipboard text into Moldavite's Markdown-to-HTML
+ * pipeline, so patterns here must be stronger than ordinary punctuation.
+ */
+
+const SUPPORTED_ATX_HEADING = /^[ \t]{0,3}#{1,3}[ \t]+\S/m;
+const UNORDERED_LIST_ITEM = /^[ \t]{0,3}[-+*][ \t]+\S/m;
+const ORDERED_LIST_ITEM = /^[ \t]{0,3}\d+\.[ \t]+\S/m;
+const BLOCKQUOTE = /^[ \t]{0,3}>[ \t]+\S/m;
+const FENCED_CODE_BLOCK = /^[ \t]{0,3}(?:`{3,}|~{3,})[^\n]*$/m;
+const HORIZONTAL_RULE = /^[ \t]{0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/m;
+
+const STRONG = /(\*\*|__)(?=\S)(?:[^\n]*?\S)?\1/;
+const EMPHASIS_ASTERISK = /(^|[\s([{"'])\*(?=\S)(?:[^*\n]*\S)?\*(?=$|[\s)\]}.,!?;:'"])/m;
+const EMPHASIS_UNDERSCORE = /(^|[\s([{"'])_(?=\S)(?:[^_\n]*\S)?_(?=$|[\s)\]}.,!?;:'"])/m;
+const STRIKETHROUGH = /~~(?=\S)(?:[^\n]*?\S)?~~/;
+const INLINE_CODE = /(^|[^`])`(?=\S)(?:[^`\n]*\S)?`(?!`)/m;
+const MARKDOWN_LINK = /\[[^\]\n]+\]\((?![ \t]*\))[^\s)\n]+(?:[ \t]+["'][^"'\n]*["'])?[ \t]*\)/;
+const WIKI_LINK = /\[\[[^\]|\n]*\S[^\]|\n]*(?:\|[^\]\n]*\S[^\]\n]*)?\]\]/;
+
+const MARKDOWN_PATTERNS = [
+  SUPPORTED_ATX_HEADING,
+  UNORDERED_LIST_ITEM,
+  ORDERED_LIST_ITEM,
+  BLOCKQUOTE,
+  FENCED_CODE_BLOCK,
+  HORIZONTAL_RULE,
+  STRONG,
+  EMPHASIS_ASTERISK,
+  EMPHASIS_UNDERSCORE,
+  STRIKETHROUGH,
+  INLINE_CODE,
+  MARKDOWN_LINK,
+  WIKI_LINK,
+];
+
+/**
+ * Returns true when clipboard text contains a strong Markdown signal that the
+ * current TipTap schema can faithfully represent.
+ */
+export function looksLikeMarkdown(text: string): boolean {
+  if (!text.trim()) return false;
+
+  const normalized = text.replace(/\r\n?/g, '\n');
+  return MARKDOWN_PATTERNS.some((pattern) => pattern.test(normalized));
+}

--- a/src/lib/markdownPaste.ts
+++ b/src/lib/markdownPaste.ts
@@ -11,11 +11,12 @@ const BLOCKQUOTE = /^[ \t]{0,3}>[ \t]+\S/m;
 const FENCED_CODE_BLOCK = /^[ \t]{0,3}(?:`{3,}|~{3,})[^\n]*$/m;
 const HORIZONTAL_RULE = /^[ \t]{0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/m;
 
-const STRONG = /(\*\*|__)(?=\S)(?:[^\n]*?\S)?\1/;
+const STRONG =
+  /(?:\*\*(?=\S)(?:[^\n]*?\S)?\*\*|(^|[\s([{"'])__(?=\S)(?:[^_\n]*?\S)?__(?=$|[\s)\]}.,!?;:'"]))/m;
 const EMPHASIS_ASTERISK = /(^|[\s([{"'])\*(?=\S)(?:[^*\n]*\S)?\*(?=$|[\s)\]}.,!?;:'"])/m;
 const EMPHASIS_UNDERSCORE = /(^|[\s([{"'])_(?=\S)(?:[^_\n]*\S)?_(?=$|[\s)\]}.,!?;:'"])/m;
 const STRIKETHROUGH = /~~(?=\S)(?:[^\n]*?\S)?~~/;
-const INLINE_CODE = /(^|[^`])`(?=\S)(?:[^`\n]*\S)?`(?!`)/m;
+const INLINE_CODE = /(^|[\s([{"'])`(?=\S)(?:[^`\n]*\S)?`(?=$|[\s)\]}.,!?:'"])/m;
 const MARKDOWN_LINK = /\[[^\]\n]+\]\((?![ \t]*\))[^\s)\n]+(?:[ \t]+["'][^"'\n]*["'])?[ \t]*\)/;
 const WIKI_LINK = /\[\[[^\]|\n]*\S[^\]|\n]*(?:\|[^\]\n]*\S[^\]\n]*)?\]\]/;
 
@@ -35,6 +36,16 @@ const MARKDOWN_PATTERNS = [
   WIKI_LINK,
 ];
 
+function hasYamlFrontmatter(text: string): boolean {
+  const lines = text.split('\n');
+  if (lines[0].trim() !== '---') return false;
+
+  const closingDelimiter = lines.findIndex((line, index) => index > 0 && line.trim() === '---');
+  if (closingDelimiter === -1) return false;
+
+  return lines.slice(1, closingDelimiter).some((line) => /^[A-Za-z0-9_-]+:[ \t]*/.test(line));
+}
+
 /**
  * Returns true when clipboard text contains a strong Markdown signal that the
  * current TipTap schema can faithfully represent.
@@ -43,5 +54,13 @@ export function looksLikeMarkdown(text: string): boolean {
   if (!text.trim()) return false;
 
   const normalized = text.replace(/\r\n?/g, '\n');
-  return MARKDOWN_PATTERNS.some((pattern) => pattern.test(normalized));
+  if (hasYamlFrontmatter(normalized)) return false;
+
+  const matchedPatterns = MARKDOWN_PATTERNS.filter((pattern) => pattern.test(normalized));
+
+  // A horizontal rule is too ambiguous on its own: the same delimiter frames
+  // Moldavite's YAML frontmatter. Keep it as corroboration for other signals.
+  if (matchedPatterns.length === 1 && matchedPatterns[0] === HORIZONTAL_RULE) return false;
+
+  return matchedPatterns.length > 0;
 }


### PR DESCRIPTION
## Problem

Moldavite stores notes as Markdown, but pasting raw Markdown into the rich-text
editor does not reliably preserve that formatting. Markdown syntax can instead
appear literally or be pasted as preformatted content.

## Approach

This change adds conservative Markdown detection to the editor's existing paste
handler.

When pasted plain text clearly looks like Markdown, it is passed through
Moldavite's existing `markdownToHtml()` conversion pipeline and inserted at the
current editor selection.

This intentionally reuses the application's existing Markdown conversion,
wiki-link handling, task-list processing, and sanitization rather than
introducing another Markdown parser.

Existing behavior is preserved for:

- image paste
- ordinary plain-text paste
- normal rich-text paste

## Verification

- Added focused Markdown-detection regression tests
- Verified headings, inline formatting, lists, task lists, links, blockquotes,
  code, and Moldavite wiki links
- Verified insertion replaces the current selection correctly
- Verified image paste still works
- Verified ordinary prose still uses normal paste behavior
- Verified save/reopen Markdown round-trip

Checks run:

- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run build`

## Compatibility / data impact

Frontend editor behavior only.

No changes to:

- Markdown-on-disk format
- migrations
- backend writes
- Forge structure
- plugin permissions
- note addressing
- frontmatter