### PR TITLE
ci: push the cask with a deploy key instead of a PAT

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -126,15 +126,29 @@ jobs:
           brew style "${TAP_OWNER}/${TAP_NAME}"
           brew audit --cask --strict --online --arch all "${TAP_OWNER}/${TAP_NAME}/moldavite"
 
+      # Pushes with a deploy key rather than a personal access token. The key is
+      # write-scoped to the tap repository and nothing else, so a leak cannot
+      # reach any other repo or the account, which a PAT with Contents:write
+      # could not promise as narrowly.
       - name: Push to the tap
         if: env.SKIP != '1'
         env:
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
         run: |
           set -euo pipefail
+          key_file="$(mktemp)"
+          # Remove the key even if the push fails, so it never outlives the step.
+          trap 'rm -f "$key_file"' EXIT
+          printf '%s\n' "$TAP_DEPLOY_KEY" > "$key_file"
+          chmod 600 "$key_file"
+          # IdentitiesOnly stops ssh offering any agent key ahead of this one.
+          # accept-new trusts github.com on first contact: runners are ephemeral
+          # so there is no stored key to compare against, and pinning a host key
+          # here would break silently whenever GitHub rotates one.
+          export GIT_SSH_COMMAND="ssh -i $key_file -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
           tap_dir="$(brew --repository "${TAP_OWNER}/${TAP_NAME}")"
           cd "$tap_dir"
-          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/${TAP_REPO}.git"
+          git remote set-url origin "git@github.com:${TAP_REPO}.git"
           git push origin HEAD:main
           git remote set-url origin "https://github.com/${TAP_REPO}.git"
 


### PR DESCRIPTION
## The tap bump has never actually run

Worth stating, because I got this wrong earlier and corrected it: `HOMEBREW_TAP_TOKEN` was never removed — **it never existed**. The tap job was added in #54, *after* v1.8.1, and `git show v1.8.1:.github/workflows/release.yml` has zero mentions of homebrew. The v1.8.1 release run has four jobs and no tap job. The cask at 1.8.1 in the tap repo was pushed by hand the day after.

So v1.9.0 would have been this automation's first execution, against a secret that was never created, and it would have failed at `git push` with an empty token.

## Deploy key rather than a PAT

`docs/RELEASING.md` specifies a fine-grained PAT with Contents:write on the tap repo. A deploy key is strictly narrower: it is bound to **one repository** and cannot reach any other repo or the account, which even the tightest PAT cannot promise, since a PAT always belongs to the account that issued it.

It also needs nobody to mint anything in a browser — GitHub has no API for creating fine-grained PATs, but deploy keys can be created and installed entirely through the API.

## Verified before wiring, not during the release

I didn't want the release to be the first test:

```
$ ssh -i <key> -T git@github.com
Hi mauropereiira/homebrew-moldavite! You've successfully authenticated...

$ git push origin HEAD:refs/heads/deploy-key-write-check
 * [new branch]      HEAD -> deploy-key-write-check
$ git push origin --delete deploy-key-write-check
 - [deleted]         deploy-key-write-check
```

`git push --dry-run` was not enough — with nothing to push it reports "Everything up-to-date" without proving the key may write. Pushing and deleting a throwaway ref proves it. The tap repo is unchanged.

An earlier key was installed before I had verified it; it has been deleted, and the key in the secret is the one exercised above. The private half was never written anywhere but a temp file, which is destroyed.

## Handling in the workflow

- Key written to `mktemp`, `chmod 600`, removed by a `trap ... EXIT` so it cannot outlive the step even if the push fails
- `IdentitiesOnly=yes` so ssh does not offer an agent key ahead of it
- `StrictHostKeyChecking=accept-new` because runners are ephemeral — there is no stored key to compare against, and pinning one would break silently whenever GitHub rotates a host key

## Verification

YAML parses, the job's push step reads `HOMEBREW_TAP_DEPLOY_KEY`, and no reference to `HOMEBREW_TAP_TOKEN` remains anywhere in the file.

`docs/RELEASING.md` still describes the PAT in its secrets table; that wants updating, but I'd rather do it once this has run for real in a release than document a mechanism that has still only been tested by hand.

Claude-Session: https://claude.ai/code/session_01MUCCyuT1JFU5HSpR5Boxxm