### PR TITLE
fix(editor): make Copy URL produce a link that opens the note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Moldavite are documented here.
 
 ### Fixed
 
+- **Copied note URLs now open their note.** Note links were accepted by the clipboard but ignored when Moldavite received them. They now open root notes, foldered notes, daily notes, and weekly notes in the existing editor tab flow, while missing or locked notes produce a visible error.
 - **Tag, wiki-link, and slash-command suggestions no longer get stuck after the editor loses focus.** Once a suggestion menu had opened, clicking elsewhere or switching notes could leave it floating above the app, and Escape only hid it without closing its editor state. Suggestion menus now close completely on blur or Escape, while mouse selection keeps the editor focused until the chosen item is inserted.
 - **Inter and Merriweather now work as editor fonts.** Both typefaces were blocked and silently fell back to the default. They now ship with the app, so both work offline and neither fetches anything from a third party.
 - **Keyboard shortcut labels now match your operating system.** Moldavite keeps the familiar Command, Option, Control, and Shift notation on macOS, while Windows and Linux now show Ctrl, Alt, and Shift shortcuts joined with plus signs.

--- a/src-tauri/src/deep_link.rs
+++ b/src-tauri/src/deep_link.rs
@@ -1,24 +1,34 @@
-//! Strict routing for website-initiated community-plugin install links.
+//! Strict routing for URLs that open app content or plugin install prompts.
 //!
-//! Deep-link URLs are untrusted OS input. Only `moldavite://plugin/<id>` is
-//! routed, and the final segment must satisfy the same id rules as plugin
-//! folders and install commands.
+//! Deep-link URLs are untrusted OS input. Only `moldavite://plugin/<id>` and
+//! `moldavite://note/<path>` are routed. Plugin ids follow the installer rules;
+//! note paths use the validator for addressing existing visible notes.
 
 use std::collections::VecDeque;
 use std::sync::Mutex;
 
+use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 
 use crate::commands::plugins::is_valid_plugin_id;
+use crate::validation::is_safe_existing_note_path;
 
 const PLUGIN_LINK_PREFIX: &str = "moldavite://plugin/";
-pub(crate) const PLUGIN_INSTALL_EVENT: &str = "plugin-install-requested";
+const NOTE_LINK_PREFIX: &str = "moldavite://note/";
+pub(crate) const DEEP_LINK_EVENT: &str = "deep-link-requested";
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub(crate) enum DeepLinkRequest {
+    Plugin { id: String },
+    Note { path: String },
+}
 
 /// Valid links wait here until the frontend is ready to drain them.
 #[derive(Default)]
-pub(crate) struct PendingPluginInstallLinks(Mutex<VecDeque<String>>);
+pub(crate) struct PendingDeepLinks(Mutex<VecDeque<DeepLinkRequest>>);
 
-/// Return the requested plugin id only for the one supported URL shape.
+/// Return the requested plugin id only for the supported plugin URL shape.
 pub(crate) fn plugin_id_from_url(url: &str) -> Option<&str> {
     let id = url.strip_prefix(PLUGIN_LINK_PREFIX)?;
     if is_valid_plugin_id(id) {
@@ -28,6 +38,59 @@ pub(crate) fn plugin_id_from_url(url: &str) -> Option<&str> {
     }
 }
 
+fn percent_decode(value: &str) -> Option<String> {
+    fn hex_value(byte: u8) -> Option<u8> {
+        match byte {
+            b'0'..=b'9' => Some(byte - b'0'),
+            b'a'..=b'f' => Some(byte - b'a' + 10),
+            b'A'..=b'F' => Some(byte - b'A' + 10),
+            _ => None,
+        }
+    }
+
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+
+        let high = hex_value(*bytes.get(index + 1)?)?;
+        let low = hex_value(*bytes.get(index + 2)?)?;
+        decoded.push((high << 4) | low);
+        index += 3;
+    }
+
+    String::from_utf8(decoded).ok()
+}
+
+/// Decode and validate a path that addresses an existing note.
+pub(crate) fn note_path_from_url(url: &str) -> Option<String> {
+    let encoded = url.strip_prefix(NOTE_LINK_PREFIX)?;
+    // Raw query and fragment delimiters are URL structure, not filename data.
+    // Existing filenames containing these characters still round-trip through
+    // encodeURIComponent as `%3F` and `%23`.
+    if encoded.contains(['?', '#']) {
+        return None;
+    }
+    let path = percent_decode(encoded)?;
+    if path.ends_with(".md") && is_safe_existing_note_path(&path) {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn request_from_url(url: &str) -> Option<DeepLinkRequest> {
+    if let Some(id) = plugin_id_from_url(url) {
+        return Some(DeepLinkRequest::Plugin { id: id.to_owned() });
+    }
+    note_path_from_url(url).map(|path| DeepLinkRequest::Note { path })
+}
+
 /// Validate OS-delivered URLs, queue supported requests, and wake a live UI.
 pub(crate) fn route_urls<R, I, S>(app: &AppHandle<R>, urls: I)
 where
@@ -35,25 +98,25 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    let state = app.state::<PendingPluginInstallLinks>();
+    let state = app.state::<PendingDeepLinks>();
     for url in urls {
         let url = url.as_ref();
-        let Some(id) = plugin_id_from_url(url) else {
+        let Some(request) = request_from_url(url) else {
             log::info!("[deep-link] ignored unsupported URL: {url}");
             continue;
         };
 
         match state.0.lock() {
-            Ok(mut pending) => pending.push_back(id.to_owned()),
+            Ok(mut pending) => pending.push_back(request),
             Err(error) => {
-                log::warn!("[deep-link] could not queue plugin request: {error}");
+                log::warn!("[deep-link] could not queue request: {error}");
                 continue;
             }
         }
 
-        if let Err(error) = app.emit(PLUGIN_INSTALL_EVENT, ()) {
-            // A cold-start WebView may not be listening yet. The queued id is
-            // intentionally retained for `take_pending_plugin_install_links`.
+        if let Err(error) = app.emit(DEEP_LINK_EVENT, ()) {
+            // A cold-start WebView may not be listening yet. The queued request
+            // is intentionally retained for `take_pending_deep_links`.
             log::info!("[deep-link] frontend not ready for event: {error}");
         }
     }
@@ -61,13 +124,11 @@ where
 
 /// Atomically hand all validated requests to the initialized frontend.
 #[tauri::command]
-pub(crate) fn take_pending_plugin_install_links(
-    state: State<'_, PendingPluginInstallLinks>,
-) -> Vec<String> {
+pub(crate) fn take_pending_deep_links(state: State<'_, PendingDeepLinks>) -> Vec<DeepLinkRequest> {
     match state.0.lock() {
         Ok(mut pending) => pending.drain(..).collect(),
         Err(error) => {
-            log::warn!("[deep-link] could not drain plugin requests: {error}");
+            log::warn!("[deep-link] could not drain requests: {error}");
             Vec::new()
         }
     }
@@ -75,7 +136,7 @@ pub(crate) fn take_pending_plugin_install_links(
 
 #[cfg(test)]
 mod tests {
-    use super::plugin_id_from_url;
+    use super::{note_path_from_url, plugin_id_from_url, request_from_url, DeepLinkRequest};
 
     #[test]
     fn routes_only_the_plugin_install_shape() {
@@ -84,6 +145,63 @@ mod tests {
             Some("publish-wordpress")
         );
         assert_eq!(plugin_id_from_url("moldavite://plugin/a"), Some("a"));
+    }
+
+    #[test]
+    fn routes_root_and_foldered_note_paths() {
+        assert_eq!(
+            request_from_url("moldavite://note/valid-id.md"),
+            Some(DeepLinkRequest::Note {
+                path: "valid-id.md".to_string(),
+            })
+        );
+        assert_eq!(
+            note_path_from_url("moldavite://note/Root%20note.md"),
+            Some("Root note.md".to_string())
+        );
+        assert_eq!(
+            note_path_from_url("moldavite://note/Projects%2FRoadmap.md"),
+            Some("Projects/Roadmap.md".to_string())
+        );
+    }
+
+    #[test]
+    fn decodes_percent_encoded_unicode_names() {
+        assert_eq!(
+            note_path_from_url("moldavite://note/Projects%2Fcaf%C3%A9%20notes.md"),
+            Some("Projects/café notes.md".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_note_paths() {
+        for url in [
+            "moldavite://note/../evil.md",
+            "moldavite://note/Projects%2F..%2Fevil.md",
+            "moldavite://note/%2Fabsolute.md",
+            "moldavite://note/C%3A%2Fevil.md",
+            "moldavite://note/C:/evil.md",
+            "moldavite://note/Projects%5Cevil.md",
+            "moldavite://note/.trash%2Fevil.md",
+        ] {
+            assert_eq!(note_path_from_url(url), None, "unexpected route for {url}");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_or_unsupported_note_urls() {
+        for url in [
+            "moldavite://note/",
+            "moldavite://note/no-extension",
+            "moldavite://note/bad%2",
+            "moldavite://note/bad%GG.md",
+            "moldavite://note/valid.md?query=true",
+            "moldavite://note/valid.md#fragment",
+            "https://note/valid.md",
+            "MOLDAVITE://note/valid.md",
+        ] {
+            assert_eq!(note_path_from_url(url), None, "unexpected route for {url}");
+        }
     }
 
     #[test]
@@ -97,7 +215,7 @@ mod tests {
             "moldavite://plugin/valid-id?confirm=true",
             "moldavite://plugin/valid-id#fragment",
             "moldavite://plugins/valid-id",
-            "moldavite://note/valid-id",
+            "moldavite://note/valid-id.md",
             "https://plugin/valid-id",
             "MOLDAVITE://plugin/valid-id",
         ] {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -222,7 +222,7 @@ pub fn run() {
         })
         .manage(backlinks_index.clone())
         .manage(recent_writes.clone())
-        .manage(deep_link::PendingPluginInstallLinks::default())
+        .manage(deep_link::PendingDeepLinks::default())
         .setup(move |app| {
             // Register before WebView hydration. Live URLs wake the frontend;
             // cold-start URLs remain queued until React drains them.
@@ -289,7 +289,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            deep_link::take_pending_plugin_install_links,
+            deep_link::take_pending_deep_links,
             ensure_directories,
             get_app_binary_path,
             get_mcp_writes_enabled,

--- a/src/components/editor/MoreOptionsMenu.tsx
+++ b/src/components/editor/MoreOptionsMenu.tsx
@@ -26,6 +26,7 @@ import { SaveTemplateModal } from '@/components/templates/SaveTemplateModal';
 import { PdfExportOptionsModal } from './PdfExportOptionsModal';
 import type { NoteFile } from '@/types';
 import type { PdfPageSize, PdfMarginPreset } from '@/stores';
+import { noteDeepLink } from '@/hooks/usePluginDeepLinks';
 
 const RenameNoteModal = lazy(() =>
   import('@/components/ui/RenameNoteModal').then((m) => ({ default: m.RenameNoteModal }))
@@ -60,15 +61,8 @@ export function MoreOptionsMenu({
   const handleCopyUrl = async () => {
     if (!currentNote) return;
 
-    const filename =
-      currentNote.isDaily && currentNote.date
-        ? `${currentNote.date}.md`
-        : `${currentNote.title}.md`;
-
-    const link = `moldavite://note/${encodeURIComponent(filename)}`;
-
     try {
-      await navigator.clipboard.writeText(link);
+      await navigator.clipboard.writeText(noteDeepLink(currentNote));
       onShowToast?.('URL copied');
     } catch (error) {
       console.error('[MoreOptionsMenu] Failed to copy URL:', error);

--- a/src/hooks/usePluginDeepLinks.test.tsx
+++ b/src/hooks/usePluginDeepLinks.test.tsx
@@ -1,15 +1,20 @@
-/** Validation and cold/running delivery tests for plugin install deep links. */
+/** Validation and cold/running delivery tests for app deep links. */
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useGraphStore } from '@/stores/graphStore';
+import { useNoteStore } from '@/stores/noteStore';
 import { usePluginInstallStore } from '@/stores/pluginInstallStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useTimelineStore } from '@/stores/timelineStore';
+import { useToastStore } from '@/stores/toastStore';
+import type { Note, NoteFile } from '@/types';
 
 const invokeMock = vi.fn();
 const listenMock = vi.fn();
 let eventHandler: (() => void) | undefined;
+let pendingRequests: unknown[];
+let listedNotes: NoteFile[];
 
 vi.mock('@/lib/ipc', () => ({
   safeInvoke: (...args: unknown[]) => invokeMock(...args),
@@ -19,12 +24,47 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: (...args: unknown[]) => listenMock(...args),
 }));
 
-import { routePluginInstallRequest, usePluginDeepLinks } from './usePluginDeepLinks';
+import {
+  noteDeepLink,
+  routeNoteRequest,
+  routePluginInstallRequest,
+  usePluginDeepLinks,
+} from './usePluginDeepLinks';
+
+const rootNote: NoteFile = {
+  name: 'Root note.md',
+  path: 'notes/Root note.md',
+  isDaily: false,
+  isWeekly: false,
+  isLocked: false,
+};
+
+const folderedNote: NoteFile = {
+  name: 'café notes.md',
+  path: 'notes/Projects/café notes.md',
+  folderPath: 'Projects',
+  isDaily: false,
+  isWeekly: false,
+  isLocked: false,
+};
 
 beforeEach(() => {
   localStorage.clear();
   eventHandler = undefined;
-  invokeMock.mockReset().mockResolvedValue([]);
+  pendingRequests = [];
+  listedNotes = [rootNote, folderedNote];
+  invokeMock.mockReset().mockImplementation(async (command: string) => {
+    if (command === 'take_pending_deep_links') {
+      const requests = pendingRequests;
+      pendingRequests = [];
+      return requests;
+    }
+    if (command === 'list_notes') return listedNotes;
+    if (command === 'read_note') {
+      return { content: '# Opened note', color: null, contentHash: 'content-hash' };
+    }
+    return undefined;
+  });
   listenMock.mockReset().mockImplementation(async (_event: string, handler: () => void) => {
     eventHandler = handler;
     return vi.fn();
@@ -33,43 +73,130 @@ beforeEach(() => {
   usePluginInstallStore.setState({ pending: null });
   useTimelineStore.setState({ isOpen: false });
   useGraphStore.setState({ isOpen: false });
+  useToastStore.setState({ toasts: [] });
+  useNoteStore.setState({
+    notes: [],
+    openTabs: [],
+    activeTabId: null,
+    currentNote: null,
+    recentNoteIds: [],
+    unlockedNotes: new Set(),
+    externallyChanged: new Set(),
+    isLoading: false,
+    isSaving: false,
+  });
 });
 
-describe('plugin install deep links', () => {
-  it('opens Settings with a validated cold-start request and yields transient views', async () => {
-    invokeMock.mockResolvedValueOnce(['publish-wordpress', '../invalid']);
-    useTimelineStore.getState().open();
-    useGraphStore.getState().open();
+describe('app deep links', () => {
+  it('round-trips root and foldered note identities through Copy URL encoding', () => {
+    const root: Note = {
+      id: rootNote.path,
+      title: 'Root note',
+      content: '',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isDaily: false,
+      isWeekly: false,
+    };
+    const foldered = { ...root, id: folderedNote.path, title: 'café notes' };
+
+    expect(noteDeepLink(root)).toBe('moldavite://note/Root%20note.md');
+    expect(noteDeepLink(foldered)).toBe('moldavite://note/Projects%2Fcaf%C3%A9%20notes.md');
+    expect(
+      noteDeepLink({
+        ...root,
+        id: 'daily/2026-08-14.md',
+        isDaily: true,
+        date: '2026-08-14',
+      })
+    ).toBe('moldavite://note/daily%2F2026-08-14.md');
+    expect(
+      noteDeepLink({
+        ...root,
+        id: 'weekly/2026-W33.md',
+        isWeekly: true,
+        week: '2026-W33',
+      })
+    ).toBe('moldavite://note/weekly%2F2026-W33.md');
+  });
+
+  it('opens a validated cold-start note through the normal tab flow', async () => {
+    pendingRequests = [{ kind: 'note', path: 'Projects/café notes.md' }];
 
     renderHook(() => usePluginDeepLinks());
 
-    await waitFor(() =>
-      expect(usePluginInstallStore.getState().pending?.id).toBe('publish-wordpress')
+    await waitFor(() => expect(useNoteStore.getState().currentNote?.id).toBe(folderedNote.path));
+    expect(invokeMock).toHaveBeenCalledWith('read_note', {
+      filename: 'Projects/café notes.md',
+      isDaily: false,
+      isWeekly: false,
+    });
+  });
+
+  it('drains the same backend queue for a running-instance note event', async () => {
+    renderHook(() => usePluginDeepLinks());
+    await waitFor(() => expect(eventHandler).toBeTypeOf('function'));
+    pendingRequests = [{ kind: 'note', path: 'Root note.md' }];
+
+    act(() => eventHandler?.());
+
+    await waitFor(() => expect(useNoteStore.getState().currentNote?.id).toBe(rootNote.path));
+    expect(invokeMock).toHaveBeenLastCalledWith('read_note', {
+      filename: 'Root note.md',
+      isDaily: false,
+      isWeekly: false,
+    });
+  });
+
+  it('shows a visible error when a linked note does not exist', async () => {
+    listedNotes = [];
+    useNoteStore.setState({ notes: [rootNote] });
+
+    expect(
+      await routeNoteRequest('Root note.md', vi.fn(), async () => {
+        useNoteStore.setState({ notes: listedNotes });
+      })
+    ).toBe(false);
+
+    expect(useToastStore.getState().toasts[0]?.message).toBe(
+      'The linked note was not found in this Forge.'
     );
+  });
+
+  it('opens Settings with a validated plugin request and yields transient views', () => {
+    useTimelineStore.getState().open();
+    useGraphStore.getState().open();
+
+    expect(routePluginInstallRequest('publish-wordpress')).toBe(true);
+
+    expect(usePluginInstallStore.getState().pending?.id).toBe('publish-wordpress');
     expect(useSettingsStore.getState().isSettingsOpen).toBe(true);
     expect(useSettingsStore.getState().activeSettingsTab).toBe('plugins');
     expect(useTimelineStore.getState().isOpen).toBe(false);
     expect(useGraphStore.getState().isOpen).toBe(false);
   });
 
-  it('drains the backend queue again for a running-instance event', async () => {
+  it('keeps plugin requests on the shared cold-start queue', async () => {
+    pendingRequests = [{ kind: 'plugin', id: 'publish-wordpress' }];
+
     renderHook(() => usePluginDeepLinks());
-    await waitFor(() => expect(eventHandler).toBeTypeOf('function'));
-    invokeMock.mockResolvedValueOnce(['second-plugin']);
 
-    act(() => eventHandler?.());
-
-    await waitFor(() => expect(usePluginInstallStore.getState().pending?.id).toBe('second-plugin'));
-    expect(invokeMock).toHaveBeenLastCalledWith('take_pending_plugin_install_links');
+    await waitFor(() =>
+      expect(usePluginInstallStore.getState().pending?.id).toBe('publish-wordpress')
+    );
+    expect(useSettingsStore.getState().activeSettingsTab).toBe('plugins');
   });
 
-  it('rejects malformed frontend payloads defensively', () => {
-    expect(routePluginInstallRequest('valid-plugin')).toBe(true);
-    const validRequest = usePluginInstallStore.getState().pending;
+  it('rejects malformed frontend payloads defensively', async () => {
+    const loadNote = vi.fn();
+    const refresh = vi.fn().mockResolvedValue(undefined);
 
     expect(routePluginInstallRequest('valid-plugin/extra')).toBe(false);
     expect(routePluginInstallRequest('-leading')).toBe(false);
-    expect(routePluginInstallRequest({ id: 'valid-plugin' })).toBe(false);
-    expect(usePluginInstallStore.getState().pending).toEqual(validRequest);
+    expect(await routeNoteRequest('../evil.md', loadNote, refresh)).toBe(false);
+    expect(await routeNoteRequest('/absolute.md', loadNote, refresh)).toBe(false);
+    expect(await routeNoteRequest('C:/evil.md', loadNote, refresh)).toBe(false);
+    expect(loadNote).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/usePluginDeepLinks.ts
+++ b/src/hooks/usePluginDeepLinks.ts
@@ -1,4 +1,4 @@
-/** Cold-start and running-instance delivery for website plugin install links. */
+/** Cold-start and running-instance delivery for validated app deep links. */
 
 import { useEffect } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -7,9 +7,43 @@ import { useGraphStore } from '@/stores/graphStore';
 import { usePluginInstallStore } from '@/stores/pluginInstallStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useTimelineStore } from '@/stores/timelineStore';
+import { useNoteStore } from '@/stores/noteStore';
+import { useToastStore } from '@/stores/toastStore';
+import { useNotes } from './useNotes';
+import type { Note, NoteFile } from '@/types';
 
-export const PLUGIN_INSTALL_EVENT = 'plugin-install-requested';
+export const DEEP_LINK_EVENT = 'deep-link-requested';
 const PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const DRIVE_PREFIX_RE = /^[a-z]:/i;
+
+interface PluginDeepLinkRequest {
+  kind: 'plugin';
+  id: string;
+}
+
+interface NoteDeepLinkRequest {
+  kind: 'note';
+  path: string;
+}
+
+type DeepLinkRequest = PluginDeepLinkRequest | NoteDeepLinkRequest;
+type LoadNote = (note: NoteFile, inNewTab?: boolean) => Promise<void>;
+type RefreshNotes = () => Promise<void>;
+
+/** Build a path-stable note URL, preserving folders and note type. */
+export function noteDeepLink(
+  note: Pick<Note, 'id' | 'isDaily' | 'isWeekly' | 'date' | 'week'>
+): string {
+  let reference: string;
+  if (note.isDaily && note.date) {
+    reference = `daily/${note.date}.md`;
+  } else if (note.isWeekly && note.week) {
+    reference = `weekly/${note.week}.md`;
+  } else {
+    reference = note.id.startsWith('notes/') ? note.id.slice('notes/'.length) : note.id;
+  }
+  return `moldavite://note/${encodeURIComponent(reference)}`;
+}
 
 /** Route only backend-validated plugin ids into Settings; fail closed otherwise. */
 export function routePluginInstallRequest(value: unknown): boolean {
@@ -26,28 +60,108 @@ export function routePluginInstallRequest(value: unknown): boolean {
   return true;
 }
 
+function isSafeNoteReference(value: unknown): value is string {
+  if (
+    typeof value !== 'string' ||
+    !value.endsWith('.md') ||
+    value.includes('\0') ||
+    value.includes('\\') ||
+    value.startsWith('/') ||
+    DRIVE_PREFIX_RE.test(value)
+  ) {
+    return false;
+  }
+  return value.split('/').every((part) => part.length > 0 && !part.startsWith('.'));
+}
+
+function notePathForReference(reference: string): string {
+  if (
+    reference.startsWith('notes/') ||
+    reference.startsWith('daily/') ||
+    reference.startsWith('weekly/')
+  ) {
+    return reference;
+  }
+  return `notes/${reference}`;
+}
+
+async function findLinkedNote(
+  reference: string,
+  refreshNotes: RefreshNotes
+): Promise<NoteFile | null> {
+  const targetPath = notePathForReference(reference);
+  // Cold-start delivery can beat initialization, while a live request can see
+  // a stale list after an external deletion. Refresh before resolving either.
+  await refreshNotes();
+  const note = useNoteStore.getState().notes.find((candidate) => candidate.path === targetPath);
+  return note ?? null;
+}
+
+/** Resolve a validated note reference and use the normal editor navigation path. */
+export async function routeNoteRequest(
+  value: unknown,
+  loadNote: LoadNote,
+  refreshNotes: RefreshNotes
+): Promise<boolean> {
+  if (!isSafeNoteReference(value)) return false;
+
+  const note = await findLinkedNote(value, refreshNotes);
+  if (!note) {
+    useToastStore.getState().addToast('error', 'The linked note was not found in this Forge.');
+    return false;
+  }
+  if (note.isLocked) {
+    useToastStore
+      .getState()
+      .addToast('error', 'The linked note is locked. Unlock it from the sidebar first.');
+    return false;
+  }
+
+  useSettingsStore.getState().setIsSettingsOpen(false);
+  await loadNote(note);
+  return true;
+}
+
+function isDeepLinkRequest(value: unknown): value is DeepLinkRequest {
+  if (!value || typeof value !== 'object') return false;
+  const request = value as Record<string, unknown>;
+  if (request.kind === 'plugin') {
+    return typeof request.id === 'string' && PLUGIN_ID_RE.test(request.id);
+  }
+  return request.kind === 'note' && isSafeNoteReference(request.path);
+}
+
 /**
  * Subscribe before draining so a URL arriving during startup cannot be lost.
  * The Rust queue is also the payload source for live events, avoiding separate
  * cold/running routing paths.
  */
 export function usePluginDeepLinks() {
+  const { loadNote, refresh } = useNotes();
+
   useEffect(() => {
     let disposed = false;
     let unlisten: UnlistenFn | undefined;
 
     const drain = async () => {
       try {
-        const pending = await safeInvoke<unknown>('take_pending_plugin_install_links');
+        const pending = await safeInvoke<unknown>('take_pending_deep_links');
         if (!Array.isArray(pending)) return;
-        pending.forEach(routePluginInstallRequest);
+        for (const request of pending) {
+          if (!isDeepLinkRequest(request)) continue;
+          if (request.kind === 'plugin') {
+            routePluginInstallRequest(request.id);
+          } else {
+            await routeNoteRequest(request.path, loadNote, refresh);
+          }
+        }
       } catch (error) {
-        console.error('[deep-link] could not read pending plugin requests:', error);
+        console.error('[deep-link] could not read pending requests:', error);
       }
     };
 
     const initialize = async () => {
-      const stop = await listen(PLUGIN_INSTALL_EVENT, () => {
+      const stop = await listen(DEEP_LINK_EVENT, () => {
         void drain();
       });
       if (disposed) {
@@ -63,5 +177,5 @@ export function usePluginDeepLinks() {
       disposed = true;
       unlisten?.();
     };
-  }, []);
+  }, [loadNote, refresh]);
 }


### PR DESCRIPTION
Closes #63.

## What was wrong

The note menu offered **Copy URL** and handed back `moldavite://note/<file>`. The deep-link router only ever accepted `moldavite://plugin/`, and `deep_link.rs` carried an **explicit test asserting the note form returns `None`**.

So the link had never worked, on any platform. Paste one into a note, a task manager or a message and it looks like a working deep link right up until someone clicks it. A menu item that silently produces a dead link is worse than no menu item.

## What changed

The router now understands a `note/` route and opens the referenced note through **the same queue the plugin route already uses** — so a click works whether the app is already running or starts cold, rather than a second delivery path being bolted on beside it.

**The reference is untrusted input and is validated like one.** It is percent-decoded as UTF-8, required to end in `.md`, and rejected for traversal, hidden components, absolute paths, backslashes, drive prefixes, queries and fragments.

It validates with `is_safe_existing_note_path`, not the stricter new-name validator. A deep link addresses a note **already on disk**, and this repo now distinguishes the two: using the strict one would refuse legacy filenames that are still perfectly reachable in the app.

## A second bug found on the way

Copy URL was rebuilding a filename from the note's **display title** — the thing `CLAUDE.md` explicitly warns against ("Never derive a filename from a note's display title"). It now copies the stored path, so notes in folders and daily and weekly notes keep their identity through the round trip.

A link to a note that no longer exists, or one that is locked, now reports that rather than doing nothing.

The old test asserting `note/` returns `None` encoded the previous contract, so it is **replaced deliberately** with coverage of the new one rather than deleted.

## Verification

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — `16 problems (0 errors, 16 warnings)`, unchanged
- `npm test` — **435 passing**
- `npm run build && npm run check:size` — within budget
- `cargo clippy --lib --all-targets -- -D warnings` — clean
- `cargo test --lib` — **292 passing**, 0 failed

Frontend tests cover root and folder round-tripping, daily and weekly identity, cold start, live delivery, a missing note, plugin-link compatibility, and rejection of malformed payloads.

**Not verified:** nobody has clicked a `moldavite://` link on a running build. Cold-start delivery in particular is exercised by tests, not by an actual OS handoff. Worth a manual pass before release, on both platforms.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm