### PR TITLE
fix(editor): dismiss a stuck tag or wiki-link suggestion popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Moldavite are documented here.
 
 ### Fixed
 
+- **Tag, wiki-link, and slash-command suggestions no longer get stuck after the editor loses focus.** Once a suggestion menu had opened, clicking elsewhere or switching notes could leave it floating above the app, and Escape only hid it without closing its editor state. Suggestion menus now close completely on blur or Escape, while mouse selection keeps the editor focused until the chosen item is inserted.
 - **Inter and Merriweather now work as editor fonts.** Both typefaces were blocked and silently fell back to the default. They now ship with the app, so both work offline and neither fetches anything from a third party.
 - **Keyboard shortcut labels now match your operating system.** Moldavite keeps the familiar Command, Option, Control, and Shift notation on macOS, while Windows and Linux now show Ctrl, Alt, and Shift shortcuts joined with plus signs.
 - **Notes inside folders can be renamed.** Moldavite validated their folder-relative addresses as bare filenames, so every rename stopped at "Invalid filename" as soon as the note lived below `notes/`. Foldered notes now keep their relative path during the rename, and inbound `[[wiki links]]` follow the new note name.

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -13,7 +13,11 @@ import { slugifyNoteName } from '@/lib/fileSystem';
 import { isContentEmpty } from '@/lib/validation';
 import { ReactRenderer } from '@tiptap/react';
 import type { Editor as TiptapEditor, Range as TiptapRange } from '@tiptap/core';
-import type { SuggestionProps, SuggestionKeyDownProps } from '@tiptap/suggestion';
+import {
+  exitSuggestion,
+  type SuggestionProps,
+  type SuggestionKeyDownProps,
+} from '@tiptap/suggestion';
 import tippy, { Instance } from 'tippy.js';
 
 /**
@@ -43,6 +47,9 @@ import {
 } from './extensions';
 import { usePluginCommandStore } from '@/stores/pluginCommandStore';
 import { ResizableImage } from './extensions/ResizableImage';
+import { tagSuggestionPluginKey } from './extensions/TagSuggestion';
+import { wikiLinkSuggestionPluginKey } from './extensions/WikiLinkSuggestion';
+import { slashCommandsPluginKey } from './extensions/SlashCommands';
 import type { TagItem, SlashCommandItem } from './extensions';
 import { LinkModal } from './LinkModal';
 import { ConfirmDialog } from '@/components/ui';
@@ -326,9 +333,9 @@ export function Editor() {
                 suggestion: {
                   char: '#',
                   allowSpaces: false,
-                  // See the WikiLinkSuggestion note: a note body ending in a
-                  // tag would otherwise pop this open the moment the note is
-                  // opened, with nothing to dismiss it.
+                  // Only start while the editor has focus. Once open, keep the
+                  // plugin active until Escape or onBlur explicitly exits it.
+                  // The list buttons preserve focus until their clicks insert.
                   allow: ({ editor, isActive }: { editor: TiptapEditor; isActive?: boolean }) =>
                     isActive === true || editor.isFocused,
                   items: ({ query }: { query: string }) => {
@@ -399,11 +406,6 @@ export function Editor() {
 
                       onKeyDown(props: SuggestionKeyDownProps) {
                         try {
-                          if (props.event.key === 'Escape') {
-                            popup?.[0]?.hide();
-                            return true;
-                          }
-
                           return (
                             (component?.ref as SuggestionListHandle | null)?.onKeyDown(
                               props.event
@@ -454,11 +456,9 @@ export function Editor() {
             // on a single '[' makes the query keep the second bracket
             // ("[Menta"), which can never match a note name.
             allowSpaces: true,
-            // Opening a note restores the selection at the end of the document.
-            // If the body ends in a tag or a link, that alone would activate the
-            // suggestion and leave a popup on screen the user never asked for.
-            // Only start while the editor has focus; `isActive` keeps an open
-            // popup alive so clicking one of its items still works.
+            // Only start while the editor has focus. Once open, keep the plugin
+            // active until Escape or onBlur explicitly exits it. The list buttons
+            // preserve focus until their clicks insert.
             allow: ({ editor, isActive }: { editor: TiptapEditor; isActive?: boolean }) =>
               isActive === true || editor.isFocused,
             items: ({ query }: { query: string }) => {
@@ -520,11 +520,6 @@ export function Editor() {
 
                 onKeyDown(props: SuggestionKeyDownProps) {
                   try {
-                    if (props.event.key === 'Escape') {
-                      popup?.[0]?.hide();
-                      return true;
-                    }
-
                     return (
                       (component?.ref as SuggestionListHandle | null)?.onKeyDown(props.event) ||
                       false
@@ -582,6 +577,7 @@ export function Editor() {
             char: '/',
             allowSpaces: false,
             startOfLine: true,
+            // Match the tag and wiki-link lifecycle above.
             allow: ({ editor, isActive }: { editor: TiptapEditor; isActive?: boolean }) =>
               isActive === true || editor.isFocused,
             items: ({ query }: { query: string }) => {
@@ -647,11 +643,6 @@ export function Editor() {
 
                 onKeyDown(props: SuggestionKeyDownProps) {
                   try {
-                    if (props.event.key === 'Escape') {
-                      popup?.[0]?.hide();
-                      return true;
-                    }
-
                     return (
                       (component?.ref as SuggestionListHandle | null)?.onKeyDown(props.event) ||
                       false
@@ -709,6 +700,11 @@ export function Editor() {
         } catch (error) {
           console.error('[Editor] onUpdate error:', error);
         }
+      },
+      onBlur: ({ editor }) => {
+        exitSuggestion(editor.view, tagSuggestionPluginKey);
+        exitSuggestion(editor.view, wikiLinkSuggestionPluginKey);
+        exitSuggestion(editor.view, slashCommandsPluginKey);
       },
       onDestroy: () => {
         // Clean up any pending operations when editor is destroyed

--- a/src/components/editor/extensions/SlashCommandList.tsx
+++ b/src/components/editor/extensions/SlashCommandList.tsx
@@ -252,6 +252,7 @@ export const SlashCommandList = forwardRef<SlashCommandListRef, SlashCommandList
             <button
               key={item.title}
               className={`slash-command-item ${index === selectedIndex ? 'selected' : ''}`}
+              onMouseDown={(event) => event.preventDefault()}
               onClick={() => selectItem(index)}
               onMouseEnter={() => setSelectedIndex(index)}
             >

--- a/src/components/editor/extensions/SlashCommands.ts
+++ b/src/components/editor/extensions/SlashCommands.ts
@@ -2,6 +2,8 @@ import { Extension } from '@tiptap/core';
 import { PluginKey } from '@tiptap/pm/state';
 import Suggestion, { SuggestionOptions } from '@tiptap/suggestion';
 
+export const slashCommandsPluginKey = new PluginKey('slashCommands');
+
 /**
  * TipTap extension that provides a command menu when typing "/" at the start of a line.
  * Shows formatting options like headings, lists, quotes, code blocks, etc.
@@ -16,7 +18,7 @@ export const SlashCommands = Extension.create({
         allowSpaces: false,
         startOfLine: true, // Only trigger at start of line
         allowedPrefixes: null,
-        pluginKey: new PluginKey('slashCommands'),
+        pluginKey: slashCommandsPluginKey,
       } as Partial<SuggestionOptions>,
     };
   },

--- a/src/components/editor/extensions/TagSuggestion.ts
+++ b/src/components/editor/extensions/TagSuggestion.ts
@@ -2,6 +2,8 @@ import { Extension } from '@tiptap/core';
 import { PluginKey } from '@tiptap/pm/state';
 import Suggestion, { SuggestionOptions } from '@tiptap/suggestion';
 
+export const tagSuggestionPluginKey = new PluginKey('tagSuggestion');
+
 /**
  * TipTap extension that provides autocomplete suggestions when typing # for tags.
  * Shows a dropdown of existing tags as the user types.
@@ -16,7 +18,7 @@ export const TagSuggestion = Extension.create({
         allowSpaces: false, // Tags don't have spaces
         startOfLine: false,
         allowedPrefixes: [' ', '\n', '\t', null], // Only trigger after whitespace or start
-        pluginKey: new PluginKey('tagSuggestion'),
+        pluginKey: tagSuggestionPluginKey,
       } as Partial<SuggestionOptions>,
     };
   },

--- a/src/components/editor/extensions/TagSuggestionList.tsx
+++ b/src/components/editor/extensions/TagSuggestionList.tsx
@@ -82,6 +82,7 @@ export const TagSuggestionList = forwardRef<TagSuggestionListRef, TagSuggestionL
           <button
             key={item.name}
             className={`wiki-link-suggestion-item ${index === selectedIndex ? 'selected' : ''}`}
+            onMouseDown={(event) => event.preventDefault()}
             onClick={() => selectItem(index)}
           >
             <div className="wiki-link-suggestion-icon">

--- a/src/components/editor/extensions/WikiLinkSuggestion.ts
+++ b/src/components/editor/extensions/WikiLinkSuggestion.ts
@@ -2,6 +2,8 @@ import { Extension } from '@tiptap/core';
 import { PluginKey } from '@tiptap/pm/state';
 import Suggestion, { SuggestionOptions } from '@tiptap/suggestion';
 
+export const wikiLinkSuggestionPluginKey = new PluginKey('wikiLinkSuggestion');
+
 /**
  * TipTap extension that provides autocomplete suggestions when typing [[ for wiki links.
  * Shows a dropdown of available notes as the user types.
@@ -16,7 +18,7 @@ export const WikiLinkSuggestion = Extension.create({
         allowSpaces: true,
         startOfLine: false,
         allowedPrefixes: null, // Allow triggering after any character
-        pluginKey: new PluginKey('wikiLinkSuggestion'),
+        pluginKey: wikiLinkSuggestionPluginKey,
       } as Partial<SuggestionOptions>,
     };
   },

--- a/src/components/editor/extensions/WikiLinkSuggestionList.tsx
+++ b/src/components/editor/extensions/WikiLinkSuggestionList.tsx
@@ -81,6 +81,7 @@ export const WikiLinkSuggestionList = forwardRef<
         <button
           key={item.name}
           className={`wiki-link-suggestion-item ${index === selectedIndex ? 'selected' : ''}`}
+          onMouseDown={(event) => event.preventDefault()}
           onClick={() => selectItem(index)}
         >
           <div className="wiki-link-suggestion-icon">


### PR DESCRIPTION
Closes #40.

## The issue's framing was wrong, so here is what actually happens

Reported as hover-triggered and as appearing purely from opening a note. Neither is right — the editor has to have been focused at least once. (Its claim about surviving a Forge switch cannot be literally true either, since switching Forge reloads the window.)

The real cause is the v1.7.2 guard:

```ts
allow: ({ editor, isActive }) => isActive === true || editor.isFocused,
```

`isActive === true ||` is a **permanent escape hatch**. Once the popup has opened even once, `allow` keeps returning true regardless of focus. Three things then combine:

1. **TipTap dispatches a transaction on blur.** Its `FocusEvents` extension sets `editor.isFocused = false` then dispatches `tr.setMeta("blur", …)`. The suggestion plugin's `apply` re-runs on that transaction, `prev.active` is still `true`, so `allow` returns true via the `isActive` branch and **the popup survives losing focus**. `onExit` never fires, and the tippy instance — `appendTo: () => document.body`, outside the React tree — just stays there.

2. **Escape could not rescue it, and was broken when it could.** ProseMirror routes `handleKeyDown` only while the view has DOM focus, so an unfocused popup was unreachable. And when it *was* reachable, the renderer returned `true` for Escape, which short-circuits `@tiptap/suggestion`'s own exit: its `if (handledByKeyDown) return true;` sits **before** `renderer.onExit(...)` and `dispatchExit(...)`. So Escape hid the tippy and left plugin state `active: true` forever. **All three renderers had it** — tags, wiki links and slash commands could all stick.

3. **It survived a note switch.** `setContent` maps the selection to the end of the new document; if that one also ends in a tag, `findSuggestionMatch` matches and `isActive` keeps it alive. The `blur()` in the content effect runs inside a `requestAnimationFrame`, i.e. *after* the activating transaction.

## The fix

- Escape now falls through to the library, which runs its own `onExit` and `dispatchExit`. Safe because all three list components already return `false` for Escape, so `handledByKeyDown` is false and the library completes the exit.
- `onBlur` calls `exitSuggestion` for each of the three plugin keys, which are now exported rather than inline.

## The trap, and how it is handled

The `isActive` escape hatch exists for a reason: **clicking a suggestion with the mouse blurs the editor**, so naively exiting on blur trades a stuck popup for one you cannot click.

The list buttons now `preventDefault()` on `mousedown`. Focus never leaves the editor, so blur never fires during a click, and the subsequent `click` still runs `selectItem`. That removes the race rather than tuning a timeout around it — no `setTimeout`, no relatedTarget sniffing.

## Verification

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — `16 problems (0 errors, 16 warnings)`, unchanged
- `npm test` — 428 passing
- `npm run build && npm run check:size` — within budget

**No automated test, and I want to be straight about that.** The regression spans TipTap's focus transaction, suggestion plugin state, and tippy's body-appended DOM. `Editor.tsx` has no harness — that is #38, deliberately not built here — and a test asserting only that a plugin key is exported or that `preventDefault` was called would prove nothing about the real behaviour.

**The mouse-click interaction is reasoned, not manually exercised.** The event sequence is well-defined and the existing click handlers are unchanged, so confidence is high, but nobody has clicked a suggestion in a running build. Worth a manual pass before release: type `#`, then click an entry with the mouse and confirm it inserts.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm