### PR TITLE
feat(mcp): detect conflicts on agent note writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Moldavite are documented here.
 
 ### Fixed
 
+- **Agents had no way to notice that a note changed between reading and writing it.** The MCP read tool returned no version hash, so a second agent or the open app could update the same note and then have its work silently replaced by an older agent's write. Reads now return a content hash that an agent can send back with its next write. If the note body has changed by then, Moldavite preserves that disk version as a sibling conflict copy before saving the agent's version. Existing integrations can omit the hash and keep their previous behavior.
 - **New Forges appear while the Forge switcher is open.** A Forge created outside Moldavite, whether by an agent, the Obsidian importer, or anything else writing to your Forges folder, only joined the list the next time you opened it. The list now refreshes when Moldavite sees the new Forge on disk.
 - **The app could abort while building a note's backlinks.** The snippet shown under a backlink was cut out using byte positions, so a note containing an accented letter, an arrow, an emoji, or any other multi-byte character within about fifty characters of a `[[wiki link]]` would kill the process outright with no error and no warning. Vaults written in plain ASCII never saw it. The context window now snaps to character boundaries.
 

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -43,7 +43,7 @@ fn index_key(filename: &str) -> String {
 /// SHA-256 hex digest of a note body. The frontend keeps the hash from its
 /// last read and sends it back on save so we can tell whether the disk copy
 /// changed underneath it (external editor, sync tool, git…).
-fn sha256_hex(content: &str) -> String {
+pub(crate) fn sha256_hex(content: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
@@ -176,7 +176,7 @@ fn delete_note_at(path: &Path, base_hash: Option<&str>) -> Result<bool, String> 
 /// Serialize conflict detection, frontmatter preservation, and the replacing
 /// write as one operation. This prevents concurrent saves from both observing
 /// the same old disk version and then silently overwriting one another.
-fn save_note_with_conflict(
+pub(crate) fn save_note_with_conflict(
     path: &Path,
     base_hash: Option<&str>,
     content: &str,

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -324,6 +324,149 @@ mod tests {
     }
 
     #[test]
+    fn write_note_with_matching_base_hash_reports_no_conflict_copy() {
+        let root = temp_forge("matching-base-hash");
+        let note_path = root.join("notes/matching.md");
+        fs::write(&note_path, "---\ncolor: blue\n---\ndisk body").unwrap();
+        let base_hash = crate::commands::notes::sha256_hex("disk body");
+
+        let response = ToolContext::new(root.clone(), true, false).call(
+            "write_note",
+            &json!({
+                "path": "notes/matching.md",
+                "content": "agent body",
+                "baseHash": base_hash
+            }),
+        );
+
+        assert_eq!(response["isError"], false);
+        assert_eq!(response["structuredContent"]["written"], true);
+        assert!(response["structuredContent"]["conflictCopy"].is_null());
+        let raw = fs::read_to_string(&note_path).unwrap();
+        assert_eq!(crate::frontmatter::parse_note(&raw).body, "agent body");
+        assert_eq!(fs::read_dir(root.join("notes")).unwrap().count(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn write_note_with_mismatched_base_hash_reports_preserved_copy() {
+        let root = temp_forge("mismatched-base-hash");
+        let note_path = root.join("notes/conflicted.md");
+        let disk_version = "---\ncolor: green\ntags: [kept]\n---\nexternal body";
+        fs::write(&note_path, disk_version).unwrap();
+        let stale_hash = crate::commands::notes::sha256_hex("original body");
+
+        let response = ToolContext::new(root.clone(), true, false).call(
+            "write_note",
+            &json!({
+                "path": "notes/conflicted.md",
+                "content": "agent body",
+                "baseHash": stale_hash
+            }),
+        );
+
+        assert_eq!(response["isError"], false);
+        assert_eq!(response["structuredContent"]["written"], true);
+        let conflict_name = response["structuredContent"]["conflictCopy"]
+            .as_str()
+            .expect("conflict response should name the preserved copy");
+        let written = fs::read_to_string(&note_path).unwrap();
+        assert_eq!(crate::frontmatter::parse_note(&written).body, "agent body");
+        assert_eq!(
+            fs::read_to_string(root.join("notes").join(conflict_name)).unwrap(),
+            disk_version
+        );
+        assert_eq!(fs::read_dir(root.join("notes")).unwrap().count(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn write_note_without_base_hash_keeps_legacy_overwrite_behavior() {
+        let root = temp_forge("absent-base-hash");
+        let note_path = root.join("notes/legacy.md");
+        fs::write(&note_path, "disk body").unwrap();
+
+        let response = ToolContext::new(root.clone(), true, false).call(
+            "write_note",
+            &json!({"path": "notes/legacy.md", "content": "agent body"}),
+        );
+
+        assert_eq!(response["isError"], false);
+        assert_eq!(fs::read_to_string(&note_path).unwrap(), "agent body");
+        assert_eq!(fs::read_dir(root.join("notes")).unwrap().count(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn read_note_body_hash_round_trips_into_write_note() {
+        let root = temp_forge("read-hash-roundtrip");
+        let note_path = root.join("notes/roundtrip.md");
+        let raw = "---\ncolor: purple\ncustom: kept\n---\ndisk body";
+        fs::write(&note_path, raw).unwrap();
+        let context = ToolContext::new(root.clone(), true, false);
+
+        let read = context.call("read_note", &json!({"path": "notes/roundtrip.md"}));
+        assert_eq!(read["isError"], false);
+        assert_eq!(read["structuredContent"]["content"], raw);
+        let content_hash = read["structuredContent"]["contentHash"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            content_hash,
+            crate::commands::notes::sha256_hex("disk body")
+        );
+        assert_ne!(content_hash, crate::commands::notes::sha256_hex(raw));
+
+        let write = context.call(
+            "write_note",
+            &json!({
+                "path": "notes/roundtrip.md",
+                "content": "agent body",
+                "baseHash": content_hash
+            }),
+        );
+
+        assert_eq!(write["isError"], false);
+        let written = fs::read_to_string(&note_path).unwrap();
+        let parsed = crate::frontmatter::parse_note(&written);
+        assert_eq!(parsed.body, "agent body");
+        assert_eq!(parsed.color.as_deref(), Some("purple"));
+        assert!(parsed.extra.contains_key("custom"));
+        assert_eq!(fs::read_dir(root.join("notes")).unwrap().count(), 1);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn write_note_description_documents_optional_base_hash_and_conflict_response() {
+        let root = temp_forge("base-hash-schema");
+        let tools = ToolContext::new(root.clone(), true, false).tool_definitions();
+        let write_note = tools
+            .iter()
+            .find(|tool| tool["name"] == "write_note")
+            .unwrap();
+
+        assert_eq!(
+            write_note["inputSchema"]["properties"]["baseHash"]["type"],
+            "string"
+        );
+        assert!(write_note["description"]
+            .as_str()
+            .unwrap()
+            .contains("baseHash"));
+        assert!(write_note["description"]
+            .as_str()
+            .unwrap()
+            .contains("conflictCopy"));
+        assert!(!write_note["inputSchema"]["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|field| field.as_str() == Some("baseHash")));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn rejects_traversal_and_locked_notes() {
         let root = temp_forge("security");
         fs::write(root.join("notes/secret.md.locked"), "ciphertext").unwrap();

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -15,6 +15,7 @@ use chrono::{Local, NaiveDate};
 use serde_json::{json, Value};
 use walkdir::WalkDir;
 
+use crate::commands::notes::{save_note_with_conflict, sha256_hex};
 use crate::commands::search::search_notes_content_in;
 use crate::persist::write_atomic;
 use crate::validation::{is_safe_filename, is_safe_note_path, validate_path_within_base};
@@ -151,7 +152,10 @@ impl ToolContext {
         let path = self.checked_existing_note(forge_root, &rel)?;
         let content =
             fs::read_to_string(&path).map_err(|error| format!("Failed to read note: {error}"))?;
-        Ok(json!({ "path": rel, "content": content }))
+        // Conflict detection compares note bodies, so expose a hash in that same
+        // space while keeping the raw MCP content response wire-compatible.
+        let content_hash = sha256_hex(&crate::frontmatter::parse_note(&content).body);
+        Ok(json!({ "path": rel, "content": content, "contentHash": content_hash }))
     }
 
     fn list_notes(&self, forge_root: &Path, arguments: &Value) -> Result<Value, String> {
@@ -276,6 +280,8 @@ impl ToolContext {
         Ok(json!({ "path": rel, "created": true }))
     }
 
+    /// This append-only contract intentionally carries no base hash. A concurrent
+    /// full-file write can still interleave with its read-modify-write sequence.
     fn append_to_daily_note(&self, forge_root: &Path, arguments: &Value) -> Result<Value, String> {
         let content = required_string(arguments, "content")?;
         let date = match arguments.get("date") {
@@ -311,6 +317,7 @@ impl ToolContext {
     fn write_note(&self, forge_root: &Path, arguments: &Value) -> Result<Value, String> {
         let rel = validated_note_path(required_string(arguments, "path")?)?;
         let content = required_string(arguments, "content")?;
+        let base_hash = optional_string(arguments, "baseHash")?;
         let path = self.prepare_note_destination(forge_root, &rel)?;
         if locked_path(&path).exists() {
             return Err("Refusing to write a locked note".to_string());
@@ -318,17 +325,10 @@ impl ToolContext {
         if !path.exists() {
             return Err("Note does not exist; use create_note first".to_string());
         }
-        let raw = fs::read_to_string(&path)
-            .map_err(|error| format!("Failed to read note before writing: {error}"))?;
-        let parsed = crate::frontmatter::parse_note(&raw);
-        let serialized = crate::frontmatter::serialize_note(
-            parsed.color.as_deref(),
-            &parsed.extra,
-            content,
-        );
-        write_atomic(&path, serialized.as_bytes(), Some(0o600))?;
+        let conflict_copy = save_note_with_conflict(&path, base_hash, content, None)?
+            .map(|(conflict_name, _)| conflict_name);
         self.note_changed(forge_root, &rel);
-        Ok(json!({ "path": rel, "written": true }))
+        Ok(json!({ "path": rel, "written": true, "conflictCopy": conflict_copy }))
     }
 
     fn checked_existing_note(&self, forge_root: &Path, rel: &str) -> Result<PathBuf, String> {
@@ -373,7 +373,7 @@ fn write_tool_definitions() -> Vec<Value> {
     vec![
         tool("create_note", "Create a new Markdown note. Refuses to overwrite an existing or locked note.", content_path_schema()),
         tool("append_to_daily_note", "Append Markdown to a daily note, creating it when absent. Defaults to today's local date.", json!({"type":"object","properties":{"content":{"type":"string","description":"Markdown to append."},"date":{"type":"string","format":"date","description":"Optional YYYY-MM-DD date; defaults to today."}},"required":["content"],"additionalProperties":false})),
-        tool("write_note", "Fully replace an existing unlocked Markdown note. Refuses missing and locked notes.", content_path_schema()),
+        tool("write_note", "Fully replace an existing unlocked Markdown note. Pass read_note's contentHash as baseHash to preserve a changed disk version as a conflict copy before replacement. The response's conflictCopy is that sibling filename when a conflict was preserved, or null after a clean write. Omitting baseHash keeps legacy overwrite behavior. Refuses missing and locked notes.", content_path_schema()),
     ]
 }
 
@@ -387,7 +387,7 @@ fn note_path_schema(required: bool) -> Value {
 }
 
 fn content_path_schema() -> Value {
-    json!({"type":"object","properties":{"path":{"type":"string","description":"Forge-relative .md note path."},"content":{"type":"string","description":"Complete Markdown file content."}},"required":["path","content"],"additionalProperties":false})
+    json!({"type":"object","properties":{"path":{"type":"string","description":"Forge-relative .md note path."},"content":{"type":"string","description":"Complete Markdown file content."},"baseHash":{"type":"string","description":"For write_note, the contentHash returned by read_note. Omit it to keep legacy overwrite behavior."}},"required":["path","content"],"additionalProperties":false})
 }
 
 fn tool_result(value: Value, is_error: bool) -> Value {
@@ -404,6 +404,14 @@ fn required_string<'a>(arguments: &'a Value, name: &str) -> Result<&'a str, Stri
         .get(name)
         .and_then(Value::as_str)
         .ok_or_else(|| format!("{name} must be a string"))
+}
+
+fn optional_string<'a>(arguments: &'a Value, name: &str) -> Result<Option<&'a str>, String> {
+    match arguments.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(format!("{name} must be a string")),
+    }
 }
 
 fn optional_u32(arguments: &Value, name: &str) -> Result<Option<u32>, String> {


### PR DESCRIPTION
Closes #37. This is the top item on the roadmap and the most consequential open bug.

## Why

The GUI save path has compared a base hash against disk since v1.7.0 and preserves the disk version as a conflict copy when they differ (`commands/notes.rs:179-201`). The MCP server had none of it — `write_note` read the file only to recover frontmatter, then replaced the body unconditionally. Two agents, or one agent racing the open app, silently overwrote each other with no conflict copy and no trace.

## What changed

- `read_note` returns a `contentHash`.
- `write_note` accepts it back as an **optional** `baseHash` and routes through the same `save_note_with_conflict` the GUI uses.
- When the body changed underneath, the disk version is preserved as a sibling conflict copy and **its filename comes back in the response** as `conflictCopy`, `null` after a clean write. Without that, a caller that correctly passed a hash and displaced someone's work got byte-identical output to one that didn't — the single signal a human might need to reconcile two versions was being generated and dropped.
- `save_note_with_conflict` and `sha256_hex` become `pub(crate)`. Those two keywords are the entire change to `notes.rs`.

## The detail that would have silently broken this

`save_note_with_conflict` hashes the **parsed note body** (`notes.rs:133`), while MCP's `read_note` returns the **raw file including YAML frontmatter**. Hashing the raw file would have put the GUI and MCP in different hash spaces, so detection would fire on every write or never fire at all — and either failure looks like it works until someone loses a note. The hash is taken over `frontmatter::parse_note(&raw).body`. A test asserts the returned hash equals the body hash and differs from the raw-file hash.

## What this is not

**It is not cross-process atomicity, and nothing in the code or the changelog claims it is.** `conflict_copy_lock()` is a process-global `Mutex` and MCP runs as its own process (`moldavite --mcp`), so that lock does not serialize GUI against MCP. A TOCTOU window remains between the read and the replace. Preserving a copy instead of silently clobbering is the improvement being claimed.

`baseHash` is optional deliberately. Making it required would break every existing agent integration, and omitting it reproduces the prior behaviour exactly — the same semantics the GUI path's `base_hash: Option<&str>` already had.

`append_to_daily_note` deliberately keeps no base hash: appending cannot destroy an existing body. That is now recorded as a decision in a contract comment, with its residual risk, rather than looking like an oversight to the next reader.

## Verification

- `cargo clippy --lib --all-targets -- -D warnings` — clean
- `cargo test --lib` — **254 passing** (up from 249), 0 failed

Five new tests: matching hash writes cleanly and reports no conflict copy; mismatched hash preserves both versions and reports the copy's name; absent hash keeps legacy behaviour; `read_note`'s hash round-trips into `write_note` while preserving colour and unknown frontmatter; and the schema advertises `baseHash` as optional.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm