### PR TITLE
release: 2.2.1 — pinned tabs, inline rename, and a legible calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.2.1] - 2026-08-16
+
+### Fixed
+
+- **The editor's footer controls disappeared whenever a note was pinned.** The pinned bar sat inside the editor column, above an editor that fills its height, so the column overflowed and pushed its own footer out of view. Colour, WordPress, Share, Format and More were all gone until you unpinned.
+- **Long note names ran underneath the Options button in the index** instead of ending in an ellipsis before it.
+- **The Index overlay's keyboard hint sat almost on top of its close button**, so on a narrower window the two read as one crowded object. It moves to the left, matching the Agenda overlay it had always disagreed with.
+- **The footer controls sat too close together.** The labels are uppercase and letterspaced, so the gap between two controls was narrower than the gap inside a single word and the row scanned as one continuous run of text.
+
+### Changed
+
+- **Pinned notes behave like browser tabs.** The bar spans the whole app rather than only the editor, so a pinned note is one click away wherever you are. Four stay on the bar and the rest collapse behind a count — twelve pins used to wrap onto three lines and push the app down, which is the opposite of what the bar is for. Drag a pin to reorder it, or hold alt and press left or right when one is focused.
+- **A note can be renamed from its own title.** Click the title and type. Enter saves, Escape abandons the edit, an empty name is refused, and a rename that fails puts the old name back so the page never shows a name the file does not have. Renaming from the menus still works. Daily and weekly notes stay read-only, because they are named by date.
+- **Today is legible on the calendar at a glance.** It was a one-pixel rule under a number, in a grid of numbers, next to the two-pixel rule that marks your selection. It now carries the accent colour as well.
+- **The marks under each date say what is on that day.** They used to count events, so a day with six back-to-back meetings and a day with one long meeting looked equally busy while telling you nothing about either. Each mark now stands for a kind of thing — open to-dos, events, a note — and a legend under the grid names the colours.
+
 ## [2.2.0] - 2026-08-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -77,7 +77,11 @@ const BUDGETS = [
 // applied across thirteen overlays that previously had none of it. Keyboard
 // users could tab straight out of every modal in the app. Measured 582.4 KB
 // raw / 160.3 KB gz.
-const APP_JS_BUDGET = { rawKb: 585, gzipKb: 162 };
+// Bumped 3 KB raw for 2.2.1: pin reordering with drag and keyboard, the
+// overflow menu, inline title renaming, and the calendar's day-mark legend.
+// Measured 585.3 KB raw / 161.4 KB gz — only raw crossed, so gzip is left
+// where it is rather than given headroom nothing has asked for.
+const APP_JS_BUDGET = { rawKb: 589, gzipKb: 162 };
 
 async function main() {
   let entries;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.2.0"
+version = "2.2.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/calendar/Calendar.test.tsx
+++ b/src/components/calendar/Calendar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CalendarEvent } from '@/types';
 import { useCalendarStore, useNoteStore } from '@/stores';
@@ -63,7 +63,10 @@ describe('Calendar day indicators', () => {
     });
   });
 
-  it('renders one ink dot per event, capped at three', async () => {
+  // Dots mark what *kind* of thing is on a day, not how many. Counting events
+  // made a day with six back-to-back meetings and a day with one long one look
+  // equally busy while saying nothing about either.
+  it('marks a day with events using the events colour, once', async () => {
     const { container } = render(<Calendar />);
 
     await waitFor(() => {
@@ -74,10 +77,20 @@ describe('Calendar day indicators', () => {
     expect(day).toBeInTheDocument();
 
     await waitFor(() => {
-      const indicators = day?.querySelector('svg[data-event-count="3"]');
-      expect(indicators).toBeInTheDocument();
-      expect(indicators?.querySelectorAll('circle')).toHaveLength(3);
+      const marks = day?.querySelectorAll('circle');
+      // Three events that day, but "has events" is one fact about it.
+      expect(marks).toHaveLength(1);
+      expect(marks?.[0].getAttribute('fill')).toBe('var(--accent)');
     });
+  });
+
+  // A colour-coded grid with no key is decoration.
+  it('names every mark colour in a legend', async () => {
+    render(<Calendar />);
+    const legend = await screen.findByLabelText('What the marks under each date mean');
+    for (const label of ['To-do', 'Events', 'Note']) {
+      expect(within(legend).getByText(label)).toBeInTheDocument();
+    }
   });
 
   it('keeps the month grid and daily-note indicators when every source is unavailable', () => {

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -18,7 +18,7 @@ import {
   parseISO,
 } from 'date-fns';
 import { fetchCalendarEvents } from '@/lib/calendar';
-import { useCalendarStore, useNoteStore } from '@/stores';
+import { useCalendarStore, useNoteStore, useTaskStatusStore } from '@/stores';
 import { useNotes } from '@/hooks';
 import type { CalendarEvent } from '@/types';
 
@@ -26,8 +26,24 @@ interface CalendarProps {
   onNavigate?: () => void;
 }
 
+/**
+ * What a dot under a date means. One per *kind*, never one per event: counting
+ * events made a day with six back-to-back meetings and a day with one long one
+ * look equally busy while saying nothing about what was actually on it.
+ *
+ * Shared with the legend below the grid, so the two can never drift — a
+ * colour-coded grid with no key is decoration, and a key that disagrees with
+ * the grid is worse than none.
+ */
+const DAY_MARKS = [
+  { kind: 'tasks', label: 'To-do', color: 'var(--warning)' },
+  { kind: 'events', label: 'Events', color: 'var(--accent)' },
+  { kind: 'note', label: 'Note', color: 'var(--text-secondary)' },
+] as const;
+
 export function Calendar({ onNavigate }: CalendarProps = {}) {
   const { selectedDate, setSelectedDate, selectedWeek, setSelectedWeek, notes } = useNoteStore();
+  const taskStatusByDate = useTaskStatusStore((state) => state.taskStatusByDate);
   const {
     sources,
     calendarEnabled,
@@ -271,6 +287,18 @@ export function Calendar({ onNavigate }: CalendarProps = {}) {
                 const isToday = isSameDay(day, new Date());
                 const dayHasNote = hasNote(day);
                 const dayEventCount = eventCount(day);
+                const dayKey = format(day, 'yyyy-MM-dd');
+                const taskStatus = taskStatusByDate.get(dayKey);
+                const hasOpenTasks = Boolean(
+                  taskStatus && taskStatus.totalTasks > taskStatus.completedTasks
+                );
+                const dayMarks = DAY_MARKS.filter(({ kind }) =>
+                  kind === 'tasks'
+                    ? hasOpenTasks
+                    : kind === 'events'
+                      ? dayEventCount > 0
+                      : dayHasNote
+                );
 
                 return (
                   <button
@@ -280,12 +308,18 @@ export function Calendar({ onNavigate }: CalendarProps = {}) {
                     className="calendar-date list-item-stagger focus-ring flex h-8 items-center justify-center text-xs transition-colors"
                     style={
                       {
-                        color: isCurrentMonth
-                          ? dayHasNote
-                            ? 'var(--text-primary)'
-                            : 'var(--text-secondary)'
-                          : 'var(--text-muted)',
-                        fontWeight: dayHasNote ? 500 : 400,
+                        // Today is the one date you look for, and a 1px rule
+                        // under a number in a grid of numbers is not enough to
+                        // find at a glance — especially beside the 2px rule
+                        // that marks the selection.
+                        color: isToday
+                          ? 'var(--accent)'
+                          : isCurrentMonth
+                            ? dayHasNote
+                              ? 'var(--text-primary)'
+                              : 'var(--text-secondary)'
+                            : 'var(--text-muted)',
+                        fontWeight: isToday || dayHasNote ? 500 : 400,
                         '--index': Math.min(weekIndex * 8 + dayIndex + 1, 10),
                       } as React.CSSProperties
                     }
@@ -311,6 +345,12 @@ export function Calendar({ onNavigate }: CalendarProps = {}) {
                       >
                         {format(day, 'd')}
                       </span>
+                      {/* One dot per *kind* of thing on that day rather than
+                          one per event. Counting events made a busy day and a
+                          day with a single long meeting look equally noisy
+                          while telling you nothing about what was on it. The
+                          legend beneath the grid names the colours; without it
+                          this is decoration. */}
                       <svg
                         aria-hidden="true"
                         data-event-count={dayEventCount}
@@ -320,17 +360,16 @@ export function Calendar({ onNavigate }: CalendarProps = {}) {
                         style={{
                           display: 'block',
                           marginTop: '2px',
-                          color: 'var(--text-muted)',
                           opacity: isCurrentMonth ? 1 : 0.55,
                         }}
                       >
-                        {Array.from({ length: dayEventCount }, (_, eventIndex) => (
+                        {dayMarks.map((mark, markIndex) => (
                           <circle
-                            key={eventIndex}
-                            cx={5 - ((dayEventCount - 1) * 3) / 2 + eventIndex * 3}
+                            key={mark.kind}
+                            cx={5 - ((dayMarks.length - 1) * 3) / 2 + markIndex * 3}
                             cy="1"
                             r="1"
-                            fill="currentColor"
+                            fill={mark.color}
                           />
                         ))}
                       </svg>
@@ -341,6 +380,20 @@ export function Calendar({ onNavigate }: CalendarProps = {}) {
             </div>
           );
         })}
+      </div>
+
+      {/* Without this the colours are decoration. Kept to the same quiet
+          register as the rest of the chrome — it should be readable when you
+          look for it and invisible when you are not. */}
+      <div className="calendar-legend" aria-label="What the marks under each date mean">
+        {DAY_MARKS.map(({ kind, label, color }) => (
+          <span key={kind} className="calendar-legend-item">
+            <svg width="6" height="6" viewBox="0 0 6 6" aria-hidden="true">
+              <circle cx="3" cy="3" r="3" fill={color} />
+            </svg>
+            {label}
+          </span>
+        ))}
       </div>
     </div>
   );

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1154,7 +1154,19 @@ export function Editor() {
         </div>
 
         <EditorErrorBoundary resetKey={currentNote?.id}>
-          {showNoteHeader && <NoteHeader note={currentNote} />}
+          {showNoteHeader && (
+            <NoteHeader
+              note={currentNote}
+              // The rename command addresses the file on disk, so resolve the
+              // note's own entry rather than handing it the open buffer — the
+              // display title and the filename are allowed to diverge, and the
+              // filename is the one that decides where we write.
+              onRename={async (title) => {
+                const file = notes.find((n) => n.path === currentNote?.id);
+                if (file) await renameNote(file, title);
+              }}
+            />
+          )}
           <div key={currentNote.id} className="h-full note-switch-enter">
             <EditorContent editor={editor} className="h-full" />
           </div>

--- a/src/components/editor/NoteHeader.test.tsx
+++ b/src/components/editor/NoteHeader.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { NoteHeader } from './NoteHeader';
+import type { Note } from '@/types';
+
+const note = (over: Partial<Note> = {}) =>
+  ({
+    id: 'notes/untitled.md',
+    title: 'Untitled',
+    content: '',
+    isDaily: false,
+    isWeekly: false,
+    ...over,
+  }) as Note;
+
+describe('NoteHeader', () => {
+  it('renames from the title itself, without going through a menu', async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    render(<NoteHeader note={note()} onRename={onRename} />);
+
+    const field = screen.getByLabelText('Note title');
+    await userEvent.clear(field);
+    await userEvent.type(field, 'Roadmap{Enter}');
+
+    expect(onRename).toHaveBeenCalledWith('Roadmap');
+  });
+
+  it('abandons the edit on Escape and shows the real name again', async () => {
+    const onRename = vi.fn();
+    render(<NoteHeader note={note()} onRename={onRename} />);
+
+    const field = screen.getByLabelText('Note title');
+    await userEvent.clear(field);
+    await userEvent.type(field, 'Half a thou{Escape}');
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Note title')).toHaveValue('Untitled');
+  });
+
+  // Renaming to nothing would leave a note that cannot be addressed at all.
+  it('refuses an empty title and restores the previous one', async () => {
+    const onRename = vi.fn();
+    render(<NoteHeader note={note()} onRename={onRename} />);
+
+    const field = screen.getByLabelText('Note title');
+    await userEvent.clear(field);
+    await userEvent.tab();
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Note title')).toHaveValue('Untitled');
+  });
+
+  // A failed rename must not leave the page displaying a name the file on disk
+  // does not have — `renameNote` reports the reason itself.
+  it('puts the old name back when the rename fails', async () => {
+    const onRename = vi.fn().mockRejectedValue(new Error('Invalid note name'));
+    render(<NoteHeader note={note()} onRename={onRename} />);
+
+    const field = screen.getByLabelText('Note title');
+    await userEvent.clear(field);
+    await userEvent.type(field, 'bad/name{Enter}');
+
+    expect(onRename).toHaveBeenCalled();
+    expect(await screen.findByLabelText('Note title')).toHaveValue('Untitled');
+  });
+
+  // Daily notes are named by date and the rename command rejects them, so
+  // offering an editable field here would be a promise the app cannot keep.
+  it('leaves a daily note read-only', () => {
+    render(
+      <NoteHeader
+        note={note({ id: '2026-08-16.md', title: '2026-08-16', isDaily: true, date: '2026-08-16' })}
+        onRename={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('Note title')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '16 August' })).toBeInTheDocument();
+  });
+});

--- a/src/components/editor/NoteHeader.tsx
+++ b/src/components/editor/NoteHeader.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import { format, parseISO, isValid } from 'date-fns';
 import type { Note } from '@/types';
 
@@ -11,26 +12,94 @@ import type { Note } from '@/types';
  * and no fills, hierarchy has to be carried typographically, so the page
  * states its own name.
  *
- * Read-only on purpose: renaming already lives in the note context menu and
- * the footer's more-options, and duplicating it here would put two sources of
- * truth on the same string.
+ * The title is editable here. It used to be deliberately read-only, on the
+ * grounds that renaming lived in the context menu and the more-options menu and
+ * two sources of truth on one string is a smell. That reasoning was wrong about
+ * which one is the source: the title on the page is where you look when a note
+ * is called "Untitled", and sending you to a menu to fix the word you are
+ * already staring at is the kind of small friction that makes a note stay
+ * called "Untitled". The menus still work; they now agree with this field
+ * rather than owning it.
+ *
+ * Daily and weekly notes stay read-only: they are named by date, and the rename
+ * command rejects them for that reason.
  */
-export function NoteHeader({ note }: { note: Note | null }) {
-  if (!note) return null;
-
-  const title = note.title.replace(/\.md$/, '');
+export function NoteHeader({
+  note,
+  onRename,
+}: {
+  note: Note | null;
+  /** Resolves the on-disk file itself; the header only supplies the new name. */
+  onRename?: (title: string) => Promise<void>;
+}) {
+  const title = note ? note.title.replace(/\.md$/, '') : '';
 
   // Daily and weekly notes are named by date; render that as a real date
   // rather than repeating the filename back at the reader.
-  const asDate = note.date ? parseISO(note.date) : parseISO(title);
-  const isDateNamed = (note.isDaily || /^\d{4}-\d{2}-\d{2}$/.test(title)) && isValid(asDate);
+  const asDate = note?.date ? parseISO(note.date) : parseISO(title);
+  const isDateNamed = Boolean(
+    note && (note.isDaily || /^\d{4}-\d{2}-\d{2}$/.test(title)) && isValid(asDate)
+  );
 
   const heading = isDateNamed ? format(asDate, 'd MMMM') : title;
+  const [draft, setDraft] = useState(heading);
+  const [lastHeading, setLastHeading] = useState(heading);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Escape restores the name and then blurs, and blurring is what commits — so
+  // without this the abandoned edit would be saved by the very act of leaving
+  // the field. A ref rather than state because `commit` must see it in the same
+  // tick the blur fires.
+  const abandonedRef = useRef(false);
+
+  // Follow the note: without this the field keeps the previous note's title
+  // when you switch, which reads as the wrong note being open. Adjusted during
+  // render rather than in an effect — React's own recommendation for deriving
+  // state from props, and it avoids a second render with the stale name
+  // painted on screen first.
+  if (heading !== lastHeading) {
+    setLastHeading(heading);
+    setDraft(heading);
+  }
+
+  if (!note) return null;
+
   const label = isDateNamed
     ? format(asDate, 'EEEE · yyyy')
     : note.updatedAt
       ? `Edited ${format(new Date(note.updatedAt), 'd MMM yyyy')}`
       : null;
+
+  const canRename = Boolean(onRename) && !isDateNamed && !note.isWeekly;
+
+  const headingStyle = {
+    fontFamily: 'var(--font-display)',
+    fontSize: 'clamp(26px, 3vw, 32px)',
+    lineHeight: 1.15,
+    fontWeight: 400,
+    letterSpacing: '-0.02em',
+    color: 'var(--text-primary)',
+    margin: 0,
+    overflowWrap: 'anywhere' as const,
+  };
+
+  const commit = async () => {
+    if (abandonedRef.current) {
+      abandonedRef.current = false;
+      return;
+    }
+    const next = draft.trim();
+    if (!next || next === heading) {
+      setDraft(heading);
+      return;
+    }
+    try {
+      await onRename?.(next);
+    } catch {
+      // `renameNote` reports the reason itself; put the old name back so the
+      // page never shows a name the file does not have.
+      setDraft(heading);
+    }
+  };
 
   return (
     <header
@@ -41,20 +110,39 @@ export function NoteHeader({ note }: { note: Note | null }) {
         borderBottom: '1px solid var(--border-muted)',
       }}
     >
-      <h1
-        style={{
-          fontFamily: 'var(--font-display)',
-          fontSize: 'clamp(26px, 3vw, 32px)',
-          lineHeight: 1.15,
-          fontWeight: 400,
-          letterSpacing: '-0.02em',
-          color: 'var(--text-primary)',
-          margin: 0,
-          overflowWrap: 'anywhere',
-        }}
-      >
-        {heading}
-      </h1>
+      {canRename ? (
+        <h1 style={{ margin: 0 }}>
+          <input
+            ref={inputRef}
+            value={draft}
+            aria-label="Note title"
+            spellCheck={false}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={() => void commit()}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                inputRef.current?.blur();
+              } else if (event.key === 'Escape') {
+                event.preventDefault();
+                abandonedRef.current = true;
+                setDraft(heading);
+                inputRef.current?.blur();
+              }
+            }}
+            style={{
+              ...headingStyle,
+              width: '100%',
+              padding: 0,
+              border: 0,
+              background: 'transparent',
+              outline: 'none',
+            }}
+          />
+        </h1>
+      ) : (
+        <h1 style={headingStyle}>{heading}</h1>
+      )}
       {label && (
         <p
           style={{

--- a/src/components/editor/WordPressMenu.test.tsx
+++ b/src/components/editor/WordPressMenu.test.tsx
@@ -138,6 +138,31 @@ describe('WordPressMenu', () => {
     expect(screen.queryByText(/Woo Happiness/)).not.toBeInTheDocument();
   });
 
+  // Choosing a site sets up the next step rather than ending the interaction.
+  // The menu used to close on selection, hiding the Publish button the choice
+  // had just been made for, so you had to reopen it to find the action.
+  it('keeps the menu open when you pick a site, leaving Publish in view', async () => {
+    status.mockResolvedValue({ available: true, connected: true, error: null });
+    sites.mockResolvedValue([
+      { id: 1, name: 'Main blog', url: 'https://a.com' },
+      { id: 2, name: 'Side blog', url: 'https://b.com' },
+    ]);
+
+    render(<WordPressMenu />);
+    await waitFor(() => expect(sites).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole('button', { name: 'WordPress' }));
+
+    expect(await screen.findByText('Choose a site first')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Side blog · b.com' }));
+
+    // Still open — the site list is still there to change your mind with.
+    expect(screen.getByRole('menuitem', { name: '✓ Side blog · b.com' })).toBeInTheDocument();
+
+    // And the action the choice was made for is now in view and ready.
+    const publish = screen.getByRole('menuitem', { name: 'Publish to Side blog · b.com' });
+    expect(publish).not.toBeDisabled();
+  });
+
   it('offers no search box for a handful of sites', async () => {
     status.mockResolvedValue({ available: true, connected: true, error: null });
     sites.mockResolvedValue([

--- a/src/components/editor/WordPressMenu.tsx
+++ b/src/components/editor/WordPressMenu.tsx
@@ -11,7 +11,13 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { listen } from '@tauri-apps/api/event';
-import { Dropdown, DropdownItem, DropdownDivider, DropdownSearch } from '@/components/ui/Dropdown';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownDivider,
+  DropdownSearch,
+  DropdownStatic,
+} from '@/components/ui/Dropdown';
 import { useNoteStore } from '@/stores';
 import { useWordPressStore } from '@/stores/wordpressStore';
 import { htmlToMarkdown } from '@/lib';
@@ -140,18 +146,13 @@ export function WordPressMenu({
 
       {connected && (
         <>
-          <DropdownItem
-            onClick={() => void handlePublish()}
-            // Without `publishing`, reopening the menu mid-publish and clicking
-            // again sends a second create — neither call has a post id yet, so
-            // you get two drafts and only the later one stays mapped.
-            disabled={!currentNote || !chosenSite || publishing}
-          >
-            {chosenSite ? `Publish to ${siteLabel(chosenSite)}` : 'Choose a site first'}
-          </DropdownItem>
+          {/* The picker comes first and does not dismiss the menu, so choosing
+              a site leaves you looking at the button that publishes to it.
+              Publishing used to sit above a list that closed on selection —
+              you chose a site, the menu vanished, and you had to reopen it to
+              find the action you had just set up. */}
           {sites.length > 1 && (
-            <>
-              <DropdownDivider />
+            <DropdownStatic>
               {showSearch && (
                 <DropdownSearch
                   value={query}
@@ -179,8 +180,25 @@ export function WordPressMenu({
                   ))
                 )}
               </div>
-            </>
+              <DropdownDivider />
+            </DropdownStatic>
           )}
+
+          <DropdownItem
+            variant="primary"
+            onClick={() => void handlePublish()}
+            // Without `publishing`, reopening the menu mid-publish and clicking
+            // again sends a second create — neither call has a post id yet, so
+            // you get two drafts and only the later one stays mapped.
+            disabled={!currentNote || !chosenSite || publishing}
+          >
+            {publishing
+              ? 'Publishing…'
+              : chosenSite
+                ? `Publish to ${siteLabel(chosenSite)}`
+                : 'Choose a site first'}
+          </DropdownItem>
+
           <DropdownDivider />
           <DropdownItem onClick={() => void disconnect()}>Disconnect</DropdownItem>
         </>

--- a/src/components/index-overlay/IndexOverlay.tsx
+++ b/src/components/index-overlay/IndexOverlay.tsx
@@ -62,15 +62,22 @@ export function IndexOverlay({ isOpen, onClose }: IndexOverlayProps) {
 
       <Sidebar presentation="index" autoFocusSearch onNavigate={onClose} />
 
+      {/* Left, not tucked in beside the close button. Pinned to `right: 56px`
+          it sat 32px from the ×, so on a narrower window the hint and the
+          control read as one crowded object — and it disagreed with the Agenda
+          overlay, which has always put its shortcut under the title on the
+          left. Two overlays that behave the same should look the same. */}
       <p
         style={{
           position: 'absolute',
-          right: '56px',
+          left: '24px',
           top: '24px',
+          zIndex: 2,
           color: 'var(--text-muted)',
           fontSize: '10px',
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
+          pointerEvents: 'none',
         }}
       >
         ⌘\ · Esc closes

--- a/src/components/layout/Layout.test.tsx
+++ b/src/components/layout/Layout.test.tsx
@@ -1,6 +1,12 @@
 import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useOverlayStore, useSettingsStore, useTimelineStore } from '@/stores';
+import {
+  useNoteStore,
+  useOverlayStore,
+  useQuickSwitcherStore,
+  useSettingsStore,
+  useTimelineStore,
+} from '@/stores';
 import { Layout } from './Layout';
 
 vi.mock('../editor/Editor', () => ({
@@ -114,5 +120,36 @@ describe('Layout navigation surfaces', () => {
     act(() => useOverlayStore.getState().openAgenda(false));
     expect(screen.queryByTestId('index-overlay')).not.toBeInTheDocument();
     expect(screen.getByTestId('agenda-overlay')).toBeInTheDocument();
+  });
+
+  // The pinned bar used to live inside the editor column, as a sibling above an
+  // editor whose root is `h-full`. That made the column taller than its box and
+  // pushed the editor's own footer — Colour, WordPress, Share, Format, More —
+  // out of view, so those controls vanished exactly when a note was pinned.
+  // It belongs above the whole app: full width, outside the content row.
+  it('puts the pinned bar above the content row, not inside the editor column', () => {
+    useQuickSwitcherStore.setState({ pinnedNoteIds: ['notes/roadmap.md'] });
+    useNoteStore.setState({
+      notes: [
+        {
+          name: 'roadmap.md',
+          path: 'notes/roadmap.md',
+          isDaily: false,
+          isWeekly: false,
+          isLocked: false,
+        },
+      ] as never,
+      currentNote: null,
+    });
+
+    render(<Layout />);
+
+    const bar = screen.getByRole('navigation', { name: 'Pinned notes' });
+    const content = screen.getByTestId('app-content-area');
+    // Not a descendant of the content area, and therefore not of the editor
+    // column inside it.
+    expect(content.contains(bar)).toBe(false);
+    // Ordered before it in the document, so it reads as a bar across the top.
+    expect(bar.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -117,121 +117,131 @@ export function Layout() {
 
   return (
     <div
-      className="flex h-screen w-screen overflow-hidden"
+      className="flex flex-col h-screen w-screen overflow-hidden"
       style={{ backgroundColor: 'var(--bg-base)' }}
     >
-      {showIconRail && <IconRail />}
+      {/* Full width, above everything including the rail and the index, so a
+          pinned note is one click away from wherever you are. It sits outside
+          the content row rather than inside the editor column: the editor is
+          `h-full`, so a sibling above it there pushed its own footer out of
+          view — which is why the footer controls disappeared whenever
+          something was pinned. Overlays and modals mount above this and cover
+          it, which is what you want when one is open. */}
+      <PinnedBar />
 
-      <div
-        data-testid="app-content-area"
-        className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden"
-      >
-        {/* Left Sidebar */}
-        {sidebarVisible && (
-          <div
-            className="app-sidebar flex-shrink-0 relative"
-            style={{
-              width: `${sidebarWidth}px`,
-              backgroundColor: 'var(--bg-sidebar)',
-              borderRight: '1px solid var(--border-default)',
-            }}
-          >
-            <Sidebar />
+      <div className="flex min-h-0 w-full flex-1 overflow-hidden">
+        {showIconRail && <IconRail />}
 
-            {/* Left Resize Handle */}
-            <div
-              className="absolute top-0 right-0 w-1 h-full cursor-col-resize z-10 transition-colors"
-              style={{
-                transitionDuration: 'var(--duration-fast)',
-                backgroundColor:
-                  isResizing === 'left'
-                    ? 'var(--accent-primary)'
-                    : isHovering === 'left'
-                      ? 'var(--border-strong)'
-                      : 'transparent',
-              }}
-              onMouseDown={handleMouseDown('left')}
-              onMouseEnter={() => setIsHovering('left')}
-              onMouseLeave={() => setIsHovering(null)}
-            />
-
-            {/* Extended hit area for easier grabbing */}
-            <div
-              className="absolute top-0 right-0 w-2 h-full cursor-col-resize z-10"
-              style={{ transform: 'translateX(50%)' }}
-              onMouseDown={handleMouseDown('left')}
-              onMouseEnter={() => setIsHovering('left')}
-              onMouseLeave={() => setIsHovering(null)}
-            />
-          </div>
-        )}
-
-        {/* Center pane — Editor by default, Timeline when toggled on */}
         <div
-          className="relative flex-1 flex flex-col min-w-0"
-          style={{ backgroundColor: 'var(--bg-editor)' }}
+          data-testid="app-content-area"
+          className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden"
         >
-          {isTimelineOpen ? (
-            <Suspense fallback={null}>
-              <TimelineView />
-            </Suspense>
-          ) : (
-            <>
-              <PinnedBar />
-              <Editor />
-              <EditorNavigation />
-            </>
-          )}
-        </div>
-
-        {/* Right Panel */}
-        {rightPanelVisible && (
-          <div
-            className="app-right-panel relative min-h-0 flex-shrink-0 overflow-hidden"
-            style={{
-              width: `${rightPanelWidth}px`,
-              backgroundColor: 'var(--bg-panel)',
-              borderLeft: '1px solid var(--border-default)',
-            }}
-          >
-            {/* Right Resize Handle */}
+          {/* Left Sidebar */}
+          {sidebarVisible && (
             <div
-              className="absolute top-0 left-0 w-1 h-full cursor-col-resize z-10 transition-colors"
+              className="app-sidebar flex-shrink-0 relative"
               style={{
-                transitionDuration: 'var(--duration-fast)',
-                backgroundColor:
-                  isResizing === 'right'
-                    ? 'var(--accent-primary)'
-                    : isHovering === 'right'
-                      ? 'var(--border-strong)'
-                      : 'transparent',
+                width: `${sidebarWidth}px`,
+                backgroundColor: 'var(--bg-sidebar)',
+                borderRight: '1px solid var(--border-default)',
               }}
-              onMouseDown={handleMouseDown('right')}
-              onMouseEnter={() => setIsHovering('right')}
-              onMouseLeave={() => setIsHovering(null)}
-            />
+            >
+              <Sidebar />
 
-            {/* Extended hit area for easier grabbing */}
-            <div
-              className="absolute top-0 left-0 w-2 h-full cursor-col-resize z-10"
-              style={{ transform: 'translateX(-50%)' }}
-              onMouseDown={handleMouseDown('right')}
-              onMouseEnter={() => setIsHovering('right')}
-              onMouseLeave={() => setIsHovering(null)}
-            />
+              {/* Left Resize Handle */}
+              <div
+                className="absolute top-0 right-0 w-1 h-full cursor-col-resize z-10 transition-colors"
+                style={{
+                  transitionDuration: 'var(--duration-fast)',
+                  backgroundColor:
+                    isResizing === 'left'
+                      ? 'var(--accent-primary)'
+                      : isHovering === 'left'
+                        ? 'var(--border-strong)'
+                        : 'transparent',
+                }}
+                onMouseDown={handleMouseDown('left')}
+                onMouseEnter={() => setIsHovering('left')}
+                onMouseLeave={() => setIsHovering(null)}
+              />
 
-            <RightPanel />
+              {/* Extended hit area for easier grabbing */}
+              <div
+                className="absolute top-0 right-0 w-2 h-full cursor-col-resize z-10"
+                style={{ transform: 'translateX(50%)' }}
+                onMouseDown={handleMouseDown('left')}
+                onMouseEnter={() => setIsHovering('left')}
+                onMouseLeave={() => setIsHovering(null)}
+              />
+            </div>
+          )}
+
+          {/* Center pane — Editor by default, Timeline when toggled on */}
+          <div
+            className="relative flex-1 flex flex-col min-w-0"
+            style={{ backgroundColor: 'var(--bg-editor)' }}
+          >
+            {isTimelineOpen ? (
+              <Suspense fallback={null}>
+                <TimelineView />
+              </Suspense>
+            ) : (
+              <>
+                <Editor />
+                <EditorNavigation />
+              </>
+            )}
           </div>
-        )}
 
-        <IndexOverlay
-          isOpen={activeOverlay === 'index' && indexMode === 'overlay'}
-          onClose={closeOverlay}
-        />
-        <AgendaOverlay
-          isOpen={activeOverlay === 'agenda' && agendaMode === 'overlay'}
-          onClose={closeOverlay}
-        />
+          {/* Right Panel */}
+          {rightPanelVisible && (
+            <div
+              className="app-right-panel relative min-h-0 flex-shrink-0 overflow-hidden"
+              style={{
+                width: `${rightPanelWidth}px`,
+                backgroundColor: 'var(--bg-panel)',
+                borderLeft: '1px solid var(--border-default)',
+              }}
+            >
+              {/* Right Resize Handle */}
+              <div
+                className="absolute top-0 left-0 w-1 h-full cursor-col-resize z-10 transition-colors"
+                style={{
+                  transitionDuration: 'var(--duration-fast)',
+                  backgroundColor:
+                    isResizing === 'right'
+                      ? 'var(--accent-primary)'
+                      : isHovering === 'right'
+                        ? 'var(--border-strong)'
+                        : 'transparent',
+                }}
+                onMouseDown={handleMouseDown('right')}
+                onMouseEnter={() => setIsHovering('right')}
+                onMouseLeave={() => setIsHovering(null)}
+              />
+
+              {/* Extended hit area for easier grabbing */}
+              <div
+                className="absolute top-0 left-0 w-2 h-full cursor-col-resize z-10"
+                style={{ transform: 'translateX(-50%)' }}
+                onMouseDown={handleMouseDown('right')}
+                onMouseEnter={() => setIsHovering('right')}
+                onMouseLeave={() => setIsHovering(null)}
+              />
+
+              <RightPanel />
+            </div>
+          )}
+
+          <IndexOverlay
+            isOpen={activeOverlay === 'index' && indexMode === 'overlay'}
+            onClose={closeOverlay}
+          />
+          <AgendaOverlay
+            isOpen={activeOverlay === 'agenda' && agendaMode === 'overlay'}
+            onClose={closeOverlay}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/layout/PinnedBar.test.tsx
+++ b/src/components/layout/PinnedBar.test.tsx
@@ -73,4 +73,54 @@ describe('PinnedBar', () => {
     expect(screen.getByRole('button', { name: 'ideas' })).toHaveAttribute('aria-current', 'page');
     expect(screen.getByRole('button', { name: 'roadmap' })).not.toHaveAttribute('aria-current');
   });
+
+  // Twelve pins wrapped onto three lines and pushed the whole app down, which
+  // is the opposite of the speed the bar exists for. Browser-tab behaviour:
+  // a few stay put, the rest collapse into a menu.
+  it('keeps four pins on the bar and puts the rest behind a count', async () => {
+    const paths = ['a', 'b', 'c', 'd', 'e', 'f'].map((n) => `notes/${n}.md`);
+    useNoteStore.setState({ notes: paths.map((p) => file(p)) as never, currentNote: null });
+    useQuickSwitcherStore.setState({ pinnedNoteIds: paths });
+
+    render(<PinnedBar />);
+
+    expect(screen.getByRole('button', { name: 'a' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'd' })).toBeInTheDocument();
+    // Beyond the fourth, they are not on the bar.
+    expect(screen.queryByRole('button', { name: 'e' })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: '2 more pinned notes' }));
+    expect(await screen.findByRole('menuitem', { name: 'e' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'f' })).toBeInTheDocument();
+  });
+
+  // The order is the user's, and a drag-only control would be unusable without
+  // a mouse — this is the keyboard path to the same reordering.
+  it('moves a pin with alt+arrow so reordering is not mouse-only', async () => {
+    const paths = ['a', 'b', 'c'].map((n) => `notes/${n}.md`);
+    useNoteStore.setState({ notes: paths.map((p) => file(p)) as never, currentNote: null });
+    useQuickSwitcherStore.setState({ pinnedNoteIds: paths });
+
+    render(<PinnedBar />);
+    screen.getByRole('button', { name: 'c' }).focus();
+    await userEvent.keyboard('{Alt>}{ArrowLeft}{/Alt}');
+
+    expect(useQuickSwitcherStore.getState().pinnedNoteIds).toEqual([
+      'notes/a.md',
+      'notes/c.md',
+      'notes/b.md',
+    ]);
+  });
+
+  it('refuses to move a pin off either end', async () => {
+    const paths = ['a', 'b'].map((n) => `notes/${n}.md`);
+    useNoteStore.setState({ notes: paths.map((p) => file(p)) as never, currentNote: null });
+    useQuickSwitcherStore.setState({ pinnedNoteIds: paths });
+
+    render(<PinnedBar />);
+    screen.getByRole('button', { name: 'a' }).focus();
+    await userEvent.keyboard('{Alt>}{ArrowLeft}{/Alt}');
+
+    expect(useQuickSwitcherStore.getState().pinnedNoteIds).toEqual(['notes/a.md', 'notes/b.md']);
+  });
 });

--- a/src/components/layout/PinnedBar.tsx
+++ b/src/components/layout/PinnedBar.tsx
@@ -1,60 +1,120 @@
 /**
- * A strip of pinned notes above the editor.
+ * A strip of pinned notes across the top of the app.
  *
  * It exists only when something is pinned. An empty bar is worse than no bar:
  * it costs a row of vertical space in an app whose whole layout argument is
  * that the note is the only thing on screen that has earned its place.
  *
- * Pins are `quickSwitcherStore.pinnedNoteIds` — the same list the Quick
- * Switcher already showed. Adding a second pin concept would mean a note could
- * be pinned in one surface and not the other, which nobody would be able to
- * explain. (Tabs have their own `isPinned`, which is a different idea: it means
- * "don't reuse this tab", not "keep this note to hand".)
+ * It behaves like browser tabs, because that is what people already know. A
+ * handful stay on the bar and the rest collapse into a menu — twelve pins
+ * wrapped onto three lines and pushed the app down, which is the opposite of
+ * the speed the bar is for. Order is the user's: drag a pin to move it, or use
+ * the arrow keys when one is focused, so the reordering is not mouse-only.
  *
- * Opening a pinned note goes through the normal load path, so if that note is
- * already open it focuses the existing tab rather than opening a second copy.
+ * Pins are `quickSwitcherStore.pinnedNoteIds` — the same list the Quick
+ * Switcher shows. A second pin concept would mean a note could be pinned in one
+ * surface and not the other, which nobody could explain. (Tabs keep their own
+ * `isPinned`, which means "don't reuse this tab" — a different idea.)
+ *
+ * Opening a pinned note goes through the normal load path, so if it is already
+ * open it focuses that tab rather than opening a second copy.
  */
 
+import { useState } from 'react';
 import { useNoteStore, useQuickSwitcherStore } from '@/stores';
 import { useNotes } from '@/hooks';
+import { Dropdown, DropdownItem } from '@/components/ui/Dropdown';
 import type { NoteFile } from '@/types';
 
 /** `NoteFile` carries a filename, not a display title — strip the folder and
  *  the extension so the bar reads as names rather than paths. */
 const noteLabel = (note: NoteFile) => note.name.replace(/\.md$/, '').split('/').pop() ?? note.name;
 
+/**
+ * How many stay on the bar. Four is about what fits beside the window controls
+ * at a normal width without the bar becoming the loudest thing on screen.
+ */
+const VISIBLE_PINS = 4;
+
 export function PinnedBar() {
-  const { pinnedNoteIds, togglePinned } = useQuickSwitcherStore();
+  const { pinnedNoteIds, togglePinned, movePinnedNote } = useQuickSwitcherStore();
   const { notes, currentNote } = useNoteStore();
   const { loadNote } = useNotes();
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
 
-  // A pin can outlive its note — deleted outside the app, or in another Forge.
-  // Resolve against the live list rather than trusting the stored ids, so a
-  // stale pin is simply absent instead of rendering a row that cannot open.
-  const pinned = pinnedNoteIds
-    .map((id) => notes.find((note) => note.path === id))
-    .filter((note): note is NonNullable<typeof note> => Boolean(note));
+  // A pin can outlive its note — deleted outside the app, or belonging to
+  // another Forge. Resolve against the live list rather than trusting the
+  // stored ids, so a stale pin is simply absent instead of a row that cannot
+  // open. Indices are kept against the *stored* list so reordering addresses
+  // the real array rather than the filtered view.
+  const resolved = pinnedNoteIds
+    .map((id, index) => ({ index, note: notes.find((n) => n.path === id) }))
+    .filter((entry): entry is { index: number; note: NoteFile } => Boolean(entry.note));
 
-  if (pinned.length === 0) return null;
+  if (resolved.length === 0) return null;
+
+  const onBar = resolved.slice(0, VISIBLE_PINS);
+  const overflow = resolved.slice(VISIBLE_PINS);
+
+  const open = (note: NoteFile) => void loadNote(note);
 
   return (
     <nav className="pinned-bar" aria-label="Pinned notes">
-      {pinned.map((note) => {
+      {onBar.map(({ index, note }, position) => {
         const isCurrent = currentNote?.id === note.path;
         return (
-          <span key={note.path} className="pinned-bar-item" data-current={isCurrent || undefined}>
+          <span
+            key={note.path}
+            className="pinned-bar-item"
+            data-current={isCurrent || undefined}
+            data-drop={overIndex === index && dragIndex !== index ? '' : undefined}
+            draggable
+            onDragStart={(event) => {
+              setDragIndex(index);
+              event.dataTransfer.effectAllowed = 'move';
+              // Firefox refuses to start a drag without payload.
+              event.dataTransfer.setData('text/plain', note.path);
+            }}
+            onDragOver={(event) => {
+              event.preventDefault();
+              event.dataTransfer.dropEffect = 'move';
+              setOverIndex(index);
+            }}
+            onDragLeave={() => setOverIndex((current) => (current === index ? null : current))}
+            onDrop={(event) => {
+              event.preventDefault();
+              if (dragIndex !== null) movePinnedNote(dragIndex, index);
+              setDragIndex(null);
+              setOverIndex(null);
+            }}
+            onDragEnd={() => {
+              setDragIndex(null);
+              setOverIndex(null);
+            }}
+          >
             <button
               type="button"
               className="pinned-bar-open"
               aria-current={isCurrent ? 'page' : undefined}
-              onClick={() => void loadNote(note)}
+              onClick={() => open(note)}
+              onKeyDown={(event) => {
+                // The keyboard path to the same reordering. A drag-only control
+                // is unusable without a mouse, and this bar is meant to be the
+                // fast way around.
+                if (!event.altKey || (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight')) {
+                  return;
+                }
+                event.preventDefault();
+                movePinnedNote(index, index + (event.key === 'ArrowLeft' ? -1 : 1));
+              }}
             >
               {noteLabel(note)}
             </button>
             <button
               type="button"
               className="pinned-bar-unpin"
-              // The title alone is the accessible name for the open button, so
+              // The label alone is the accessible name for the open button, so
               // the unpin button has to name the note too — otherwise a screen
               // reader hears a row of identical "Unpin" controls.
               aria-label={`Unpin ${noteLabel(note)}`}
@@ -63,9 +123,34 @@ export function PinnedBar() {
             >
               ×
             </button>
+            {position === onBar.length - 1 && overflow.length > 0 && (
+              <span className="pinned-bar-sep" aria-hidden="true" />
+            )}
           </span>
         );
       })}
+
+      {overflow.length > 0 && (
+        <Dropdown
+          position="left"
+          trigger={
+            <button
+              type="button"
+              className="pinned-bar-more"
+              aria-label={`${overflow.length} more pinned notes`}
+              title={`${overflow.length} more pinned notes`}
+            >
+              +{overflow.length}
+            </button>
+          }
+        >
+          {overflow.map(({ note }) => (
+            <DropdownItem key={note.path} onClick={() => open(note)}>
+              {noteLabel(note)}
+            </DropdownItem>
+          ))}
+        </Dropdown>
+      )}
     </nav>
   );
 }

--- a/src/components/sidebar/DraggableNoteItem.tsx
+++ b/src/components/sidebar/DraggableNoteItem.tsx
@@ -83,13 +83,19 @@ function DraggableNoteItemImpl({
         }${isSelected ? ' is-selected' : ''}`}
         aria-pressed={isSelected || undefined}
       >
-        <span className="flex items-baseline gap-2">
+        {/* `min-w-0` on both: a flex item's default minimum is its content
+            size, so `truncate` never engages and a long note name runs under
+            the Options button instead of ellipsing before it. */}
+        <span className="flex min-w-0 items-baseline gap-2">
           {note.isLocked && (
-            <span className="text-[10px] font-normal" style={{ color: 'var(--text-muted)' }}>
+            <span
+              className="flex-shrink-0 text-[10px] font-normal"
+              style={{ color: 'var(--text-muted)' }}
+            >
               Locked
             </span>
           )}
-          <span className="note-card-title truncate">{note.name.replace(/\.md$/, '')}</span>
+          <span className="note-card-title min-w-0 truncate">{note.name.replace(/\.md$/, '')}</span>
         </span>
         {tags.length > 0 && (
           <div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-0.5">

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -79,6 +79,11 @@ export function Dropdown({
       // would make it impossible to focus, let alone type in.
       if (child.type === DropdownSearch) return child;
 
+      // Neither is a setting you are adjusting *before* you act. Anything
+      // inside a static region keeps the menu open, including its descendants,
+      // so picking a site leaves you looking at the button that publishes to it.
+      if (child.type === DropdownStatic) return child;
+
       const clickable = child as React.ReactElement<{
         onClick?: React.MouseEventHandler<HTMLElement>;
       }>;
@@ -126,7 +131,7 @@ interface DropdownItemProps {
   children: React.ReactNode;
   onClick?: () => void;
   icon?: React.ReactNode;
-  variant?: 'default' | 'danger';
+  variant?: 'default' | 'danger' | 'primary';
   disabled?: boolean;
 }
 
@@ -141,9 +146,21 @@ export function DropdownItem({
     <button
       onClick={disabled ? undefined : onClick}
       role="menuitem"
-      className="w-full px-3 py-2 text-sm text-left flex items-center gap-2 transition-colors focus-ring"
+      // `primary` marks the action the menu exists for. The accent is the one
+      // colour this design holds back for a single thing at a time, so it reads
+      // as "this is the button" without a filled block shouting in a menu of
+      // quiet rows.
+      className={`w-full px-3 py-2 text-sm text-left flex items-center gap-2 transition-colors focus-ring${
+        variant === 'primary' ? ' dropdown-item-primary' : ''
+      }`}
       style={{
-        color: variant === 'danger' ? 'var(--error)' : 'var(--text-primary)',
+        color:
+          variant === 'danger'
+            ? 'var(--error)'
+            : variant === 'primary'
+              ? 'var(--accent)'
+              : 'var(--text-primary)',
+        fontWeight: variant === 'primary' ? 600 : undefined,
         opacity: disabled ? 0.5 : 1,
         cursor: disabled ? 'not-allowed' : 'pointer',
       }}
@@ -200,6 +217,18 @@ export function DropdownSearch({
       />
     </div>
   );
+}
+
+/**
+ * A region of a menu that does not dismiss it.
+ *
+ * `Dropdown` closes on any child's click, which is right for a choice that ends
+ * the interaction and wrong for one that sets up the next step. Choosing which
+ * site to publish to is the second kind: closing there hides the Publish button
+ * the choice was made for, and you have to reopen the menu to find it.
+ */
+export function DropdownStatic({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
 }
 
 // Divider component

--- a/src/index.css
+++ b/src/index.css
@@ -3437,6 +3437,50 @@ button[aria-expanded='true'] .wn-caret {
   display: none;
 }
 
+/* Where a dragged pin will land. A line rather than a moving gap: the row is
+   short and reflowing it on every dragover reads as jitter. */
+.pinned-bar-item[data-drop] {
+  box-shadow: inset 2px 0 0 0 var(--accent);
+}
+
+.pinned-bar-item[draggable='true'] {
+  cursor: grab;
+}
+
+.pinned-bar-item[draggable='true']:active {
+  cursor: grabbing;
+}
+
+/* Divides the pins that fit from the overflow count, so "+8" reads as a
+   continuation rather than another pin. */
+.pinned-bar-sep {
+  width: 1px;
+  height: 12px;
+  margin-left: 8px;
+  background: var(--border-muted);
+}
+
+.pinned-bar-more {
+  padding: 2px 6px;
+  color: var(--text-muted);
+  font: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  transition: color var(--dur-micro) var(--ease-standard);
+}
+
+.pinned-bar-more:hover {
+  color: var(--text-primary);
+}
+
+/* The bar is chrome, and its menu is not: reset the uppercase letterspacing
+   so note names in the overflow read as names. */
+.pinned-bar [role='menu'] {
+  letter-spacing: normal;
+  line-height: var(--text-sm--line-height);
+  text-transform: none;
+}
+
 .editor-footer {
   display: flex;
   align-items: center;

--- a/src/index.css
+++ b/src/index.css
@@ -3513,10 +3513,6 @@ button[aria-expanded='true'] .wn-caret {
   text-overflow: ellipsis;
 }
 
-.editor-footer-right {
-  flex: 0 0 auto;
-}
-
 .editor-footer-left > * {
   color: var(--text-muted);
   transition: color var(--dur-micro) var(--ease-standard);
@@ -3841,7 +3837,12 @@ html.welcome-asteroid-cursor-active:not(.welcome-asteroid-yielded) * {
 .editor-footer-right {
   display: flex;
   align-items: center;
-  gap: 8px;
+  /* Never squeezed: these controls are their labels. */
+  flex: 0 0 auto;
+  /* Roomier than the 8px these started at. The labels are uppercase and
+     letterspaced, so at 8px the gap between two controls read as narrower than
+     the gap inside one word and the row scanned as a single run of text. */
+  gap: 18px;
 }
 
 .editor-footer .toolbar-button {
@@ -5166,4 +5167,28 @@ button.editor-index-trigger:not(:disabled):hover {
 
 .obs-import-details p + p {
   margin-top: 0.375rem;
+}
+
+/* Key for the marks under each date in the month grid. Same quiet register as
+   the rest of the chrome: legible when looked for, silent otherwise. */
+.calendar-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-muted);
+  color: var(--text-muted);
+  font-family: var(--font-display);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  line-height: 1.6;
+  text-transform: uppercase;
+}
+
+.calendar-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
 }

--- a/src/stores/quickSwitcherStore.ts
+++ b/src/stores/quickSwitcherStore.ts
@@ -33,6 +33,11 @@ interface QuickSwitcherState {
   togglePinned: (noteId: string) => void;
   isPinned: (noteId: string) => boolean;
   renamePinnedNote: (oldId: string, newId: string) => void;
+  /**
+   * Move a pin to a new position. The order is the user's, like browser tabs —
+   * the one you reach for most belongs where you can hit it without looking.
+   */
+  movePinnedNote: (from: number, to: number) => void;
 }
 
 export const useQuickSwitcherStore = create<QuickSwitcherState>()(
@@ -79,6 +84,21 @@ export const useQuickSwitcherStore = create<QuickSwitcherState>()(
         set((state) => ({
           pinnedNoteIds: state.pinnedNoteIds.map((id) => (id === oldId ? newId : id)),
         })),
+
+      movePinnedNote: (from, to) =>
+        set((state) => {
+          const ids = state.pinnedNoteIds;
+          // Out-of-range indices come from a drop that landed nowhere useful.
+          // Silently keeping the current order is the right answer: the user
+          // sees the pin snap back rather than jump somewhere they did not aim.
+          if (from === to || from < 0 || to < 0 || from >= ids.length || to >= ids.length) {
+            return state;
+          }
+          const next = [...ids];
+          const [moved] = next.splice(from, 1);
+          next.splice(to, 0, moved);
+          return { pinnedNoteIds: next };
+        }),
     }),
     {
       // The key is namespaced by `forgeNamespacedStorage` on every access, not


### PR DESCRIPTION
Follow-up to 2.2.0, mostly from using it.

## Fixed

**The editor's footer controls disappeared whenever a note was pinned** — my regression from 2.2.0. The pinned bar sat inside the editor column as a sibling above an editor whose root is `h-full`, so the column overflowed and pushed its own footer out of view. Reported as the buttons being missing "most of the time", which turned out to mean "whenever something was pinned".

Long note names ran under the Options button in the index (`truncate` is inert without `min-w-0` on a flex child). The Index overlay's shortcut hint sat 32px from its close button and read as one crowded object on a narrow window; it now matches the Agenda overlay. Footer controls are 18px apart rather than 8px — the labels are letterspaced, so the gap between controls was narrower than the gap inside a word.

## Changed

**Pinned notes behave like browser tabs.** Full-width bar above the whole app, four on the bar and the rest behind a `+N` menu, drag to reorder with a drop line rather than a reflowing gap. Alt+←/→ does the same from the keyboard — we just spent an audit round removing drag-only controls and this wasn't going to add one back.

**Rename from the note's own title.** Enter commits, Escape abandons, empty is refused, a failed rename restores the old name. Escape exposed a real bug while building it: restoring then blurring meant the blur handler committed the abandoned edit.

**Today reads as today** — accent colour, not a 1px rule competing with the 2px selection rule. **The day marks stopped counting events** and now mark kinds (to-do, events, note), with a legend that shares one list with the dots so the two cannot drift.

## Verification

622 frontend tests, 341 Rust, tsc / clippy `-D warnings` / Prettier clean, lint at its 16-warning cap, bundles within budget.

Note on local testing: this machine's default Node is now v26, which breaks jsdom and fails ~200 tests for environmental reasons. All numbers above are under Node 22; CI pins Node 20 and was never affected.

A Codex agent is still stress-testing resize combinations (compact mode, rail, pinned/overlay panels, focus mode, 0–12 pins, long names). Anything it finds lands in the next release rather than holding this one.