### PR TITLE
test: give every wall-clock assertion one budget, sized for Windows

### DIFF
--- a/src-tauri/src/commands/export_import.rs
+++ b/src-tauri/src/commands/export_import.rs
@@ -703,7 +703,10 @@ mod tests {
             "week 53"
         );
         eprintln!("[stress] 500-note ZIP round trip took {elapsed:?}");
-        assert!(elapsed.as_secs() < 15, "ZIP round trip took {elapsed:?}");
+        assert!(
+            elapsed.as_secs() < crate::stress_test::REGRESSION_BUDGET_SECS,
+            "ZIP round trip took {elapsed:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -1544,6 +1544,9 @@ mod tests {
             "ciphertext containing [[café]] must stay byte-identical"
         );
         eprintln!("[stress] rewrote 550 foldered Unicode backlinks in {elapsed:?}");
-        assert!(elapsed.as_secs() < 30, "link rewrite took {elapsed:?}");
+        assert!(
+            elapsed.as_secs() < crate::stress_test::REGRESSION_BUDGET_SECS,
+            "link rewrite took {elapsed:?}"
+        );
     }
 }

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -741,9 +741,10 @@ mod tests {
             10
         );
         eprintln!("[stress] MCP search over 1000 notes took {elapsed:?}");
-        // Order-of-magnitude alarm, not a benchmark; mirrors
-        // stress_test::REGRESSION_BUDGET_SECS, see the rationale there.
-        assert!(elapsed.as_secs() < 30, "MCP search took {elapsed:?}");
+        assert!(
+            elapsed.as_secs() < crate::stress_test::REGRESSION_BUDGET_SECS,
+            "MCP search took {elapsed:?}"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src-tauri/src/semantic.rs
+++ b/src-tauri/src/semantic.rs
@@ -1366,7 +1366,10 @@ mod tests {
             1000
         );
         eprintln!("[stress] semantic build over 1000 notes took {elapsed:?}");
-        assert!(elapsed.as_secs() < 10, "semantic build took {elapsed:?}");
+        assert!(
+            elapsed.as_secs() < crate::stress_test::REGRESSION_BUDGET_SECS,
+            "semantic build took {elapsed:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/stress_test.rs
+++ b/src-tauri/src/stress_test.rs
@@ -8,12 +8,17 @@
 //! addition to generous upper bounds; timing thresholds are regression alarms,
 //! not performance benchmarks.
 
-/// Upper bound for the timing assertions in this module. These are
-/// order-of-magnitude alarms, not benchmarks: the operations they guard run in
-/// tens of milliseconds locally, so a breach means something regressed by a
-/// factor of hundreds. Five seconds was tight enough that a loaded or throttled
-/// CI machine tripped it on healthy code, and a test that cries wolf gets muted.
-const REGRESSION_BUDGET_SECS: u64 = 30;
+/// Upper bound for every wall-clock assertion in the crate's test suites, not
+/// just this module's. These are order-of-magnitude alarms, not benchmarks: the
+/// operations they guard run in well under a second locally, so a breach means
+/// something regressed by a factor of hundreds.
+///
+/// Sized for the slowest platform we test on rather than the fastest. The
+/// Windows CI runner measured 25s for the 500-note ZIP round trip and 31s for
+/// the 550-link rewrite on healthy code, roughly ten times the macOS figures,
+/// because these suites are dominated by per-file I/O. A budget tuned to a Mac
+/// simply reports Windows as broken.
+pub(crate) const REGRESSION_BUDGET_SECS: u64 = 120;
 
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Follow-up to #73, prompted by the Windows job added in #61.

## What Windows found

Two stress tests failed on `windows-latest` with healthy code:

```
[stress] 500-note ZIP round trip took 25.1545227s
  → panicked: ZIP round trip took 25.1545227s        (budget: 15s)

[stress] rewrote 550 foldered Unicode backlinks in 31.4684244s
  → panicked: link rewrite took 31.4684244s          (budget: 30s)
```

Neither is in `stress_test.rs`, so neither was in #44 and neither was touched by #73. Windows is roughly **ten times slower** on these suites because they are dominated by per-file I/O.

## The actual scope of #44

There were **six** wall-clock assertions in the crate, across five files:

| file | old budget | status |
| --- | --- | --- |
| `stress_test.rs` (search) | 5s | fixed in #73 |
| `stress_test.rs` (link rewrite) | 5s | fixed in #73, not in the issue |
| `mcp/server.rs` | 5s | fixed in #73 |
| `commands/export_import.rs` | 15s | **failing on Windows** |
| `commands/notes.rs` | 30s | **failing on Windows** |
| `semantic.rs` | 10s | next to go |

The issue named two of six. Each had its own number, chosen against whatever machine its author happened to be using.

## What changed

All six now share `stress_test::REGRESSION_BUDGET_SECS`. `semantic.rs` is included even though it has not failed yet — at 10s it was clearly next, and leaving it to fail on some future Windows run just to keep this diff smaller is a false economy.

**The budget is 120s, sized for the slowest platform we test on rather than the fastest.** These operations run in well under a second locally, so a 120s bound still catches the order-of-magnitude regression they exist to catch — which is all they are for, per the module's own doc: *"timing thresholds are regression alarms, not performance benchmarks."*

The general point: a threshold tuned to a Mac does not measure a regression on Windows, it just reports Windows as broken. Every test still `eprintln!`s its measured time, so a genuine slowdown stays visible in the log without failing the build.

## Verification

- `cargo clippy --lib --all-targets -- -D warnings` — clean
- `cargo test --lib` — 256 passing, 0 failed

Windows is the platform this is actually for, and CI is the authority for it.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm