### PR TITLE
test: raise the stress-test timing budget to 30 seconds

### DIFF
--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -598,7 +598,9 @@ mod tests {
             10
         );
         eprintln!("[stress] MCP search over 1000 notes took {elapsed:?}");
-        assert!(elapsed.as_secs() < 5, "MCP search took {elapsed:?}");
+        // Order-of-magnitude alarm, not a benchmark; mirrors
+        // stress_test::REGRESSION_BUDGET_SECS, see the rationale there.
+        assert!(elapsed.as_secs() < 30, "MCP search took {elapsed:?}");
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src-tauri/src/stress_test.rs
+++ b/src-tauri/src/stress_test.rs
@@ -8,6 +8,13 @@
 //! addition to generous upper bounds; timing thresholds are regression alarms,
 //! not performance benchmarks.
 
+/// Upper bound for the timing assertions in this module. These are
+/// order-of-magnitude alarms, not benchmarks: the operations they guard run in
+/// tens of milliseconds locally, so a breach means something regressed by a
+/// factor of hundreds. Five seconds was tight enough that a loaded or throttled
+/// CI machine tripped it on healthy code, and a test that cries wolf gets muted.
+const REGRESSION_BUDGET_SECS: u64 = 30;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -78,7 +85,7 @@ fn stress_search_over_1000_note_vault() {
     assert_eq!(results.len(), 10, "expected exactly the 10 seeded matches");
     eprintln!("[stress] search over 1000 notes took {elapsed:?}");
     assert!(
-        elapsed.as_secs() < 5,
+        elapsed.as_secs() < REGRESSION_BUDGET_SECS,
         "search over 1000 notes took {elapsed:?} — order-of-magnitude regression"
     );
 }
@@ -178,5 +185,9 @@ fn stress_rewrite_links_across_large_corpus() {
     );
     // note i links to (i+para)%1000 for para 0..8 — several notes link to 42.
     assert!(touched > 0, "expected at least one note to link to note-42");
-    assert!(started.elapsed().as_secs() < 5);
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed.as_secs() < REGRESSION_BUDGET_SECS,
+        "link rewrite across 500 notes took {elapsed:?} — order-of-magnitude regression"
+    );
 }


### PR DESCRIPTION
Closes #44.

## What

Three timing assertions in the stress tests asserted a five-second wall clock. The module doc directly above them already claimed the opposite:

> These use generous time bounds so they stay green on slow CI machines while still catching order-of-magnitude regressions.
> […] timing thresholds are regression alarms, not performance benchmarks.

The code contradicted its own stated contract, and it bit a real build during v1.7.4 verification.

## The issue undercounted

#44 lists two assertions. There are **three** — it misses `stress_test.rs:181`, in `stress_rewrite_links_across_large_corpus`, which was also the only one with no failure message at all.

| location | before | after |
| --- | --- | --- |
| `stress_test.rs` — `stress_search_over_1000_note_vault` | `< 5` | `< REGRESSION_BUDGET_SECS` |
| `stress_test.rs` — `stress_rewrite_links_across_large_corpus` | `< 5`, no message | `< REGRESSION_BUDGET_SECS`, reports measured time |
| `mcp/server.rs` — `keyword_search_over_1000_note_forge_is_time_bounded` | `< 5` | `< 30` |

The budget is now a named constant carrying the reasoning, rather than a bare `5` repeated three times.

## Why 30 and not something else

The guarded operations complete in tens of milliseconds locally, so 30 seconds still catches an order-of-magnitude regression by a factor of hundreds — which is all these assertions are for. Five seconds was tight enough that a contended runner failed healthy code, and a test that cries wolf gets muted. That costs more than the coverage is worth.

`#[ignore]` was considered and rejected: CI runs `cargo test --lib`, so an ignored test would silently stop running and the alarm would be gone entirely rather than widened.

Every one of these tests still `eprintln!`s its measured elapsed time, so a real slowdown remains visible in the log even when it does not breach the bound.

## Verification

- `cargo clippy --lib --all-targets -- -D warnings` — clean
- `cargo test --lib` — 249 passing, 0 failed

No CHANGELOG entry: test-only change with no user-visible effect.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm