### PR TITLE
test(editor): give Editor.tsx a harness

### DIFF
--- a/src/components/editor/Editor.test.tsx
+++ b/src/components/editor/Editor.test.tsx
@@ -1,0 +1,288 @@
+import { act, render, waitFor } from '@testing-library/react';
+import type { DependencyList } from 'react';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Editor as TiptapEditor } from '@tiptap/core';
+import type { Note } from '@/types';
+
+const tiptapHarness = vi.hoisted(() => ({
+  editor: null as TiptapEditor | null,
+  setContentCalls: [] as unknown[][],
+  setTextSelectionCalls: [] as unknown[][],
+  blurCallCount: 0,
+  afterSetContent: null as (() => void) | null,
+}));
+
+const safeInvoke = vi.hoisted(() => vi.fn());
+const convertFileSrc = vi.hoisted(() => vi.fn((path: string) => `asset://${path}`));
+
+vi.mock('@tiptap/react', async () => {
+  const actual = await vi.importActual<typeof import('@tiptap/react')>('@tiptap/react');
+
+  return {
+    ...actual,
+    useEditor: (options: Parameters<typeof actual.useEditor>[0], deps?: DependencyList) => {
+      const editor = actual.useEditor(options, deps);
+      if (editor && editor !== tiptapHarness.editor) {
+        const commandManager = editor as unknown as {
+          commandManager: {
+            rawCommands: Record<string, (...args: unknown[]) => (props: unknown) => boolean>;
+          };
+        };
+        const rawCommands = commandManager.commandManager.rawCommands;
+        const originalSetContent = rawCommands.setContent;
+        const originalSetTextSelection = rawCommands.setTextSelection;
+        const originalBlur = rawCommands.blur;
+
+        rawCommands.setContent = (...args: unknown[]) => {
+          tiptapHarness.setContentCalls.push(args);
+          const command = originalSetContent(...args);
+          return (props: unknown) => {
+            const result = command(props);
+            tiptapHarness.afterSetContent?.();
+            return result;
+          };
+        };
+        rawCommands.setTextSelection = (...args: unknown[]) => {
+          tiptapHarness.setTextSelectionCalls.push(args);
+          return originalSetTextSelection(...args);
+        };
+        rawCommands.blur = (...args: unknown[]) => {
+          tiptapHarness.blurCallCount += 1;
+          return originalBlur(...args);
+        };
+      }
+      tiptapHarness.editor = editor;
+      return editor;
+    },
+  };
+});
+
+vi.mock('@/lib/ipc', () => ({
+  safeInvoke: (...args: unknown[]) => safeInvoke(...args),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+  convertFileSrc: (path: string) => convertFileSrc(path),
+}));
+
+vi.mock('@/hooks', () => ({
+  useAutoSave: vi.fn(),
+  useKeyboardShortcuts: () => ({
+    showTemplatePicker: false,
+    handleTemplateSelect: vi.fn(),
+    handleTemplatePickerClose: vi.fn(),
+    openTemplatePicker: vi.fn(),
+  }),
+  useNotes: () => ({
+    deleteCurrentNote: vi.fn(),
+    loadDailyNote: vi.fn(),
+    createNote: vi.fn(),
+    loadNote: vi.fn(),
+    renameNote: vi.fn(),
+  }),
+  useTemplates: () => ({ getTemplateContent: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('./EditorFooter', () => ({ EditorFooter: () => null }));
+vi.mock('./TabBar', () => ({ TabBar: () => null }));
+vi.mock('./SelectionToolbar', () => ({ SelectionToolbar: () => null }));
+vi.mock('./ImageToolbar', () => ({ ImageToolbar: () => null }));
+vi.mock('./LinkModal', () => ({ LinkModal: () => null }));
+vi.mock('./ImageModal', () => ({ ImageModal: () => null }));
+vi.mock('./ExternalChangeBanner', () => ({ ExternalChangeBanner: () => null }));
+vi.mock('@/components/backlinks', () => ({ BacklinksPanel: () => null }));
+vi.mock('@/components/templates/EmptyNoteTemplatePicker', () => ({
+  EmptyNoteTemplatePicker: () => null,
+}));
+vi.mock('@/components/templates/TemplatePickerModal', () => ({
+  TemplatePickerModal: () => null,
+}));
+
+import { Editor } from './Editor';
+import {
+  useNoteColorsStore,
+  useNoteStore,
+  useSettingsStore,
+  useTagStore,
+  useThemeStore,
+} from '@/stores';
+import { usePluginCommandStore } from '@/stores/pluginCommandStore';
+
+const rangeGetClientRects = Object.getOwnPropertyDescriptor(
+  window.Range.prototype,
+  'getClientRects'
+);
+const rangeGetBoundingClientRect = Object.getOwnPropertyDescriptor(
+  window.Range.prototype,
+  'getBoundingClientRect'
+);
+
+beforeAll(() => {
+  Object.defineProperties(window.Range.prototype, {
+    getClientRects: {
+      configurable: true,
+      value: () => [],
+    },
+    getBoundingClientRect: {
+      configurable: true,
+      value: () => new DOMRect(),
+    },
+  });
+});
+
+afterAll(() => {
+  if (rangeGetClientRects) {
+    Object.defineProperty(window.Range.prototype, 'getClientRects', rangeGetClientRects);
+  } else {
+    Reflect.deleteProperty(window.Range.prototype, 'getClientRects');
+  }
+  if (rangeGetBoundingClientRect) {
+    Object.defineProperty(
+      window.Range.prototype,
+      'getBoundingClientRect',
+      rangeGetBoundingClientRect
+    );
+  } else {
+    Reflect.deleteProperty(window.Range.prototype, 'getBoundingClientRect');
+  }
+});
+
+function note(id: string, content: string, externalRev?: number): Note {
+  return {
+    id,
+    title: id.replace('.md', ''),
+    content,
+    createdAt: new Date('2026-08-14T09:00:00Z'),
+    updatedAt: new Date('2026-08-14T09:00:00Z'),
+    isDaily: false,
+    isWeekly: false,
+    externalRev,
+  };
+}
+
+function setOpenNotes(currentNote: Note, otherNotes: Note[] = []) {
+  useNoteStore.setState({
+    openTabs: [currentNote, ...otherNotes],
+    activeTabId: currentNote.id,
+    currentNote,
+  });
+}
+
+async function renderEditor(currentNote: Note, otherNotes: Note[] = []) {
+  setOpenNotes(currentNote, otherNotes);
+  render(<Editor />);
+
+  await waitFor(() => expect(tiptapHarness.editor).not.toBeNull());
+  const editor = tiptapHarness.editor as TiptapEditor;
+  const editable = document.querySelector('[contenteditable="true"]');
+  const scrollContainer = editable?.closest('.editor-paper');
+  if (!(scrollContainer instanceof HTMLElement)) {
+    throw new Error('Editor scroll container was not rendered');
+  }
+
+  return { editor, scrollContainer };
+}
+
+beforeEach(() => {
+  tiptapHarness.editor = null;
+  tiptapHarness.setContentCalls = [];
+  tiptapHarness.setTextSelectionCalls = [];
+  tiptapHarness.blurCallCount = 0;
+  tiptapHarness.afterSetContent = null;
+  safeInvoke.mockReset();
+  convertFileSrc.mockClear();
+  useNoteStore.setState({
+    notes: [],
+    openTabs: [],
+    activeTabId: null,
+    currentNote: null,
+    isLoading: false,
+    isSaving: false,
+    unlockedNotes: new Set(),
+    externallyChanged: new Set(),
+  });
+  useSettingsStore.setState({ spellCheck: true, tagsEnabled: true });
+  useThemeStore.setState({ theme: 'light', baseMode: 'light' });
+  useNoteColorsStore.setState({ colors: {}, isLoading: false });
+  useTagStore.setState({ allTags: new Map(), selectedTags: [], selectedTag: null });
+  usePluginCommandStore.getState().clear();
+});
+
+describe('Editor content synchronization', () => {
+  it('loads note content without emitting an editor update', async () => {
+    const currentNote = note('notes/first.md', '<p>First note body</p>');
+    setOpenNotes(currentNote);
+
+    render(<Editor />);
+
+    await waitFor(() => {
+      expect(tiptapHarness.setContentCalls).toContainEqual([
+        '<p>First note body</p>',
+        { emitUpdate: false },
+      ]);
+      expect(tiptapHarness.editor?.getHTML()).toBe('<p>First note body</p>');
+    });
+  });
+
+  it('preserves scroll position and selection during an external reload', async () => {
+    const currentNote = note('notes/first.md', '<p>abcdefghi</p>');
+    const { editor, scrollContainer } = await renderEditor(currentNote);
+
+    await waitFor(() => expect(editor.getHTML()).toBe('<p>abcdefghi</p>'));
+    editor.commands.setTextSelection({ from: 3, to: 7 });
+    scrollContainer.scrollTop = 180;
+    tiptapHarness.setTextSelectionCalls = [];
+    tiptapHarness.afterSetContent = () => {
+      scrollContainer.scrollTop = 0;
+    };
+
+    act(() => {
+      useNoteStore.getState().applyExternalContent(currentNote.id, '<p>externally changed</p>');
+    });
+
+    await waitFor(() => {
+      expect(editor.getHTML()).toBe('<p>externally changed</p>');
+      expect(scrollContainer.scrollTop).toBe(180);
+      expect(editor.state.selection.from).toBe(3);
+      expect(editor.state.selection.to).toBe(7);
+    });
+    expect(tiptapHarness.setTextSelectionCalls).toContainEqual([{ from: 3, to: 7 }]);
+  });
+
+  it('resets scroll and does not carry selection to a different note', async () => {
+    const firstNote = note('notes/first.md', '<p>abcdefghi</p>');
+    const secondNote = note('notes/second.md', '<p>second</p>');
+    const { editor, scrollContainer } = await renderEditor(firstNote, [secondNote]);
+
+    await waitFor(() => expect(editor.getHTML()).toBe('<p>abcdefghi</p>'));
+    editor.commands.focus();
+    await waitFor(() => expect(editor.isFocused).toBe(true));
+    editor.commands.setTextSelection({ from: 3, to: 7 });
+    scrollContainer.scrollTop = 220;
+    tiptapHarness.setTextSelectionCalls = [];
+    tiptapHarness.blurCallCount = 0;
+
+    act(() => {
+      useNoteStore.getState().switchTab(secondNote.id);
+    });
+
+    await waitFor(() => {
+      expect(editor.getHTML()).toBe('<p>second</p>');
+      expect(scrollContainer.scrollTop).toBe(0);
+    });
+    expect(tiptapHarness.setTextSelectionCalls).toEqual([]);
+    expect(tiptapHarness.blurCallCount).toBe(1);
+    await waitFor(() => {
+      expect(editor.isFocused).toBe(false);
+      expect(window.getSelection()?.rangeCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #38.

`Editor.tsx` is ~1140 lines, the largest component in the app, and had **zero** tests. That is why several fixes this cycle shipped reasoned rather than verified, and it is why #40's mouse-click interaction had to be described as "high confidence, not manually exercised."

## What is asserted

**1. Opening a note calls `setContent` with `{ emitUpdate: false }`.** The single most valuable assertion here. That flag is what stops merely *opening* a note from marking it dirty and rewriting it to disk — the v1.7.2 regression — and until now it was guarded by nothing but a comment.

**2. An external reload preserves scroll position and cursor.**

**3. A note switch resets scroll to the top and does not carry the selection over.**

Two and three pin the classification in the content effect, which is the code most recently touched by #82 and the one #46 is still circling.

## Why these aren't vacuous

The external-reload test **deliberately zeroes `scrollTop` during `setContent`**:

```ts
tiptapHarness.afterSetContent = () => {
  scrollContainer.scrollTop = 0;
};
```

so asserting it is back to `180` afterwards proves the restoration code actually ran, rather than proving nothing moved. Selection is read from `editor.state.selection`, i.e. real ProseMirror state, not a recorded call.

## What is real and what is mocked

The harness drives **real TipTap**, a real ProseMirror document, real commands, selection, focus and blur, and **all six real Zustand stores** (the issue says four; it is six).

Mocked: the IPC boundary, the four orchestration hooks, unrelated child UI, and a zero-layout `Range` shim that ProseMirror needs and jsdom lacks.

That line is deliberate. Mocking the editor itself would have produced a harness whose assertions only check the mock, which is worse than no harness because it reads as protection.

## Not covered, and honestly so

Tippy popup interaction, browser layout geometry, autosave persistence, and child toolbar/modal behaviour. Those need a real browser, not a deeper mock. Stated rather than papered over with tests that would pass regardless.

## Verification

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — `16 problems (0 errors, 16 warnings)`, unchanged
- `npm test` — **438 passing across 51 files** (up from 435/50)
- `npm run build && npm run check:size` — within budget

`Editor.tsx` itself is **untouched** — no production code was reshaped to make it testable.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm