### PR TITLE
ci: split checks into per-status jobs and verify Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Checks
 
 on:
   push:
@@ -6,10 +6,32 @@ on:
   pull_request:
     branches: [main]
 
+# Fork PRs get a read-only token. Nothing here needs to write.
+permissions:
+  contents: read
+
 jobs:
-  frontend:
-    name: Frontend lint & build
+  # One job per check so each reports as its own required status. `matrix.run`
+  # is a literal defined below, never event input, so interpolating it is safe.
+  web:
+    name: ${{ matrix.task }}
     runs-on: ubuntu-latest
+    strategy:
+      # Report every failure in one pass instead of cancelling siblings.
+      fail-fast: false
+      matrix:
+        include:
+          - task: check-format
+            run: npm run format:check
+          # Ratchet: main sits at 16 warnings, 0 errors. Blocks new ones
+          # without demanding the backlog get fixed first. Lower it as
+          # warnings get cleared; never raise it.
+          - task: check-js
+            run: npm run lint -- --max-warnings 16
+          - task: test-js
+            run: npm test
+          - task: build-web
+            run: npm run build && npm run check:size
     steps:
       - uses: actions/checkout@v4
 
@@ -22,21 +44,20 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Lint
-        run: npx eslint . --ext ts,tsx --max-warnings 9999
-
-      - name: Unit tests
-        run: npm test
-
-      - name: Build
-        run: npm run build
-
-      - name: Bundle size budget
-        run: npm run check:size
+      - name: Run ${{ matrix.task }}
+        run: ${{ matrix.run }}
 
   rust:
-    name: Rust clippy & tests
+    name: ${{ matrix.task }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: check-rust
+            run: cargo clippy --lib --all-targets -- -D warnings
+          - task: test-rust
+            run: cargo test --lib
     steps:
       - uses: actions/checkout@v4
 
@@ -50,10 +71,12 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev
 
+      # Pinned by SHA: a fork PR runs third-party actions, and a moving tag
+      # is a supply-chain hole. Bump deliberately, not implicitly.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          components: clippy, rustfmt
+          components: clippy
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -62,12 +85,47 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             src-tauri/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          # Keyed per task. Clippy and test build different artifacts, and on a
+          # single shared key whichever job saves second just evicts the other.
+          key: ${{ runner.os }}-cargo-${{ matrix.task }}-${{ hashFiles('src-tauri/Cargo.lock') }}
 
-      - name: Clippy
+      - name: Run ${{ matrix.task }}
         working-directory: src-tauri
-        run: cargo clippy --lib --all-targets -- -D warnings
+        run: ${{ matrix.run }}
 
-      - name: Tests
+  # Windows is a shipped target but nothing verified it until a release tag was
+  # already pushed, so `#[cfg(windows)]` code and every `#[cfg(unix)]`-skipped
+  # test went unproven. No apt step and no Swift/EventKit here; otherwise this
+  # is the Linux job. First run is slow because `fastembed` fetches the ONNX
+  # Runtime binaries at build time (Cargo.toml only excludes it on Intel macOS).
+  rust-windows:
+    name: ${{ matrix.task }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: check-rust-windows
+            run: cargo clippy --lib --all-targets -- -D warnings
+          - task: test-rust-windows
+            run: cargo test --lib
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          components: clippy
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ matrix.task }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+
+      - name: Run ${{ matrix.task }}
         working-directory: src-tauri
-        run: cargo test --lib
+        run: ${{ matrix.run }}

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ yarn-error.log*
 .env.local
 .env.*.local
 
+# Local-only build-time credentials. src-tauri/.cargo/config.toml carries the
+# development Google OAuth client via Cargo's [env]; release builds read it from
+# Actions secrets instead. It already documents itself as uncommitted — this is
+# the line that actually makes that true.
+src-tauri/.cargo/
+
 # TypeScript
 *.tsbuildinfo
 
@@ -57,3 +63,7 @@ AGENTS.md
 AGENTS.local.md
 sdd/
 docs/superpowers/
+.agents/
+.qwen/
+.playwright-mcp/
+skills-lock.json

--- a/src-tauri/src/commands/export_import.rs
+++ b/src-tauri/src/commands/export_import.rs
@@ -209,12 +209,19 @@ fn export_notes_from(notes_dir: &Path, zip_path: &Path) -> Result<(), String> {
     let file = zip
         .finish()
         .map_err(|e| format!("Failed to finalize ZIP: {}", e))?;
+    // The archive holds every note, so the 0600 set at create time is re-asserted
+    // here: finish() rewrites the file and can widen the mode back to the umask.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         file.set_permissions(fs::Permissions::from_mode(0o600))
             .map_err(|e| format!("Failed to secure ZIP file: {}", e))?;
     }
+    // Windows has no POSIX mode bits; the file inherits the target directory's
+    // ACL. Dropped explicitly so the handle closes here on every platform rather
+    // than reading as an unused binding.
+    #[cfg(not(unix))]
+    drop(file);
 
     Ok(())
 }


### PR DESCRIPTION
## Why

Two things this repo could not do before.

**Tell you what broke.** Every check ran inside one of two jobs, so a red build reported `Frontend lint & build failed` and you opened the log to find out whether that was lint, tests, the build, or the size budget.

**Verify Windows.** Windows has been a shipped target since v0.1.1 and no job ever compiled the crate for it. `#[cfg(windows)]` code and the ten `#[cfg(unix)]`-gated tests that skip there were unproven until a release tag had already been pushed and the artifact built. That is the wrong end of the pipeline to discover a compile error.

## What changed

Each check is now its own job and its own status context, with `fail-fast: false` so one failure does not cancel its siblings:

| context | runs |
| --- | --- |
| `check-format` | `npm run format:check` |
| `check-js` | `npm run lint -- --max-warnings 16` |
| `test-js` | `npm test` |
| `build-web` | `npm run build && npm run check:size` |
| `check-rust` | `cargo clippy --lib --all-targets -- -D warnings` |
| `test-rust` | `cargo test --lib` |
| `check-rust-windows` | clippy, on `windows-latest` |
| `test-rust-windows` | `cargo test --lib`, on `windows-latest` |

Alongside that:

- **Prettier is enforced.** It was never a gate before.
- **ESLint moves from `--max-warnings 9999` to `16`**, which is exactly where `main` sits (0 errors). New warnings now fail without demanding the existing backlog be cleared first. Lower it as warnings get cleared; never raise it.
- **`dtolnay/rust-toolchain` is pinned by SHA.** A fork PR runs third-party actions, and a moving tag is a supply-chain hole.
- **The Cargo cache is keyed per task.** Clippy and test build different artifacts; on a single shared key whichever job saved second just evicted the other.
- **`permissions: contents: read`.** Nothing here needs to write.

The Windows leg has no apt step and no Swift/EventKit path. Its first run is slow because `fastembed` fetches the ONNX Runtime binaries at build time — `Cargo.toml` only excludes that crate on Intel macOS, so Windows compiles it. Later runs hit the cache.

## Also: a credential one `git add -A` away from a public repo

`src-tauri/.cargo/config.toml` carries the development Google OAuth client that Cargo injects through `[env]`. Its own header says `NOT COMMITTED — see .gitignore`, and `.gitignore` did not list it, so it sat untracked-but-not-ignored in every `git status`. It is ignored now, along with the local tool directories beside it.

## Verification

Run locally against this branch, mirroring the new job set one-for-one:

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — `16 problems (0 errors, 16 warnings)`, exactly at the ratchet
- `npm test` — 383 passing, 48 files, 7.78s
- `npm run build && npm run check:size` — all bundles within budget; app JS 539.5 KB raw / 141.9 KB gz against 544 / 146
- `cargo clippy --lib --all-targets -- -D warnings` — clean
- `cargo test --lib` — 249 passing, 0 failed

Windows is the one thing that cannot be checked from this machine — there is no Windows box and no VM here, which is the entire reason this job exists. Its first green run on this PR is the proof.

## Note for merging

This renames every status context, so the two currently required by branch protection (`Frontend lint & build`, `Rust clippy & tests`) will never report again once this lands. Protection has to be updated in the same beat or every open PR wedges waiting for a status that no longer exists.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm