### PR TITLE
chore: release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [1.9.0] - 2026-08-14
 
 ### Added
 
+- **Windows is a supported platform.** It shipped as experimental in December 2025 and was never promoted, because nothing verified it: no job compiled Moldavite for Windows until a release had already been tagged. Every change now runs the full Rust test suite and a linter with warnings denied on Windows before it can merge, and the round of fixes below came out of turning that on. Installers are still unsigned, so Windows may warn you once when you run one.
 - **Pasted Markdown keeps its formatting.** Pasting recognizable raw Markdown into the editor now inserts formatted note content through Moldavite's existing conversion pipeline, while ordinary text, rich text, and image paste keep their existing behavior.
 - **Install with Homebrew.** `brew install --cask mauropereiira/moldavite/moldavite` fetches the signed, notarized DMG for your architecture and verifies its checksum. It also links the app binary onto your `PATH`, so connecting an AI tool is now `claude mcp add moldavite -- moldavite --mcp` instead of the full bundle path. The cask is marked as self-updating, so Homebrew stays out of the way of Moldavite's own updater.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "1.8.1"
+version = "1.9.0"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v1.9.0 — Windows becomes a supported platform

Windows shipped as "experimental" in v0.1.1 (December 2025) and was never promoted, because nothing verified it: **no CI job compiled Moldavite for Windows until a release had already been tagged.** This release turns that on and fixes everything it found.

Minor bump rather than patch: nothing about the note format or the plugin API changed, but the set of platforms Moldavite claims to support did.

## What the Windows CI job found on `main`, immediately

Recorded because it is the actual argument for the job existing:

1. **`main` did not compile for Windows** under `-D warnings`. A `#[cfg(unix)]`-only binding in the ZIP export left an unused variable everywhere else. Release builds do not deny warnings, so it had sat there unnoticed.
2. **Five test failures.** Four were fixture bugs; one was a real defect — trash filenames kept backslashes and drive-letter colons from persisted metadata, producing names NTFS rejects outright.
3. **Two more wall-clock assertions** blowing their budgets at 25s and 31s. Issue #44 named two; there were six across five files.
4. **A clippy lint inside a `#[cfg(windows)]` block** that macOS clippy structurally cannot see.
5. **A storage policy that was dead code on Linux**, which the Linux job caught in turn.

## Contents

20 PRs. Every open issue closed except two, noted below.

**Windows** — plugins never loaded (the loader used the macOS scheme URL); `moldavite://` links opened a duplicate app; a Forge could not live on `D:\` or a UNC share while `C:\Windows` was unprotected; "Open Forge in Finder" was a silent no-op; reserved device names like `NUL` silently discarded a note; atomic saves had no retry against the sharing violations sync clients and antivirus routinely cause; shortcut labels said Cmd.

**Everywhere** — MCP writes now detect conflicts instead of silently clobbering (#37, the top roadmap item); renaming a note inside a folder works, and no longer breaks its inbound links; the watcher decides self-write suppression by content hash rather than a 500 ms race (#39); suggestion popups can be dismissed (#40); Copy URL produces a link that opens; Inter and Merriweather ship with the app instead of being blocked by our own CSP; the Forge switcher refreshes live (#36).

**Contributed** — @NoobCity99's Markdown-aware paste (#60), with follow-up hardening.

## Verification

Against this branch:

- `npm run format:check`, `npm run lint -- --max-warnings 16` — clean, 0 errors
- `npm test` — **435 passing**, 50 files
- `npm run build && npm run check:size` — within budget
- `cargo clippy --lib --all-targets -- -D warnings` — clean
- `cargo test --lib` — **292 passing**, 0 failed
- `node scripts/extract-changelog.mjs 1.9.0` — returns the right section

Started the day at 383 frontend / 249 Rust tests.

## Known limits, stated rather than buried

**No Windows runtime testing exists.** There is no Windows machine or VM on this project. CI proves the code compiles, lints and passes its tests on Windows; **nobody has launched the app there.** The plugin loader fix, Explorer reveal, single-instance deep links, shortcut labels and fonts are all verified by construction and by test, not by use. `docs/PROJECT_STATUS.md` says exactly this rather than implying more.

**Windows installers remain unsigned.** There is no Authenticode certificate, so SmartScreen will warn on first run. `docs/RELEASING.md` previously claimed Windows builds were "signed + notarized"; that claim is corrected in #88. Updater artifacts *are* signed on every platform, so auto-update integrity was never the gap.

**Still open:** #38 (Editor test harness) and #46 (needs reproducing on a real build before any code — analysis posted on the issue).

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm