### PR TITLE
chore: raise the changelog chunk budget

### DIFF
--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -24,7 +24,10 @@ const BUDGETS = [
   // The bundled CHANGELOG.md (?raw) lives in its own chunk so release-notes
   // content doesn't count against the app-code budget and can grow per release.
   // gzip bumped for the v1.6 release-notes section (What's New content ships in this chunk).
-  { pattern: /^changelog-.*\.js$/, rawKb: 48, gzipKb: 16 },
+  // Bumped for the v1.9 round: this chunk is prose, so it grows once per entry
+  // and the only way to hold a line here is to write fewer or worse release
+  // notes. Measured 40.2 KB raw / 16.1 KB gz on main at the time of the bump.
+  { pattern: /^changelog-.*\.js$/, rawKb: 64, gzipKb: 22 },
   { pattern: /^index-.*\.css$/, rawKb: 130, gzipKb: 25 },
 ];
 


### PR DESCRIPTION
## `main` is currently red

`build-web` fails on `main` right now:

```
changelog-BTdWIb_O.js    40.2 KB    16.1 KB gz   ❌ over budget (48 / 16 gz)
```

`CHANGELOG.md` is bundled with `?raw` into its own chunk so the What's New popup can render release notes. A budget on that chunk is therefore a budget on **how much prose a release is allowed to contain**, and the v1.9 round crossed the gzip line partway through. The only ways back under it are to write fewer entries or worse ones.

Raised to **64 KB raw / 22 KB gz**, measured at 40.2 / 16.1 on `main`, with the reasoning recorded in the file alongside the existing bump log.

The `APP_JS_BUDGET` is deliberately untouched — that one constrains actual app code and is doing real work at 539.8 / 141.9 against 544 / 146.

## How this got in

Worth recording, because it is a process finding rather than a code one. Every PR in this round passed `check:size` on its own branch, and the combination did not. This chunk only grows, so per-branch green never implied green after the merge.

Branch protection has `strict` (require branches up to date) temporarily off for this round so a dozen file-disjoint PRs can land without serialising a full CI run behind every merge. This is precisely the class of failure that trades away: not a textual conflict, but a cumulative budget crossing a line that no single branch could see. Caught by re-running the full verification against `main` after the wave, which is the mitigation that makes the tradeoff acceptable.

## Verification

- `npm run build && npm run check:size` on `main` + this change — `All bundles within budget.`

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm