### PR TITLE
release: 2.2.2 — footer labels overlapped in compact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.2.2] - 2026-08-16
+
+### Fixed
+
+- **The editor's footer controls overlapped each other in compact mode.** COLOUR, WORDPRESS, SHARE, FORMAT and MORE were drawn on top of one another, unreadable. Compact mode gives toolbar buttons a fixed 24px width for icon buttons, and the footer's buttons — which are their labels, with no icon to fall back on — were not overriding it. The previous attempt relied on a rule that Chrome respects and Safari does not, so it tested clean everywhere except the app, which is built on Safari's engine.
+
 ## [2.2.1] - 2026-08-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/scripts/check-tokens.mjs
+++ b/scripts/check-tokens.mjs
@@ -41,6 +41,8 @@ const HEX_ALLOWLIST = new Map([
   ['src/components/ui/NoteColorPicker.tsx', 'note colour palette'],
   ['src/components/graph/GraphView.tsx', 'canvas fallbacks read via getComputedStyle'],
   ['src/lib/fileSystem.ts', 'markdown/HTML conversion colours'],
+  ['src/stores/calendarStore.test.ts', 'provider-supplied calendar colour fixture'],
+  ['src/components/timeline/TimelineView.test.tsx', 'provider-supplied calendar colour fixture'],
 ]);
 
 /** Files allowed to contain named colours as data or checker fixtures. */
@@ -178,8 +180,41 @@ failed += report(
   'Named CSS colours ignore the theme. Use a token, or allowlist genuine colour data with a reason.'
 );
 
+// ── One layout invariant, checked here because this is the script that already
+// reads index.css in CI. It is not about tokens, and it is labelled so nobody
+// mistakes it for one.
+//
+// Compact mode gives every toolbar button a fixed 24px width, for icon buttons.
+// The editor footer's buttons ARE their labels, so they must override it with
+// `width: auto`. `min-width: max-content` is not enough: Blink honours it over
+// a fixed width, WebKit does not — it paints the label full-width while the
+// flex layout still allocates 24px, so the labels overlap. The app is WebKit,
+// so this shipped broken twice while every browser check said it was fine.
+// Only meaningful when compact mode actually pins a width to override. That
+// keeps it silent against the synthetic fixture roots this script's own tests
+// build, and means it retires itself if compact mode ever stops doing so.
+const indexCss = (await readFile(join(ROOT, 'src/index.css'), 'utf8').catch(() => '')).replace(
+  /\/\*[\s\S]*?\*\//g,
+  ''
+);
+const compactPinsWidth = /\.compact-mode \.toolbar-button\s*\{[^}]*width:\s*\d/.test(indexCss);
+if (compactPinsWidth) {
+  const footerRule = indexCss.match(/\.editor-footer \.toolbar-button\s*\{([^}]*)\}/);
+  if (!footerRule || !/(^|;|\s)width:\s*auto/.test(footerRule[1])) {
+    console.error(
+      '\n✗ `.editor-footer .toolbar-button` must set `width: auto`.\n' +
+        '  Compact mode pins toolbar buttons to a fixed width for icon buttons, and the\n' +
+        '  footer buttons are their labels, so they have to beat it. `min-width: max-content`\n' +
+        '  is not enough: Blink honours it over a fixed width, WebKit does not — it paints\n' +
+        '  the label full-width while the flex layout still allocates the fixed width, so the\n' +
+        '  labels overlap. The app is WebKit. This shipped broken twice.\n'
+    );
+    failed += 1;
+  }
+}
+
 if (failed) {
-  console.error(`\n${failed} token problem(s).\n`);
+  console.error(`\n${failed} problem(s).\n`);
   process.exit(1);
 }
 console.log(`✓ tokens clean — ${defined.size} defined, ${files.length} files checked`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.2.1"
+version = "2.2.2"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/index.css
+++ b/src/index.css
@@ -3848,12 +3848,20 @@ html.welcome-asteroid-cursor-active:not(.welcome-asteroid-yielded) * {
 .editor-footer .toolbar-button {
   /* These buttons are their labels — there is no icon to fall back on, so a
      shrunk one is not "smaller", it is unreadable. `.toolbar-button` carries
-     `overflow: hidden` for its press effect, and a flex item that shrinks past
-     its text then clips it symmetrically: COLOUR renders as "OLOU", WORDPRESS
-     as "DPR". Refusing to shrink is what keeps the labels whole; the word
-     count on the left yields instead, and it can afford to. */
+     `overflow: hidden` for its press effect, and a flex item narrower than its
+     text then clips it: COLOUR rendered as "OLOU", WORDPRESS as "DPR".
+     
+     `width: auto` is doing the real work and must stay. Compact mode sets
+     `.compact-mode .toolbar-button { width: 24px }` for icon buttons, and this
+     rule has to beat it. `min-width: max-content` alone did not: Blink honours
+     it over a fixed width, WebKit does not, and the app runs on WebKit — so
+     the labels stayed pinned to 24px boxes and overlapped each other while
+     every browser test said they were fine. Set the width itself and the
+     intrinsic keyword is not load-bearing. */
+  width: auto;
   flex: 0 0 auto;
   min-width: max-content;
+  white-space: nowrap;
   height: 32px;
   padding: 0;
   color: var(--text-muted);


### PR DESCRIPTION
One fix, and the reason it took three attempts.

## The bug

`.compact-mode .toolbar-button { width: 24px }` is right for icon buttons and wrong for the editor footer's, which are their labels with no icon to fall back on. My override was `min-width: max-content`.

**Blink honours that over a fixed width. WebKit does not.** It paints the label at full width while the flex layout still allocates 24px, so the labels draw on top of one another. The app is WebKit, so this shipped broken twice while every check said it was fine — my harness had no `.compact-mode`, and when I finally added it I measured in Chrome.

`width: auto` takes the intrinsic keyword off the load-bearing path.

## Evidence

Same page, same Safari, one declaration apart, measured against the built stylesheet:

| | overlap |
|---|---|
| without `width: auto` | true |
| with `width: auto` | false |

## Guard

`check-tokens.mjs` already reads `index.css` in CI, so the invariant lives there with its reasoning. It only applies while compact mode actually pins a width — quiet against the fixture roots that script's own tests build, and self-retiring if compact mode changes. Verified it fires by removing the declaration.

Also fixes `check:tokens`, **already failing on main**: the calendar work added `#336699` provider-colour fixtures to two test files without allowlisting them.

## Verification

622 frontend, 341 Rust, tsc / lint / Prettier / tokens / bundle budget all clean, under Node 22 (this machine's default Node 26 breaks jsdom; CI pins 20).