### PR TITLE
docs: say Windows is supported, and stop claiming it is signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <a href="https://github.com/mauropereiira/Moldavite/releases/latest"><img src="https://img.shields.io/github/v/release/mauropereiira/Moldavite?style=flat-square&color=9dc183&label=release" alt="Latest release"></a>
   <img src="https://img.shields.io/badge/macOS-10.15%2B-2d5a3d?style=flat-square&logo=apple&logoColor=white" alt="macOS 10.15+">
+  <img src="https://img.shields.io/badge/Windows-supported-2d5a3d?style=flat-square&logo=windows&logoColor=white" alt="Windows supported">
   <img src="https://img.shields.io/badge/license-MIT-c9a227?style=flat-square" alt="MIT">
 </p>
 
@@ -28,15 +29,19 @@
 
 ---
 
-Moldavite is a notes app for macOS. Your notes are plain Markdown files in a
-folder you own. There is no account and no sync service.
+Moldavite is a notes app for macOS and Windows. Your notes are plain Markdown
+files in a folder you own. There is no account and no sync service.
 
-Open that folder in Finder, put it in git, edit it in another app, and Moldavite
-picks up the change. It also runs an MCP server, so Claude and other AI tools can
-read your notes on your machine. Read tools are on by default. Writing stays off
-until you switch it on.
+Open that folder in Finder or File Explorer, put it in git, edit it in another
+app, and Moldavite picks up the change. It also runs an MCP server, so Claude and
+other AI tools can read your notes on your machine. Read tools are on by default.
+Writing stays off until you switch it on.
 
 ## Install
+
+### macOS
+
+Install with Homebrew:
 
 ```sh
 brew install --cask mauropereiira/moldavite/moldavite
@@ -50,8 +55,23 @@ and drag it to Applications:
 | Apple Silicon | `Moldavite_x.x.x_aarch64.dmg` |
 | Intel | `Moldavite_x.x.x_x64.dmg` |
 
-Builds are signed and notarized, so macOS opens them without a warning. Requires
-macOS 10.15 or later. Updates install themselves after a minisign check.
+macOS builds are signed and notarized. Requires macOS 10.15 or later. Updates
+install themselves after a minisign check.
+
+### Windows
+
+[Download the latest release](https://github.com/mauropereiira/Moldavite/releases/latest)
+and run one of these x64 installers:
+
+| Installer | File |
+|-----------|------|
+| Setup executable (recommended) | `Moldavite_x.x.x_x64-setup.exe` |
+| Windows Installer package | `Moldavite_x.x.x_x64_en-US.msi` |
+
+The Windows installers are not Authenticode-signed, so SmartScreen may show a
+warning. If you downloaded Moldavite from the official release page, choose
+**More info**, then **Run anyway**. In-app updates are signed and verified before
+installation.
 
 ## What it looks like
 
@@ -93,6 +113,9 @@ Settings → AI & Agents generates the right line for Claude Code, Claude Deskto
 Cursor, or any stdio MCP client. Add `--forge "Work"` to pin a client to one
 Forge instead of following whichever Forge is open.
 
+On Windows, use the command generated in Settings so the client gets the exact
+path to your installed executable.
+
 | Tool | Does | Default |
 |------|------|---------|
 | `list_notes` | Enumerate notes and locked-note placeholders, optionally by folder | On |
@@ -125,7 +148,7 @@ A **Forge** is a vault. It is an ordinary directory holding ordinary files, and
 you can keep as many as you like:
 
 ```
-~/Documents/Moldavite/<ForgeName>/
+<Documents>/Moldavite/<ForgeName>/
 ├── daily/         # YYYY-MM-DD.md, created on demand, removed when emptied
 ├── weekly/        # YYYY-Www.md
 ├── notes/         # standalone notes, nested folders supported
@@ -148,11 +171,11 @@ as a timestamped conflict copy.
   rewrites every inbound link across the vault and keeps your open tabs pointed
   at the right file.
 - **Finding.** Backlinks panel, `#tags` with global rename, folders, and a quick
-  switcher on `⌘P`. Search is a live scan, which is comfortable to roughly a
-  thousand notes.
+  switcher on `⌘P` (macOS) or `Ctrl+P` (Windows). Search is a live scan, which is
+  comfortable to roughly a thousand notes.
 - **Semantic search.** Optional. Pick one of three embedding models, approve the
-  download, and everything after that runs offline. Apple Silicon only; Intel
-  Macs get keyword search.
+  download, and everything after that runs offline. Windows and Apple Silicon
+  builds include semantic search; Intel Macs get keyword search.
 - **Locking.** Individual notes encrypt with AES-256-GCM and Argon2, with
   rate-limited unlock and auto-relock. Locked notes stay out of search, indexing,
   and every agent tool.
@@ -169,13 +192,12 @@ as a timestamped conflict copy.
 
 No account system, no hosted notes service, no analytics, no telemetry.
 
-Moldavite makes five network calls, all of them on purpose: a signed update check
-about fifteen seconds after launch and once a day while open; the plugin registry
-from GitHub when you press Browse; a semantic model from Hugging Face after you
-opt in; Google Calendar while a Google account is connected; and plugin requests
-to hosts you approved by name.
-
-Publishing a note to WordPress is an action you take. Full detail in the
+Moldavite has six ways to reach the network, all of them on purpose: a signed
+update check about fifteen seconds after launch and once a day while open; the
+plugin registry from GitHub when you press Browse; a semantic model from Hugging
+Face after you opt in; Google Calendar while a Google account is connected;
+plugin requests to hosts you approved by name; and publishing a note to WordPress
+when you choose that action. Full detail in the
 [Privacy Policy](https://mauropereiira.github.io/Moldavite/privacy.html).
 
 ## Contributing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ flowchart TB
     end
     subgraph OS["Operating system"]
         SW["Swift bridge → EventKit<br/>macOS only"]
-        KC["Keychain / credential store"]
+        KC["OS credential store"]
     end
     GC["Google Calendar API<br/>read-only, OAuth"]
     DISK[("Your Forge<br/>plain Markdown")]
@@ -80,7 +80,7 @@ flowchart LR
         CMD["Commands · editor · toasts"]
         NOTE["Unlocked note reads"]
         NET["HTTPS to approved exact hosts"]
-        KC["macOS Keychain<br/>namespaced per plugin"]
+        KC["OS credential store<br/>namespaced per plugin"]
     end
     P <-- "postMessage" --> B
     B --> CMD
@@ -99,11 +99,15 @@ either re-prompts the user.
 | Register commands, read/replace editor selection, toasts | No |
 | Read unlocked note metadata and Markdown | Yes |
 | HTTPS to named hosts (individually revocable) | Yes |
-| Secrets in the macOS Keychain | Yes |
+| Secrets in the OS credential store | Yes |
 | Host-rendered prompt forms | Yes |
 | DOM, `fetch`, WebSockets, Tauri IPC, other plugins' secrets, locked notes | **Never available** |
 
 The full authoring surface is in [PLUGINS.md](PLUGINS.md).
+
+The `keyring` backend stores secrets in the macOS Keychain on macOS and Windows
+Credential Manager on Windows. Plugin account names remain isolated within the
+same `Moldavite` service on either platform.
 
 ## Source layout
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,7 +1,7 @@
 # Moldavite — Project Status
 
-**Last Updated:** August 7, 2026 (v1.8.0)
-**Status:** Shipping — signed/notarized releases with in-app auto-update since v1.3.1
+**Last Updated:** August 14, 2026
+**Status:** Shipping on macOS and Windows, with in-app auto-update since v1.3.1
 
 > Keep this file honest: update it whenever a feature ships, changes, or a
 > real bug is found (see "Documentation Maintenance" in CLAUDE.md).
@@ -15,29 +15,31 @@
 - Standalone note rename UI in the sidebar and editor; open state follows the new path and inbound wiki-links are rewritten vault-wide (v1.6). Unicode-safe NFC slugs are shared by frontend + backend (v1.5)
 - `#tags` with sidebar aggregation and global tag rename
 - Templates (defaults + custom JSON) with `{{date}}`/`{{time}}`/`{{day_of_week}}`; default daily/weekly templates
-- Quick switcher / command palette (⌘P), backend full-text search with snippets, timeline view; opening any note yields transient Timeline/Graph views so navigation cannot remain hidden behind them
+- Quick switcher / command palette (⌘P on macOS, Ctrl+P on Windows), backend full-text search with snippets, timeline view; opening any note yields transient Timeline/Graph views so navigation cannot remain hidden behind them
 - Local semantic search (v1.6; requires Apple Silicon on macOS, while Intel Macs get keyword search): opt-in per-Forge embeddings index with a curated three-model picker (all-MiniLM-L6-v2 is the default; BGE small English v1.5 and Multilingual E5 small are available). Consent names the active model and download size; model changes trigger a full re-index with live progress. Fully offline afterwards; locked notes are never indexed. Sidebar Keyword/Semantic search mode chip, "Related" notes section under the editor, Settings → AI & Agents toggle + rebuild-index button
 
 ### Storage & Data Safety
 - Real Markdown on disk with YAML frontmatter (color + extensible keys); legacy HTML-bodied files still readable
-- **Atomic writes everywhere** (temp + fsync + rename; 0600 before visibility) — v1.5
+- **Atomic writes everywhere** (temp + fsync + rename; 0600 before visibility), with bounded retries when Windows temporarily blocks a replace
+- Portable note and folder name validation blocks Windows device names, illegal characters, trailing dots, and drive-relative paths before they can discard or hide data
 - Folder-relative note addressing (fixed folder-note round-trip data bug) — v1.5
 - **External-edit conflict safety** (v1.6): saves send the content hash from the last read; if the disk copy diverged (sync tool, other editor), the disk version is preserved as a `<name> (conflict YYYY-MM-DD HHMM).md` copy before the save, with a warning toast + list refresh
-- Forge file watcher: external changes refresh the note list live (self-writes suppressed)
+- Forge file watcher: external changes refresh the note list live (self-writes suppressed); the Forge switcher refreshes while open so externally created Forges appear without a relaunch
 - Trash with 7-day retention, restore, previews; multiple Forges (vaults) with per-Forge state
 - Note locking (AES-256-GCM + Argon2, rate-limited unlock, auto-lock); encrypted vault backups; settings JSON export/import
 - Import/export: Markdown, PDF, plaintext, bulk export, encrypted archive
 - Obsidian vault importer (v1.7): Settings → Import performs a read-only analysis, then copies supported daily notes, standalone notes with sanitized folder structure, converted wiki-link aliases, verbatim YAML frontmatter, and referenced attachments into a new Forge. Name collisions are suffixed deterministically; hidden items, `.trash`, Canvas files, symlinks, unreferenced attachments, and unresolved embeds are skipped or warned in the final report.
 - Agent-ready Forge (v1.6): Settings → AI & Agents writes `AGENTS.md` + `.gitignore` to the Forge root via a hard-whitelisted backend command (exactly those two filenames), with confirm-overwrite and existence indicator
-- Built-in MCP stdio server (v1.6): the single app binary switches to headless MCP mode with the exact `--mcp` flag, defaults to the active Forge (`--forge <name>` override), exposes four read tools plus three explicitly gated write tools, validates all client paths, refuses locked notes, and uses atomic writes + semantic-index change hooks
+- Built-in MCP stdio server (v1.6): the single app binary switches to headless MCP mode with the exact `--mcp` flag, defaults to the active Forge (`--forge <name>` override), exposes four read tools plus three explicitly gated write tools, validates all client paths, refuses locked notes, and uses atomic writes + semantic-index change hooks. Reads return a content hash that write tools can use to preserve a changed disk version as a conflict copy
 
 ### Platform
-- Calendar in right panel + timeline, read-only, from two sources: Apple (EventKit, permission-gated, macOS only) and Google (Calendar API v3 over PKCE loopback OAuth, all platforms, refresh token in the OS keychain). Per-source failures are reported without blanking the other source; Google needs `MOLDAVITE_GOOGLE_CLIENT_ID`/`_SECRET` at build time or it reports unavailable
-- Signed + notarized releases and minisign-verified auto-updates. Checks run about 15 seconds after launch, every 24 hours while open, and on focus after 24 hours without a successful check; automatic network/404 failures stay silent and retry, while pending versions add accent dots to Settings and About plus the existing install action. Manual checks retain explicit errors, and completed upgrades show the CHANGELOG-backed "What's New" popup (see docs/RELEASING.md)
-- Themes/presets, keyboard shortcut overlay (⌘?), settings modal with focus trap
+- Windows is a supported release target. Every PR runs clippy and the Rust library test suite on `windows-latest`; no Windows runtime journey has been exercised manually, so Windows coverage is CI-backed
+- Calendar in right panel + timeline, read-only, from two sources: Apple (EventKit, permission-gated, macOS only) and Google (Calendar API v3 over PKCE loopback OAuth, all platforms, refresh token in the OS credential store). Per-source failures are reported without blanking the other source; Google needs `MOLDAVITE_GOOGLE_CLIENT_ID`/`_SECRET` at build time or it reports unavailable
+- macOS builds are signed and notarized. Windows installers are unsigned and may trigger SmartScreen because they are not Authenticode-signed. Updater artifacts are signed for every platform, including Windows, and clients verify them before installation. Checks run about 15 seconds after launch, every 24 hours while open, and on focus after 24 hours without a successful check; automatic network/404 failures stay silent and retry, while pending versions add accent dots to Settings and About plus the existing install action. Manual checks retain explicit errors, and completed upgrades show the CHANGELOG-backed "What's New" popup (see docs/RELEASING.md)
+- Themes/presets, platform-specific keyboard shortcut labels and overlay (⌘? on macOS, Ctrl+? on Windows), settings modal with focus trap
 
 ### Plugins (v2 — v1 shipped 1.4.0, sandbox hardened 1.5.0, v2 shipped 1.6.0)
-- API v2: commands/editor/toasts plus trusted host-rendered prompt forms, permissioned unlocked-note metadata + Markdown reads, host-performed HTTPS behind manifest and individually revocable user-approved exact hosts, and per-plugin macOS Keychain secrets; API v1 remains compatible
+- API v2: commands/editor/toasts plus trusted host-rendered prompt forms, permissioned unlocked-note metadata + Markdown reads, host-performed HTTPS behind manifest and individually revocable user-approved exact hosts, and per-plugin OS credential-store secrets; API v1 remains compatible
 - Per-Forge enable state; permission sheet shows human-readable capabilities, manifest hosts, and runtime hosts with per-host revoke; manifest consent remains pinned to SHA-256 of raw manifest + code while runtime host consent is stored app-side
 - Every successful in-app install opens a themed manifest-sourced setup guide; an ⓘ action on each installed card reopens its description, commands, instructions, and permissions at any time
 - Explicit-use community browser: Settings fetches the public GitHub registry only after **Browse community plugins** is clicked, rejects malformed entries, constructs downloads only under the pinned raw-repository base, and sends both files to Rust for SHA-256 verification plus staged/atomic install. The website directory filters by name/description/author/permission with a static fallback and offers `moldavite://plugin/<id>` install links; strict queued routing handles cold and running app delivery, opens/highlights the registry entry, and requires a permission-visible confirmation. Installed versions are labeled; replacement requires update confirmation; plugins stay disabled until the existing consent flow is completed
@@ -47,31 +49,30 @@
 - Bundled first-party Publish to WordPress reference plugin: Application Password verification, draft create/update keyed by Forge-relative note path, self-hosted and WordPress.com Jetpack/Atomic support; WordPress.com Simple OAuth is an explicit limitation
 
 ## Test & Quality Status
-- Frontend: vitest — 383 tests across 48 files (stores, lib, hooks, update scheduling/error modes, graph layout, transient-view navigation, Obsidian import, deep-link routing, external-write reconciliation, calendar store migration, plugin RPC/manifest/registry/UI)
-- Backend: cargo test — 247 tests incl. stress suite, Obsidian conversion/path-safety, conflict-copy, semantic-index, MCP, plugin install/hash/secret validation, strict deep-link routing, and calendar source dispatch / PKCE / Google response mapping suites
-- Bundle budget enforced via `npm run check:size` (within budget as of v1.8.0)
+- Frontend: vitest covers stores, libraries, hooks, update scheduling/error modes, graph layout, transient-view navigation, Obsidian import, deep-link routing, external-write reconciliation, calendar store migration, and plugin RPC/manifest/registry/UI
+- Backend: cargo tests cover the stress suite, Obsidian conversion/path safety, conflict copies, semantic indexing, MCP, plugin install/hash/secret validation, strict deep-link routing, Windows path and persistence behavior, and calendar source dispatch / PKCE / Google response mapping
+- Windows CI runs clippy with warnings denied and the Rust library test suite on every PR
+- Bundle budget enforced via `npm run check:size`
 - ESLint: 0 errors, 16 pre-existing warnings (set-state-in-effect patterns in modals; tracked below)
 
 ## Known Issues / Debt
 - **Search scales linearly** — live WalkDir scan per query; fine to ~1k notes. Planned: persistent incremental index (would also speed backlinks + previews).
-- **Plugin API has no note writes or panels yet** — v2 adds note reads, trusted prompt forms, dynamically approved exact-host HTTPS, and Keychain secrets while keeping the Worker boundary narrow.
+- **Plugin API has no note writes or panels yet** — v2 adds note reads, trusted prompt forms, dynamically approved exact-host HTTPS, and OS credential-store secrets while keeping the Worker boundary narrow.
 - All note metadata held in memory (no pagination); startup daily-note scan capped at 8 concurrent reads but still O(vault age).
 - ESLint set-state-in-effect warnings in ImageModal/LinkModal/SlashCommandList et al. — cosmetic, no user impact observed.
 - No automatic scheduled backups (manual + encrypted export exist).
 - No multi-window support.
-- **MCP write tools have no conflict detection** ([#37](https://github.com/mauropereiira/Moldavite/issues/37)) — unlike the GUI save path they replace a note body unconditionally, so two agents can clobber each other with no conflict copy.
 - **`Editor.tsx` has no test harness** ([#38](https://github.com/mauropereiira/Moldavite/issues/38)) — the only significant component without one.
 - **Self-write suppression is a 500ms timing window** ([#39](https://github.com/mauropereiira/Moldavite/issues/39)) — a slow disk can make the app read its own save as an external change.
-- **Externally created Forges need a QuickSwitcher pass or relaunch to appear** ([#36](https://github.com/mauropereiira/Moldavite/issues/36)) — `forges:changed` is emitted with no frontend listener.
 - **Two stress tests assert a wall-clock budget** ([#44](https://github.com/mauropereiira/Moldavite/issues/44)) — they can flake under CI load.
 - **Google Calendar is not brand-verified yet** — consent shows the unverified-app interstitial and there is a 100-user cap until Google completes review.
 
 ## Roadmap (in priority order)
-1. **Conflict-safe MCP writes** ([#37](https://github.com/mauropereiira/Moldavite/issues/37)) — extend the base-hash guard the GUI already uses to the MCP write tools. Silent loss between two agents is the most consequential open bug.
-2. **Google brand verification** — needs the now-live `privacy.html`, a homepage, and a Search Console-verified authorized domain. Removes the unverified-app warning and the 100-user cap.
-3. **Plugin UI/write extensions** — build on the shipped Worker/RPC boundary and v2 read/network/secrets surface with conflict-safe note writes and narrow panel slots.
-4. **Persistent search index** — incremental, on-disk; unlocks instant search, better snippets, cheaper backlinks.
-5. **Automatic local backups** — scheduled snapshots of the Forge with retention (fits the local-first/no-cloud identity).
+1. **Google brand verification** — needs the now-live `privacy.html`, a homepage, and a Search Console-verified authorized domain. Removes the unverified-app warning and the 100-user cap.
+2. **Plugin UI/write extensions** — build on the shipped Worker/RPC boundary and v2 read/network/secrets surface with conflict-safe note writes and narrow panel slots.
+3. **Persistent search index** — incremental, on-disk; unlocks instant search, better snippets, cheaper backlinks.
+4. **Automatic local backups** — scheduled snapshots of the Forge with retention (fits the local-first/no-cloud identity).
+5. ~~**Conflict-safe MCP writes**~~ — Done: reads can return a content hash and writes preserve a changed disk version as a conflict copy.
 6. ~~**Note rename UI**~~ — Done (v1.6): sidebar/editor rename keeps tabs, recents, colors, selection, and backlinks synchronized while the backend safely rewrites inbound links.
 7. ~~External-edit conflict handling beyond the file-watcher refresh.~~ Done (v1.6): conflict copies preserve both versions on divergent saves.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,8 +1,10 @@
 # Releasing Moldavite
 
-Moldavite ships signed + notarized macOS (Apple Silicon + Intel) and Windows
-builds via GitHub Actions, and updates existing installs through the Tauri
-updater. This is the end-to-end release process.
+Moldavite ships signed and notarized macOS builds (Apple Silicon and Intel) and
+unsigned Windows builds via GitHub Actions. Every platform's updater artifacts,
+including Windows, are signed with `TAURI_SIGNING_PRIVATE_KEY` so the updater can
+verify their integrity. Windows installers are not Authenticode-signed, so
+Windows may show a SmartScreen warning. This is the end-to-end release process.
 
 ## 1. Prepare the release branch
 
@@ -31,7 +33,8 @@ updater. This is the end-to-end release process.
 3. The tag push triggers `.github/workflows/release.yml`, which:
    - creates a GitHub Release whose body is the extracted `CHANGELOG.md`
      section for this version,
-   - builds, signs, and notarizes macOS aarch64 + x86_64 and Windows,
+   - builds macOS aarch64 + x86_64 and Windows installers, signs and notarizes
+     the macOS builds, and signs updater artifacts for every platform,
    - uploads artifacts and generates `latest.json` (the updater manifest),
    - bumps `Casks/moldavite.rb` in
      [mauropereiira/homebrew-moldavite](https://github.com/mauropereiira/homebrew-moldavite)
@@ -45,7 +48,7 @@ instead.
 ## 3. Verify
 
 - Confirm the Release has the DMGs, the `.exe`/`.msi`, and `latest.json`.
-- Open an older install → it should detect the update within ~5s (or via
+- Open an older install → it should detect the update after about 15s (or via
   Settings → About → Check for Updates), download, install, and relaunch.
 - On relaunch, the "What's New" popup shows this version's notes.
 - Confirm the tap commit landed, then
@@ -72,7 +75,7 @@ Two failure modes worth recognising:
 |---|---|
 | `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD` | Developer ID signing cert (base64 .p12) |
 | `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID` | Apple notarization |
-| `TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Updater artifact signing |
+| `TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Updater artifact signing on every platform (not Windows Authenticode code signing) |
 | `HOMEBREW_TAP_TOKEN` | Fine-grained PAT, `Contents: read and write` on `mauropereiira/homebrew-moldavite` only. Nothing else. |
 
 ## Updater key rotation

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -12,7 +12,7 @@
     <meta property="og:image" content="https://mauropereiira.github.io/Moldavite/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Moldavite. Notes that stay yours. Local Markdown notes for macOS with a built-in MCP server." />
+    <meta property="og:image:alt" content="Moldavite. Notes that stay yours. Local Markdown notes for macOS and Windows with a built-in MCP server." />
     <meta property="og:site_name" content="Moldavite" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Using Moldavite" />
@@ -95,6 +95,7 @@
       </nav>
 
       <h2 id="getting-started">Getting started</h2>
+      <h3>macOS</h3>
       <p>Install Moldavite with Homebrew:</p>
       <pre><code>brew install --cask mauropereiira/moldavite/moldavite</code></pre>
       <p>
@@ -102,10 +103,20 @@
         <a href="https://github.com/mauropereiira/Moldavite/releases/latest">latest release</a>,
         download the macOS DMG, and move Moldavite to Applications.
       </p>
+      <h3>Windows</h3>
       <p>
-        A <strong>Forge</strong> is a vault directory. Forges normally live side by side under the
-        Forges root at <code>~/Documents/Moldavite/</code>, although onboarding lets you choose a
-        different root. Inside each Forge, notes are ordinary Markdown files organized into
+        Open the
+        <a href="https://github.com/mauropereiira/Moldavite/releases/latest">latest release</a>
+        and download <code>Moldavite_x.x.x_x64-setup.exe</code> (recommended) or
+        <code>Moldavite_x.x.x_x64_en-US.msi</code>. The installers are not
+        Authenticode-signed, so SmartScreen may warn you. If you downloaded Moldavite from the
+        official release page, choose <strong>More info</strong>, then
+        <strong>Run anyway</strong>.
+      </p>
+      <p>
+        A <strong>Forge</strong> is a vault directory. Forges normally live side by side under a
+        <code>Moldavite</code> folder in Documents, although onboarding lets you choose a different
+        root. Inside each Forge, notes are ordinary Markdown files organized into
         <code>daily/</code>, <code>weekly/</code>, and <code>notes/</code>.
       </p>
       <ul>
@@ -260,8 +271,8 @@
       </p>
       <ul>
         <li>
-          <strong>Quick switcher</strong>: press <kbd>⌘</kbd> <kbd>P</kbd> to open a note, run an
-          app action, repeat a recent search, switch Forges, or invoke a plugin command.
+          <strong>Quick switcher</strong>: press <kbd>⌘</kbd>/<kbd>Ctrl</kbd> <kbd>P</kbd> to open a
+          note, run an app action, repeat a recent search, switch Forges, or invoke a plugin command.
         </li>
         <li>
           <strong>Keyword search</strong>: full-text search with snippets across unlocked,
@@ -279,8 +290,8 @@
           Month, and Earlier.
         </li>
         <li>
-          <strong>Shortcut help</strong>: press <kbd>⌘</kbd> <kbd>?</kbd> for the current shortcut
-          list.
+          <strong>Shortcut help</strong>: press <kbd>⌘</kbd>/<kbd>Ctrl</kbd> <kbd>?</kbd> for the
+          current shortcut list.
         </li>
       </ul>
 
@@ -292,15 +303,15 @@
         <strong>Settings → AI &amp; Agents</strong>.
       </p>
       <p>
-        Semantic search requires Apple Silicon on macOS. Intel Macs keep the full keyword search,
-        and MCP <code>search_notes</code> transparently uses keyword mode.
+        Windows builds include semantic search. On macOS it requires Apple Silicon; Intel Macs keep
+        the full keyword search, and MCP <code>search_notes</code> transparently uses keyword mode.
       </p>
 
       <h3>Choose a transparent local model</h3>
       <p>
         Before the first download, Moldavite's consent dialog names the selected model and its
         approximate size. The model is cached in the app data directory, never in a Forge. Notes are
-        embedded on your Mac; locked notes are never read or indexed.
+        embedded on your computer; locked notes are never read or indexed.
       </p>
       <div class="table-scroll">
         <table>
@@ -420,8 +431,9 @@
         <li>
           <strong>Google Calendar</strong>: connecting opens your browser for Google's consent
           screen and returns to a local port. Moldavite asks only for the read-only calendar scope.
-          The refresh token is stored in your macOS Keychain and stays outside notes and settings
-          files. <strong>Disconnect</strong> removes it, and you can also
+          The refresh token is stored in the OS credential store (macOS Keychain or Windows
+          Credential Manager) and stays outside notes and settings files.
+          <strong>Disconnect</strong> removes it, and you can also
           revoke access from your
           <a href="https://myaccount.google.com/permissions">Google Account permissions page</a>.
         </li>
@@ -452,7 +464,7 @@
       </p>
       <p>
         The current plugin API can expose active-editor HTML, trusted prompt forms, unlocked note reads,
-        host-performed HTTPS to exact approved hosts, and plugin-namespaced macOS Keychain secrets.
+        host-performed HTTPS to exact approved hosts, and plugin-namespaced OS credential-store secrets.
         <strong>It does not provide note-write methods or custom panels.</strong> See the
         <a href="plugins.html">complete author guide</a> for the exact API and security model.
       </p>
@@ -508,7 +520,7 @@
       <p>
         The first publish creates a draft. Publishing the same Forge-relative note path again
         updates the mapped post and avoids a duplicate. Configuration and the path-to-post map live
-        in the plugin's Keychain namespace and stay outside the Forge.
+        in the plugin's OS credential-store namespace and stay outside the Forge.
       </p>
       <div class="callout warn">
         <span class="callout-title">WordPress.com support boundary</span>
@@ -553,12 +565,15 @@
       <p>
         The normal Moldavite app binary becomes a local stdio MCP server when launched with
         <code>--mcp</code>. It does not initialize the GUI and does not open a network listener.
-        Settings resolves the exact binary path on your Mac and provides copy-ready snippets for
+        Settings resolves the exact binary path on your computer and provides copy-ready snippets for
         each supported client; use those generated snippets whenever possible.
       </p>
 
       <h3>Claude Code</h3>
-      <p>Run the generated command in a terminal. A standard app installation looks like this:</p>
+      <p>
+        Run the generated command in a terminal. The examples below show a standard macOS app
+        installation; on Windows, use the generated snippets so the path matches your installer.
+      </p>
       <pre><code>claude mcp add moldavite -- "/Applications/Moldavite.app/Contents/MacOS/moldavite" --mcp</code></pre>
 
       <h3>Claude Desktop</h3>
@@ -669,7 +684,7 @@
         </a>
         <a href="https://github.com/mauropereiira/Moldavite/releases/latest">
           <span class="label">Ready?</span>
-          <span class="title">Download Moldavite for Mac →</span>
+          <span class="title">Download Moldavite →</span>
         </a>
       </div>
     </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,24 +4,24 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#07090a" />
-    <title>Moldavite | Local-first Markdown notes for macOS</title>
+    <title>Moldavite | Local-first Markdown notes for macOS and Windows</title>
     <meta property="og:title" content="Moldavite" />
-    <meta property="og:description" content="Notes that stay yours. Plain Markdown on your Mac, local search, and a built-in MCP server for the AI tools you choose." />
+    <meta property="og:description" content="Notes that stay yours. Plain Markdown on your computer, local search, and a built-in MCP server for the AI tools you choose." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mauropereiira.github.io/Moldavite/" />
     <meta property="og:image" content="https://mauropereiira.github.io/Moldavite/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Moldavite. Notes that stay yours. Local Markdown notes for macOS with a built-in MCP server." />
+    <meta property="og:image:alt" content="Moldavite. Notes that stay yours. Local Markdown notes for macOS and Windows with a built-in MCP server." />
     <meta property="og:site_name" content="Moldavite" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Moldavite" />
-    <meta name="twitter:description" content="Notes that stay yours. Plain Markdown on your Mac, local search, and a built-in MCP server for the AI tools you choose." />
+    <meta name="twitter:description" content="Notes that stay yours. Plain Markdown on your computer, local search, and a built-in MCP server for the AI tools you choose." />
     <meta name="twitter:image" content="https://mauropereiira.github.io/Moldavite/og-image.png" />
     <link rel="canonical" href="https://mauropereiira.github.io/Moldavite/" />
     <meta
       name="description"
-      content="Moldavite is a private, local-first Markdown notes app for macOS with local search, a built-in MCP server, and sandboxed plugins."
+      content="Moldavite is a private, local-first Markdown notes app for macOS and Windows with local search, a built-in MCP server, and sandboxed plugins."
     />
     <link rel="icon" href="favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -114,12 +114,12 @@
           <div class="hero-copy reveal">
             <p class="eyebrow">
               <span class="eyebrow-dot" aria-hidden="true"></span>
-              Local Markdown notes for macOS
+              Local Markdown notes for macOS and Windows
             </p>
             <h1 id="hero-title">Notes that <span class="gradient-headline">stay yours.</span></h1>
             <p class="hero-lede">
-              Moldavite keeps every note as a Markdown file on your Mac, with local search and a
-              built-in bridge for the AI tools you choose.
+              Moldavite keeps every note as a Markdown file on your computer, with local search and
+              a built-in bridge for the AI tools you choose.
             </p>
             <div class="hero-actions">
               <a
@@ -129,11 +129,11 @@
                 <svg viewBox="0 0 20 20" aria-hidden="true">
                   <path d="M10 2v10m0 0 4-4m-4 4L6 8M3 15v2h14v-2" />
                 </svg>
-                Download for Mac
+                Download Moldavite
               </a>
-              <a href="#install" class="button-secondary liquid-glass">Install with Homebrew</a>
+              <a href="#install" class="button-secondary liquid-glass">Installation options</a>
             </div>
-            <p class="platform-note">Apple Silicon and Intel Mac · Free and MIT licensed</p>
+            <p class="platform-note">macOS and Windows · Free and MIT licensed</p>
           </div>
 
           <figure class="hero-demo liquid-glass reveal">
@@ -173,8 +173,10 @@
         <div class="container-wide">
           <div class="section-heading reveal">
             <p class="section-kicker">Install</p>
-            <h2 class="section-title" id="install-title">Choose the path that fits your Mac.</h2>
-            <p class="section-sub">Both routes install the same signed and notarized app.</p>
+            <h2 class="section-title" id="install-title">Choose how you want to install.</h2>
+            <p class="section-sub">
+              Use Homebrew or a signed and notarized DMG on macOS, or an x64 installer on Windows.
+            </p>
           </div>
 
           <div class="install-grid reveal-group">
@@ -211,6 +213,23 @@
               >
               <p class="card-footnote">Updates are verified inside the app before installation.</p>
             </article>
+
+            <article class="install-card liquid-glass">
+              <div class="card-index" aria-hidden="true">03</div>
+              <p class="card-label">Windows</p>
+              <h3>Run the EXE or MSI</h3>
+              <p>Open the latest release and download the x64 setup EXE or Windows Installer package.</p>
+              <a
+                href="https://github.com/mauropereiira/Moldavite/releases/latest"
+                class="button-primary compact"
+                >Open the latest release</a
+              >
+              <p class="card-footnote">
+                The installer is not Authenticode-signed, so SmartScreen may warn you. Choose
+                <strong>More info</strong>, then <strong>Run anyway</strong> if you downloaded it
+                from the official release page.
+              </p>
+            </article>
           </div>
         </div>
       </section>
@@ -222,8 +241,8 @@
             <p class="section-kicker">Your files</p>
             <h2 class="section-title" id="files-title">Your notes are just files.</h2>
             <p class="section-sub">
-              A Forge is a folder you can open in Finder. Git and other Markdown tools can use it
-              too.
+              A Forge is a folder you can open in Finder or File Explorer. Git and other Markdown
+              tools can use it too.
             </p>
           </div>
 
@@ -433,7 +452,7 @@
           <div class="section-heading reveal">
             <p class="section-kicker">Inside the app</p>
             <h2 class="section-title" id="screenshots-title">A clear view of the work.</h2>
-            <p class="section-sub">Real screens from the current macOS app.</p>
+            <p class="section-sub">Real screens from Moldavite.</p>
           </div>
 
           <div class="screenshot-grid reveal-group">
@@ -545,8 +564,8 @@
                   <h3>Semantic search is local and opt-in</h3>
                   <p>
                     Choose one of three models after a clear download prompt. Indexing and queries
-                    then run on your Mac. Semantic search requires Apple Silicon, while Intel Macs
-                    keep keyword search.
+                    then run on your computer. Windows and Apple Silicon builds include semantic
+                    search, while Intel Macs keep keyword search.
                   </p>
                 </div>
               </article>
@@ -615,7 +634,7 @@
               </article>
               <article>
                 <span>Private secrets</span>
-                <p>Use a plugin-specific namespace in the macOS Keychain.</p>
+                <p>Use a plugin-specific namespace in the OS credential store.</p>
               </article>
               <article>
                 <span>Current boundary</span>
@@ -712,9 +731,9 @@
           <div class="cta-panel liquid-glass reveal">
             <div class="cta-orbit" aria-hidden="true"></div>
             <p class="section-kicker">Free and open source</p>
-            <h2 class="section-title" id="cta-title">Start with a folder on your Mac.</h2>
+            <h2 class="section-title" id="cta-title">Start with a folder you own.</h2>
             <p>
-              Keep your Markdown files on your Mac. Connect more tools when they fit your work.
+              Keep your Markdown files on your computer. Connect more tools when they fit your work.
             </p>
             <div class="hero-actions">
               <a

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -12,7 +12,7 @@
     <meta property="og:image" content="https://mauropereiira.github.io/Moldavite/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Moldavite. Notes that stay yours. Local Markdown notes for macOS with a built-in MCP server." />
+    <meta property="og:image:alt" content="Moldavite. Notes that stay yours. Local Markdown notes for macOS and Windows with a built-in MCP server." />
     <meta property="og:site_name" content="Moldavite" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Building Moldavite Plugins" />
@@ -21,7 +21,7 @@
     <link rel="canonical" href="https://mauropereiira.github.io/Moldavite/plugins.html" />
     <meta
       name="description"
-      content="The Moldavite plugin author guide: manifests, permissions, commands, editor access, note reads, trusted prompts, exact-host HTTPS, Keychain secrets, consent, and distribution."
+      content="The Moldavite plugin author guide: manifests, permissions, commands, editor access, note reads, trusted prompts, exact-host HTTPS, OS credential-store secrets, consent, and distribution."
     />
     <link rel="icon" href="favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -75,7 +75,7 @@
       <h1>Building Plugins</h1>
       <p>
         Add sandboxed commands with narrow, host-enforced access to the editor, unlocked Markdown,
-        approved HTTPS hosts, trusted forms, and plugin-owned Keychain secrets.
+        approved HTTPS hosts, trusted forms, and plugin-owned OS credential-store secrets.
       </p>
     </section>
 
@@ -252,7 +252,9 @@
         <li>Add a current manifest and a default <code>register(api)</code> export.</li>
         <li>Open or reopen <strong>Settings → Plugins</strong>.</li>
         <li>Enable the plugin and review the permission sheet.</li>
-        <li>Run its commands from <kbd>⌘</kbd> <kbd>P</kbd> or the editor slash menu.</li>
+        <li>
+          Run its commands from <kbd>⌘</kbd>/<kbd>Ctrl</kbd> <kbd>P</kbd> or the editor slash menu.
+        </li>
       </ol>
       <p>
         There is no build or package requirement. A dependency-free <code>plugin.js</code> works as
@@ -283,7 +285,7 @@
   ],
   <span class="f">"instructions"</span>: [
     <span class="s">"Enable the plugin and approve its permissions."</span>,
-    <span class="s">"Press `Cmd+P` and run **Configure publisher** first."</span>,
+    <span class="s">"Press `Cmd/Ctrl+P` and run **Configure publisher** first."</span>,
     <span class="s">"Open a note, then run **Publish active note…**."</span>
   ]
 }</code></pre>
@@ -703,7 +705,7 @@ api.commands.<span class="f">add</span>({
         non-text responses also include <code>bodyBase64</code>.
       </p>
 
-      <h3>Keychain secrets</h3>
+      <h3>OS credential-store secrets</h3>
       <div class="method-list">
         <div class="method-card">
           <p class="method-signature">
@@ -718,7 +720,7 @@ api.commands.<span class="f">add</span>({
             <span class="permission-pill">secrets</span>
           </p>
           <p class="method-description">
-            Stores a string in this plugin's macOS Keychain namespace.
+            Stores a string in this plugin's OS credential-store namespace.
           </p>
         </div>
         <div class="method-card">
@@ -735,11 +737,12 @@ api.commands.<span class="f">add</span>({
   <span class="k">await</span> api.secrets.<span class="f">delete</span>(<span class="s">'api-token'</span>);
 }</code></pre>
       <p>
-        The Keychain service is <code>Moldavite</code>. The host constructs the account as
+        The credential-store service is <code>Moldavite</code>. The host constructs the account as
         <code>plugin:&lt;plugin-id&gt;:&lt;key&gt;</code>, so a worker cannot choose another
-        plugin's namespace. Keys are 1–128 characters, begin with a letter or digit, and then use
-        letters, digits, dots, underscores, or hyphens. Secret values are never listed or included
-        in Forge, settings, plugin, ZIP, or encrypted-backup exports.
+        plugin's namespace. macOS stores these entries in Keychain; Windows uses Credential Manager.
+        Keys are 1–128 characters, begin with a letter or digit, and then use letters, digits, dots,
+        underscores, or hyphens. Secret values are never listed or included in Forge, settings,
+        plugin, ZIP, or encrypted-backup exports.
       </p>
 
       <h2 id="consent">Permissions, consent, and failure behavior</h2>
@@ -777,7 +780,7 @@ api.commands.<span class="f">add</span>({
             </tr>
             <tr>
               <td><code>secrets</code></td>
-              <td>Read, write, and delete this plugin's Keychain entries.</td>
+              <td>Read, write, and delete this plugin's OS credential-store entries.</td>
             </tr>
           </tbody>
         </table>
@@ -821,7 +824,7 @@ api.commands.<span class="f">add</span>({
           sends the live editor HTML to <code>/wp-json/wp/v2/posts</code> as a draft.
         </li>
         <li>
-          A Keychain-backed Forge-path-to-post-id map makes later publishes of the same path use
+          An OS credential-store-backed Forge-path-to-post-id map makes later publishes of the same path use
           <code>PUT</code> to update the existing post. The success notification includes the edit
           URL.
         </li>
@@ -864,9 +867,9 @@ api.commands.<span class="f">add</span>({
         </li>
         <li>
           Uninstalling in Settings deletes the plugin folder and forgets its consent/runtime-host
-          grant. Keychain secrets remain because plugin secret keys are intentionally hidden from
-          enumeration. Provide a reset command that calls <code>secrets.delete</code> for every
-          known key when users need credential cleanup before uninstalling.
+          grant. OS credential-store secrets remain because plugin secret keys are intentionally
+          hidden from enumeration. Provide a reset command that calls <code>secrets.delete</code>
+          for every known key when users need credential cleanup before uninstalling.
         </li>
         <li>
           Test cancellation, missing notes, locked-note rejection, denied/revoked hosts, non-2xx
@@ -880,7 +883,7 @@ api.commands.<span class="f">add</span>({
         <code>app</code>, <code>commands</code>, <code>editor</code>, and
         <code>ui.toast</code> surface, with <code>api.app.apiVersion === 1</code>. They do not need
         a source or manifest migration. Use <code>"apiVersion": 2</code> for trusted prompts,
-        Forge note reads, networking, and Keychain secrets.
+        Forge note reads, networking, and OS credential-store secrets.
       </p>
 
       <div class="next-links">

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "notes",
     "note-taking",
     "macos",
+    "windows",
     "tauri",
     "react",
     "typescript",


### PR DESCRIPTION
## One doc was actively false

`docs/RELEASING.md` stated:

> Moldavite ships **signed + notarized** macOS (Apple Silicon + Intel) **and Windows** builds via GitHub Actions

The Windows half is not true and never has been. `tauri.conf.json` has no `certificateThumbprint`, `digestAlgorithm`, `timestampUrl` or `signCommand`, and `release.yml` has no Windows certificate secret. `release.yml` half-admits it already, by warning about SmartScreen in the release notes it generates.

The new wording separates the three things that were conflated:

> Moldavite ships signed and notarized macOS builds (Apple Silicon and Intel) and unsigned Windows builds via GitHub Actions. Every platform's updater artifacts, including Windows, are signed with `TAURI_SIGNING_PRIVATE_KEY` so the updater can verify their integrity. Windows installers are not Authenticode-signed, so Windows may show a SmartScreen warning.

That distinction matters: **auto-update integrity was never the gap.** Updater artifacts have always been signed on every platform. What is missing is Authenticode signing on the installer, which is the specific thing SmartScreen reacts to.

## The rest is Windows catching up to what shipped

| file | was |
| --- | --- |
| `README.md` | "a notes app **for macOS**", one badge, macOS-only install steps — while the release publishes `.exe` and `.msi` |
| `package.json` | `macos` in keywords, no `windows` |
| `docs/ARCHITECTURE.md` | "macOS Keychain", though `keyring` has been built with `windows-native` all along and secrets go to Credential Manager there |
| `docs/PROJECT_STATUS.md` | no Windows status at all |
| the website | macOS-only framing |

Install instructions use the real asset names from `release.yml` rather than guessed ones, and say plainly that SmartScreen will appear — a user who meets that unprepared assumes the app is malware.

## The claim is deliberately bounded

Windows is described as supported and **CI-backed**, and `PROJECT_STATUS.md` says so precisely:

> Windows is a supported release target. Every PR runs clippy and the Rust library test suite on `windows-latest`; no Windows runtime journey has been exercised manually, so Windows coverage is CI-backed

There is no Windows machine and no VM on this project. CI proves compilation, lint and tests — not that anyone has launched the app. Writing "fully tested on Windows" would have been the easy sentence and the wrong one.

Site copy stays evergreen with no version numbers, downloads point at `releases/latest`, and `site.js` is untouched.

## Verification

Docs-only; nothing under `src/` or `src-tauri/` changed. Ran the suite anyway to prove it:

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — unchanged
- `npm test` — 428 passing
- `npm run build && npm run check:size` — within budget

No CHANGELOG entry: correcting documentation is not a user-visible app change, and the release notes are already written.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm