### PR TITLE
fix(editor): keep your place when the editor is rebuilt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Moldavite are documented here.
 
 ### Fixed
 
+- **Changing a setting no longer scrolls the note you are reading back to the top.** Toggling anything the editor is built from, such as tags, rebuilt the editor and Moldavite treated that as opening a different note. Your place is now kept for anything that is not actually a switch to another note.
 - **Copied note URLs now open their note.** Note links were accepted by the clipboard but ignored when Moldavite received them. They now open root notes, foldered notes, daily notes, and weekly notes in the existing editor tab flow, while missing or locked notes produce a visible error.
 - **Tag, wiki-link, and slash-command suggestions no longer get stuck after the editor loses focus.** Once a suggestion menu had opened, clicking elsewhere or switching notes could leave it floating above the app, and Escape only hid it without closing its editor state. Suggestion menus now close completely on blur or Escape, while mouse selection keeps the editor focused until the chosen item is inserted.
 - **Inter and Merriweather now work as editor fonts.** Both typefaces were blocked and silently fell back to the default. They now ship with the app, so both work offline and neither fetches anything from a third party.

--- a/src/components/editor/Editor.test.tsx
+++ b/src/components/editor/Editor.test.tsx
@@ -232,6 +232,33 @@ describe('Editor content synchronization', () => {
     });
   });
 
+  it('keeps your place when the editor is rebuilt under the same note', async () => {
+    const currentNote = note('notes/first.md', '<p>abcdefghi</p>');
+    const { editor, scrollContainer } = await renderEditor(currentNote);
+
+    await waitFor(() => expect(editor.getHTML()).toBe('<p>abcdefghi</p>'));
+    editor.commands.setTextSelection({ from: 3, to: 7 });
+    scrollContainer.scrollTop = 140;
+
+    // Toggling a setting in the useEditor dep list swaps the editor instance.
+    // The note and its external revision are unchanged, so this is not a note
+    // switch and must not throw the reader back to the top.
+    act(() => {
+      useSettingsStore.setState({ tagsEnabled: false });
+    });
+
+    await waitFor(() => expect(tiptapHarness.editor).not.toBe(editor));
+    const rebuilt = tiptapHarness.editor as TiptapEditor;
+    await waitFor(() => expect(rebuilt.getHTML()).toBe('<p>abcdefghi</p>'));
+
+    // Scroll lives on a container outside the editor, so it survives the swap.
+    // The cursor does not: the effect reads selection from the new instance,
+    // and the old one is already gone by then. Scroll is the reported symptom.
+    const container = document.querySelector('.editor-paper');
+    if (!(container instanceof HTMLElement)) throw new Error('no scroll container');
+    expect(container.scrollTop).toBe(140);
+  });
+
   it('preserves scroll position and selection during an external reload', async () => {
     const currentNote = note('notes/first.md', '<p>abcdefghi</p>');
     const { editor, scrollContainer } = await renderEditor(currentNote);

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -868,13 +868,17 @@ export function Editor() {
     }
 
     const previous = lastAppliedRef.current;
-    // Same editor instance, same note, only the external revision moved: an
-    // agent, sync tool, or another editor rewrote this file while it sat open.
-    const isExternalReload =
-      !!note &&
-      previous.editor === editor &&
-      previous.noteId === currentNoteId &&
-      previous.externalRev !== note.externalRev;
+    // The reader keeps their place unless they actually moved to a different
+    // note. Two things reach here without being a switch: an external reload,
+    // where an agent or sync tool rewrote the file while it sat open, and an
+    // editor rebuild, where TipTap is recreated because a setting in its
+    // dependency list changed. Both leave the reader on the same note, so
+    // neither should throw them back to the top.
+    const isSameNote = !!note && previous.noteId !== null && previous.noteId === currentNoteId;
+    // Selection can only be carried across an external reload. On a rebuild the
+    // instance below is a fresh one and the old editor's selection is already
+    // gone, so there is nothing to read back.
+    const isExternalReload = isSameNote && previous.editor === editor;
     lastAppliedRef.current = {
       editor,
       noteId: currentNoteId ?? null,
@@ -892,7 +896,7 @@ export function Editor() {
               // reading it, so hold their scroll position and cursor. A note
               // switch keeps the original behaviour: top of the note, no
               // selection carried over from the previous one.
-              const scrollTop = isExternalReload ? (scrollContainerRef.current?.scrollTop ?? 0) : 0;
+              const scrollTop = isSameNote ? (scrollContainerRef.current?.scrollTop ?? 0) : 0;
               const selection = isExternalReload
                 ? { from: editor.state.selection.from, to: editor.state.selection.to }
                 : null;


### PR DESCRIPTION
Relates to #46.

## The reported trigger does not reproduce. The bug it points at does.

#46 says a note jumps to the top when returning to the app from another window. I could not reproduce that path: refocusing changes none of the content effect's dependencies (`[editor, currentNoteId, currentNote?.externalRev]`), so the effect does not re-run, and the only `focus` listener in the app lives in `updateStore.ts` and touches nothing note-related.

But the code it points at was genuinely wrong, and the Editor harness from #90 made that testable for the first time.

## What was wrong

The effect decided whether to hold the reader's place with:

```ts
const isExternalReload =
  !!note &&
  previous.editor === editor &&
  previous.noteId === currentNoteId &&
  previous.externalRev !== note.externalRev;
```

It only ever held position for an **external reload**. Everything else — including staying on the exact same note — fell into the note-switch branch and reset `scrollTop` to 0.

`useEditor` is keyed on `[tagsEnabled]`, so **toggling tags while reading a note rebuilds the TipTap instance and sent the reader straight back to the top.** Same symptom as the report, different trigger.

## The test that proves it

```
× keeps your place when the editor is rebuilt under the same note
AssertionError: expected +0 to be 140
```

Scroll to 140, toggle the setting, assert the offset survives. Fails on the old condition, passes on the new one.

## The fix

Position is kept unless the note id actually changed, which is the only thing that means "you opened something else":

```ts
const isSameNote = !!note && previous.noteId !== null && previous.noteId === currentNoteId;
```

`isExternalReload` still exists, narrowed to `isSameNote && previous.editor === editor`, because selection restoration genuinely only applies there.

## A limit I did not paper over

**Selection is still only restored across an external reload, not a rebuild.** On a rebuild the effect reads `editor.state.selection` from the *new* instance, and the old editor is gone by then, so there is nothing to read back. Carrying the cursor across instances would need it stashed before teardown — a larger change than the reported symptom warrants.

Scroll survives because its container lives outside the editor. That distinction is now a comment next to the code rather than something to rediscover.

## Verification

- `npm run format:check` — clean
- `npm run lint -- --max-warnings 16` — `16 problems (0 errors, 16 warnings)`, unchanged
- `npm test` — **439 passing** across 51 files
- `npm run build && npm run check:size` — within budget

## Not closing #46

This fixes a real defect in the code #46 identifies, but it is **not** the trigger the reporter described, and nobody has yet reproduced that one. Leaving the issue open for a runtime check on the released build rather than claiming a fix for a symptom I could not reproduce.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm