### PR TITLE
fix(forges): refresh the Forge list when one appears on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Moldavite are documented here.
 
 ### Fixed
 
+- **New Forges appear while the Forge switcher is open.** A Forge created outside Moldavite, whether by an agent, the Obsidian importer, or anything else writing to your Forges folder, only joined the list the next time you opened it. The list now refreshes when Moldavite sees the new Forge on disk.
 - **The app could abort while building a note's backlinks.** The snippet shown under a backlink was cut out using byte positions, so a note containing an accented letter, an arrow, an emoji, or any other multi-byte character within about fifty characters of a `[[wiki link]]` would kill the process outright with no error and no warning. Vaults written in plain ASCII never saw it. The context window now snaps to character boundaries.
 
 ## [1.8.1] - 2026-08-08
@@ -56,7 +57,7 @@ All notable changes to Moldavite are documented here.
 - **A note that starts with an image is no longer mangled.** Such notes were mistaken for old-format HTML, so every heading and list below the image turned into plain text and the next save made it permanent.
 - **Locking a note inside a folder locks that note.** Lock, unlock, and permanent unlock addressed notes by filename only, so a note in a folder resolved to the vault root — which could encrypt a different note of the same name.
 - **Renaming a tag and bulk export now cover notes inside folders.** Both addressed notes by filename alone, so they skipped folder notes or acted on a same-named note at the root.
-- **New Forges appear without restarting.** A Forge created outside the window — by an agent, the Obsidian importer, or anything writing to your Forges folder — stayed invisible until relaunch.
+- **New Forges appear when you open the Forge switcher.** A Forge created outside the window, whether by an agent, the Obsidian importer, or anything writing to your Forges folder, now appears the next time you open the switcher instead of staying invisible until relaunch.
 - **Agents follow the Forge you switch to.** An MCP session pinned the Forge at startup, so after switching in the app, agent writes silently went to the previous vault and still reported success.
 - **Locking a note removes it from backlinks immediately.** A locked note's title and a line from its body stayed visible in the backlinks panel until restart. Permanently unlocking a note now restores its links right away.
 - **"Delete all notes" deletes all of them.** It skipped weekly notes, every note inside a folder, and locked notes, while still emptying the sidebar — so the app looked empty over notes that were still on disk.

--- a/src/hooks/useForgeWatcher.ts
+++ b/src/hooks/useForgeWatcher.ts
@@ -16,7 +16,7 @@ import {
   readNoteWithMeta,
 } from '@/lib';
 import { getPendingAutosaveNoteId, resetAutosaveBaseline } from '@/lib/autosaveFlush';
-import { useNoteStore } from '@/stores';
+import { useForgeStore, useNoteStore } from '@/stores';
 import type { Note } from '@/types';
 
 /**
@@ -105,17 +105,53 @@ export async function reconcileExternalNoteChange(relPath: string): Promise<void
 }
 
 /**
- * Subscribes to backend `forge:changed` events. When something on disk
- * changes outside of Moldavite (Obsidian, an editor, a script…), we
- * reconcile the list and any semantically matching open tab.
+ * Subscribes to backend `forge:changed` and `forges:changed` events. When
+ * something on disk changes outside of Moldavite (Obsidian, an editor, a
+ * script…), we reconcile the note list, Forge list, and any semantically
+ * matching open tab.
  */
 export function useForgeWatcher(): void {
   const setNotes = useNoteStore((s) => s.setNotes);
   const refreshTimer = useRef<number | null>(null);
 
   useEffect(() => {
-    let unlisten: (() => void) | undefined;
+    let unlistenForge: (() => void) | undefined;
+    let unlistenForges: (() => void) | undefined;
     let cancelled = false;
+    let notesRefreshPending = false;
+    let forgesRefreshPending = false;
+
+    const scheduleRefresh = () => {
+      // Coalesce bursts: a folder rename can fan out to many events.
+      if (refreshTimer.current !== null) {
+        clearTimeout(refreshTimer.current);
+      }
+      refreshTimer.current = window.setTimeout(() => {
+        refreshTimer.current = null;
+        const shouldRefreshNotes = notesRefreshPending;
+        const shouldRefreshForges = forgesRefreshPending;
+        notesRefreshPending = false;
+        forgesRefreshPending = false;
+
+        if (shouldRefreshNotes) {
+          listNotes()
+            .then((notes) => {
+              if (!cancelled) setNotes(notes);
+            })
+            .catch((err) => {
+              console.error('[useForgeWatcher] refresh failed:', err);
+            });
+        }
+        if (shouldRefreshForges) {
+          void useForgeStore
+            .getState()
+            .loadForges()
+            .catch((err) => {
+              console.error('[useForgeWatcher] Forge-list refresh failed:', err);
+            });
+        }
+      }, 200);
+    };
 
     const subscribe = async () => {
       try {
@@ -123,25 +159,23 @@ export function useForgeWatcher(): void {
           void reconcileExternalNoteChange(event.payload.relPath).catch((err) => {
             console.error('[useForgeWatcher] note reconciliation failed:', err);
           });
-          // Coalesce bursts: a folder rename can fan out to many events.
-          if (refreshTimer.current !== null) {
-            clearTimeout(refreshTimer.current);
-          }
-          refreshTimer.current = window.setTimeout(() => {
-            refreshTimer.current = null;
-            listNotes()
-              .then((notes) => {
-                if (!cancelled) setNotes(notes);
-              })
-              .catch((err) => {
-                console.error('[useForgeWatcher] refresh failed:', err);
-              });
-          }, 200);
+          notesRefreshPending = true;
+          scheduleRefresh();
         });
         if (cancelled) {
           off();
         } else {
-          unlisten = off;
+          unlistenForge = off;
+        }
+
+        const offForges = await listen<ForgeChangePayload>('forges:changed', () => {
+          forgesRefreshPending = true;
+          scheduleRefresh();
+        });
+        if (cancelled) {
+          offForges();
+        } else {
+          unlistenForges = offForges;
         }
       } catch (err) {
         console.error('[useForgeWatcher] subscribe failed:', err);
@@ -156,7 +190,8 @@ export function useForgeWatcher(): void {
         clearTimeout(refreshTimer.current);
         refreshTimer.current = null;
       }
-      if (unlisten) unlisten();
+      if (unlistenForge) unlistenForge();
+      if (unlistenForges) unlistenForges();
     };
   }, [setNotes]);
 }


### PR DESCRIPTION
Closes #36.

## The issue was wrong about its own symptom

Worth stating plainly, because it changes what got built. The issue claims *"opening the sidebar dropdown itself does not refresh"*. That is false against current `main` — `src/components/sidebar/ForgeSwitcher.tsx:91-101` has re-listed on open since commit `ba7280a` (2026-07-26), twelve days before the issue was filed. `ManageForgesModal.tsx:18-20` reloads on open too.

So this is not "the list is stale until you restart the app."

## What was actually broken

The backend emits a `forges:changed` event (`src-tauri/src/forge_watcher.rs:184-191`) and **nothing listened for it** — `grep -rn "forges:changed" src/` returned zero matches. The real gap was narrow and real: a Forge created while the dropdown is already open never appeared, and there was no live push.

## What changed

A second `listen<ForgeChangePayload>('forges:changed', …)` inside the existing effect in `src/hooks/useForgeWatcher.ts`, calling `useForgeStore.getState().loadForges()`.

Both listeners now share **one** 200 ms coalescing timer with separate pending flags rather than each owning a timer. That matters because `forge_watcher.rs:184-188` emits `forges:changed` for every direct child of the Forges root, including plain files, and that branch has no `is_relevant` filter — so a stray file there can fan out. Sharing the timer with independent flags means a burst of either kind collapses to a single refresh, and a Forge event can no longer cancel a pending note refresh (or the reverse). Both unsubscribe on cleanup.

## Also: a changelog entry that overclaimed

The v1.7.2 entry this issue quotes says new Forges *"appear without restarting"*. What shipped was the on-open reload. The entry now says what was true — they appear when you open the switcher — rather than describing a live push that did not exist until this PR.

## Verification

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — `16 problems (0 errors, 16 warnings)`, unchanged
- `npm test` — 383 passing, 48 files
- `npm run build && npm run check:size` — within budget; app JS 539.8 KB raw / 142.0 KB gz

**No test for the new subscription.** `src/hooks/useForgeWatcher.test.ts` covers `reconcileExternalNoteChange` only and never exercises the hook's `listen()` wiring, so there is no existing pattern to extend; adding one means standing up a rendered-hook and event-mock harness that does not exist yet. Called out rather than quietly skipped.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm