### PR TITLE
fix(trash): make trash storage names NTFS-safe, and fix four Windows tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Moldavite are documented here.
 
 - **New Forges appear while the Forge switcher is open.** A Forge created outside Moldavite, whether by an agent, the Obsidian importer, or anything else writing to your Forges folder, only joined the list the next time you opened it. The list now refreshes when Moldavite sees the new Forge on disk.
 - **The app could abort while building a note's backlinks.** The snippet shown under a backlink was cut out using byte positions, so a note containing an accented letter, an arrow, an emoji, or any other multi-byte character within about fifty characters of a `[[wiki link]]` would kill the process outright with no error and no warning. Vaults written in plain ASCII never saw it. The context window now snaps to character boundaries.
+- **Malformed trash metadata no longer breaks trash operations on Windows.** A persisted record containing an absolute Windows path left backslashes and a drive-letter colon in Moldavite's internal trash filename, which NTFS rejects before the app can validate the restore destination. Trash storage names are now made NTFS-safe, while existing valid trashed items keep their filenames.
 
 ## [1.8.1] - 2026-08-08
 

--- a/src-tauri/src/commands/import_obsidian.rs
+++ b/src-tauri/src/commands/import_obsidian.rs
@@ -1386,11 +1386,17 @@ mod tests {
     }
 
     fn import_fixture(source: &Path, forge: &Path) -> Result<ObsidianImportReport, String> {
+        // Match the production entry point. Windows canonicalization adds a
+        // `\\?\` prefix, so a canonical child does not start with an otherwise
+        // equivalent non-canonical source path during containment checks.
+        let source = source
+            .canonicalize()
+            .map_err(|error| format!("Could not resolve test vault: {error}"))?;
         scaffold_forge(forge)?;
-        let scan = scan_vault(source)?;
-        let daily = read_daily_notes_config(source);
+        let scan = scan_vault(&source)?;
+        let daily = read_daily_notes_config(&source);
         let plan = plan_notes(&scan.notes, &daily.effective)?;
-        import_prepared_vault(source, forge, "Imported", scan, daily, plan, |_, _| {})
+        import_prepared_vault(&source, forge, "Imported", scan, daily, plan, |_, _| {})
     }
 
     #[test]
@@ -1564,8 +1570,10 @@ mod tests {
         let source = tmp.path().join("source");
         let forges = tmp.path().join("forges");
         fs::create_dir_all(&forges).unwrap();
-        write_fixture(&source.join("A:B.md"), b"one");
-        write_fixture(&source.join("A?B.md"), b"two");
+        // `:` and `?` cannot exist in Windows filenames. These portable names
+        // still collide after the sanitizer replaces `..` with `-`.
+        write_fixture(&source.join("A..B.md"), b"one");
+        write_fixture(&source.join("A-B.md"), b"two");
         write_fixture(&source.join("one/photo.png"), b"one");
         write_fixture(&source.join("two/photo.png"), b"two");
         write_fixture(&source.join("view.canvas"), b"{}");

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -33,12 +33,70 @@ fn next_trash_id() -> String {
     }
 }
 
+fn trash_item_filename(id: &str, original_path: &str) -> String {
+    #[cfg(windows)]
+    {
+        // Valid Windows note paths contain none of these characters, so their
+        // existing trash filenames are unchanged. Only malformed persisted
+        // metadata needs the NTFS-safe mapping.
+        windows_safe_trash_item_filename(id, original_path)
+    }
+    #[cfg(not(windows))]
+    {
+        // Colons and backslashes are legal filename characters on Unix. Keep
+        // the original mapping there so existing trash remains addressable.
+        format!("{}_{}", id, original_path.replace('/', "_"))
+    }
+}
+
+#[cfg(any(windows, test))]
+fn windows_safe_trash_item_filename(id: &str, original_path: &str) -> String {
+    const MAX_WINDOWS_FILENAME_UNITS: usize = 255;
+
+    let flatten = |value: &str| {
+        value
+            .chars()
+            .map(|character| {
+                if character.is_control()
+                    || matches!(
+                        character,
+                        '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'
+                    )
+                {
+                    '_'
+                } else {
+                    character
+                }
+            })
+            .collect::<String>()
+    };
+    let mut filename = format!("{}_{}", flatten(id), flatten(original_path));
+
+    if filename.encode_utf16().count() > MAX_WINDOWS_FILENAME_UNITS {
+        let mut units = 0;
+        filename = filename
+            .chars()
+            .take_while(|character| {
+                let next = units + character.len_utf16();
+                if next > MAX_WINDOWS_FILENAME_UNITS {
+                    false
+                } else {
+                    units = next;
+                    true
+                }
+            })
+            .collect();
+    }
+    if matches!(filename.chars().last(), Some(' ' | '.')) {
+        filename.pop();
+        filename.push('_');
+    }
+
+    filename
+}
+
 fn trash_item_path(trash_dir: &std::path::Path, item: &TrashedNoteMetadata) -> std::path::PathBuf {
-    trash_dir.join(format!(
-        "{}_{}",
-        item.id,
-        item.original_path.replace('/', "_")
-    ))
+    trash_dir.join(trash_item_filename(&item.id, &item.original_path))
 }
 
 fn restore_item_on_disk(
@@ -124,7 +182,7 @@ pub(crate) fn trash_note(
     ensure_trash_dir()?;
 
     // Move file to trash with unique name to avoid conflicts
-    let trash_filename = format!("{}_{}", id, filename.replace('/', "_"));
+    let trash_filename = trash_item_filename(&id, &filename);
     let trash_path = get_trash_dir().join(&trash_filename);
     fs::rename(&source_path, &trash_path).map_err(|e| format!("Failed to move to trash: {}", e))?;
 
@@ -196,9 +254,9 @@ pub(crate) fn read_trashed_note(trash_id: String) -> Result<String, String> {
         return Ok(String::new());
     }
 
-    let trash_filename = format!("{}_{}", item.id, item.original_path.replace('/', "_"));
-    let trash_path = get_trash_dir().join(&trash_filename);
-    validate_path_within_base(&trash_path, &get_trash_dir())?;
+    let trash_dir = get_trash_dir();
+    let trash_path = trash_item_path(&trash_dir, item);
+    validate_path_within_base(&trash_path, &trash_dir)?;
 
     if !trash_path.exists() {
         return Err("Trash file not found on disk".to_string());
@@ -320,8 +378,7 @@ pub(crate) fn permanently_delete_trash(trash_id: String) -> Result<(), String> {
     let item = &metadata.items[item_index];
 
     // Build trash file/folder path and delete
-    let trash_filename = format!("{}_{}", item.id, item.original_path.replace('/', "_"));
-    let trash_path = get_trash_dir().join(&trash_filename);
+    let trash_path = trash_item_path(&get_trash_dir(), item);
 
     if trash_path.exists() {
         if item.is_folder {
@@ -342,11 +399,11 @@ pub(crate) fn permanently_delete_trash(trash_id: String) -> Result<(), String> {
 #[tauri::command]
 pub(crate) fn empty_trash() -> Result<(), String> {
     let metadata = read_trash_metadata();
+    let trash_dir = get_trash_dir();
 
     // Delete all files and folders
     for item in &metadata.items {
-        let trash_filename = format!("{}_{}", item.id, item.original_path.replace('/', "_"));
-        let trash_path = get_trash_dir().join(&trash_filename);
+        let trash_path = trash_item_path(&trash_dir, item);
         if trash_path.exists() {
             if item.is_folder {
                 let _ = fs::remove_dir_all(&trash_path);
@@ -472,7 +529,7 @@ fn trash_folder_on_disk(
         .and_then(|s| s.to_str())
         .unwrap_or(path)
         .to_string();
-    let trash_filename = format!("{}_{}", id, path.replace('/', "_"));
+    let trash_filename = trash_item_filename(id, path);
     let trash_path = trash_dir.join(&trash_filename);
     validate_path_within_base(&trash_path, trash_dir)
         .map_err(|_| "Invalid trash destination".to_string())?;
@@ -556,8 +613,7 @@ pub(crate) fn restore_note_from_folder(
     let item = &metadata.items[item_index];
 
     // Build trash folder path
-    let trash_folder_name = format!("{}_{}", item.id, item.original_path.replace('/', "_"));
-    let trash_folder_path = get_trash_dir().join(&trash_folder_name);
+    let trash_folder_path = trash_item_path(&get_trash_dir(), item);
 
     if !trash_folder_path.exists() {
         return Err("Trashed folder not found on disk".to_string());
@@ -648,6 +704,39 @@ mod tests {
             contained_files: Vec::new(),
             trashed_at,
         }
+    }
+
+    #[test]
+    fn valid_trash_items_keep_the_legacy_storage_name() {
+        assert_eq!(
+            trash_item_filename("123", "Projects/Deep/note.md"),
+            "123_Projects_Deep_note.md"
+        );
+    }
+
+    #[test]
+    fn windows_trash_storage_names_flatten_untrusted_metadata() {
+        assert_eq!(
+            windows_safe_trash_item_filename("7", r"C:\Users\Mauro\note.md"),
+            "7_C__Users_Mauro_note.md"
+        );
+
+        let invalid = windows_safe_trash_item_filename(
+            r#"bad:id\part"#,
+            "bad/name<with>|invalid?chars*.\u{0001}",
+        );
+        assert!(!invalid.chars().any(|character| {
+            character.is_control()
+                || matches!(
+                    character,
+                    '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'
+                )
+        }));
+
+        let long_path = format!(r"C:\{}.", "a".repeat(300));
+        let long = windows_safe_trash_item_filename("8", &long_path);
+        assert!(long.encode_utf16().count() <= 255);
+        assert!(!long.ends_with([' ', '.']));
     }
 
     #[test]


### PR DESCRIPTION
The `windows-latest` job added in #61 found five test failures on `main` the first time it ran. **Four were test artifacts. One was real.** This fixes all five, so `test-rust-windows` can be promoted to a required check.

## The real one: trash filenames

`trash_item_path` built storage names as `{id}_{original_path}` with `/` flattened to `_`. That `original_path` comes from **persisted trash metadata on disk**, and it reached filename construction *before* anything validated it. A record holding an absolute Windows path kept its backslashes and drive-letter colon, producing a name NTFS rejects outright — so the operation blew up with `InvalidFilename` before the restore destination could even be checked.

Every trash path now goes through one mapping that flattens the characters Windows forbids (`/ \ : * ? " < > |` and control characters), caps the result at 255 UTF-16 units, and refuses a trailing dot or space.

**Five call sites** were open-coding that same `format!` string — `read_trashed_note`, `permanently_delete_trash`, `empty_trash`, `trash_note`, `trash_folder_on_disk`. They now share the helper, which is not tidying: a mapping applied in only some of them silently orphans the item so it can never be restored or deleted.

**Existing trash is not disturbed.** On unix the mapping is byte-for-byte unchanged, because colons and backslashes are legal filename characters there and changing it would strand what users already have. On Windows a valid note path cannot contain any of the newly flattened characters, so those names come out identical too.

Note this is defence at construction rather than validate-first: the ordering weakness (untrusted metadata reaching name construction ahead of validation) is neutralised rather than reordered, which also covers any future caller that forgets to validate.

## The four artifacts: the Obsidian importer

Root cause for three of them was one thing: `import_fixture` passed a **non-canonical** vault root, while Windows `canonicalize()` prefixes children with `\\?\`. Containment checks therefore matched nothing, every note was skipped, and the expected counts came back `0`. The helper now canonicalizes first, which is what the production entry point does — so the test was diverging from the real code path, not the code being wrong.

The fourth used fixtures literally named `A:B.md` and `A?B.md`. Those cannot exist on Windows at all, so the fixture write failed before the assertion. They are now portable names that still collide after the sanitizer runs, exercising the same behaviour.

**No assertion was weakened, `#[ignore]`d, or `#[cfg]`-gated out of existence.**

## Verification

- `cargo clippy --lib --all-targets -- -D warnings` — clean
- `cargo test --lib` — **251 passing** (up from 249; two new trash regressions), 0 failed

macOS is unchanged, which is the point: the mapping only diverges on Windows and the importer change is test-only. The Windows result is what this PR is actually for, and CI is the authority for it.

Once this is green, `test-rust-windows` gets added to the required status checks.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm