### PR TITLE
chore: drop two constants nothing reads

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -81,7 +81,6 @@ export const TOAST_DURATION_LONG = 5000;
 
 // Calendar
 export const CALENDAR_EVENTS_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes in milliseconds
-export const CALENDAR_DEFAULT_TIME_RANGE = 7; // days
 
 // Validation
 export const MAX_NOTE_NAME_LENGTH = 255; // characters
@@ -95,7 +94,6 @@ export const ERROR_NOTE_SAVE_FAILED = 'Failed to save note';
 export const ERROR_NOTE_LOAD_FAILED = 'Failed to load note';
 export const ERROR_NOTE_DELETE_FAILED = 'Failed to delete note';
 export const ERROR_TEMPLATE_NOT_FOUND = 'Template not found';
-export const ERROR_CALENDAR_PERMISSION_DENIED = 'Calendar access denied';
 
 // Success messages
 export const SUCCESS_NOTE_CREATED = 'Note created';


### PR DESCRIPTION
Closes #41.

## What

`CALENDAR_DEFAULT_TIME_RANGE` was exported from `src/lib/constants.ts` and never read. The calendar's window comes from the store's own range handling, so the constant documented a behaviour that no longer existed.

The issue also flagged `ERROR_CALENDAR_PERMISSION_DENIED` as "worth checking separately". It was checked, and it is dead in exactly the same way, so it goes too.

`CALENDAR_EVENTS_CACHE_DURATION`, immediately above, **is** live (read at `src/stores/calendarStore.ts:34` and `:277`) and is untouched.

## Evidence

Searching `src/`, `docs/` and `scripts/` before the change, each symbol had exactly one occurrence — its own declaration:

```
src/lib/constants.ts:84:export const CALENDAR_DEFAULT_TIME_RANGE = 7; // days
src/lib/constants.ts:98:export const ERROR_CALENDAR_PERMISSION_DENIED = 'Calendar access denied';
```

After the change the same search returns nothing.

## Verification

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — `16 problems (0 errors, 16 warnings)`, unchanged
- `npm test` — 383 passing, 48 files
- `npm run build && npm run check:size` — all bundles within budget, app JS unchanged at 539.5 KB raw / 141.9 KB gz

No CHANGELOG entry: removing an unreferenced constant has no user-visible effect.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm