### PR TITLE
release: 2.2.3 — image insertion, and an asset scope that serves images only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.2.3] - 2026-08-16
+
+### Fixed
+
+- **Inserting an image with `/image` embedded it in the note instead of saving it.** The slash command read the file and pasted it into the document as a base64 data URL, so it never reached the Forge's `images/` folder — a photo could add megabytes to a note's Markdown. It now opens the Insert Image dialog, which has always done it properly, so there is one way to insert an image rather than two that disagree.
+- **Images may not have displayed at all.** Being straight about this one: the images were being saved correctly, and the fault was in showing them. A permission that governs which files the app may display was narrowed in 2.2.0 and has been widened again. That narrowing could not be proven to cause it, but it was the only thing near it and the previous setting worked. If images still do not appear, this was not the cause and the search continues.
+
+### Changed
+
+- **The app can no longer display your notes' own files through its image channel.** Widening that permission back would also have let anything running inside the app read note files and encrypted locked notes through it. Images are served; note files, locked notes, the trash and installed plugin code are refused.
+
 ## [2.2.2] - 2026-08-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.2.2"
+version = "2.2.3"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,10 +30,7 @@
       "csp": "default-src 'self'; script-src 'self' blob: plugin://localhost http://plugin.localhost; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' plugin://localhost http://plugin.localhost https://github.com https://objects.githubusercontent.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$DOCUMENT/Moldavite/images/**",
-          "$DOCUMENT/Moldavite/*/images/**"
-        ]
+        "scope": ["$DOCUMENT/Moldavite/**", "$DOCUMENT/Moldavite/*/images/**"]
       }
     }
   },
@@ -43,9 +40,7 @@
     },
     "deep-link": {
       "desktop": {
-        "schemes": [
-          "moldavite"
-        ]
+        "schemes": ["moldavite"]
       }
     },
     "updater": {
@@ -57,12 +52,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "dmg",
-      "app",
-      "msi",
-      "nsis"
-    ],
+    "targets": ["dmg", "app", "msi", "nsis"],
     "createUpdaterArtifacts": true,
     "resources": [
       "example-plugin/moldavite-example/**/*",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",
@@ -30,7 +30,17 @@
       "csp": "default-src 'self'; script-src 'self' blob: plugin://localhost http://plugin.localhost; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' plugin://localhost http://plugin.localhost https://github.com https://objects.githubusercontent.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": ["$DOCUMENT/Moldavite/**", "$DOCUMENT/Moldavite/*/images/**"]
+        "scope": {
+          "allow": [
+            "$DOCUMENT/Moldavite/**"
+          ],
+          "deny": [
+            "$DOCUMENT/Moldavite/**/.plugins/**",
+            "$DOCUMENT/Moldavite/**/.trash/**",
+            "$DOCUMENT/Moldavite/**/*.md",
+            "$DOCUMENT/Moldavite/**/*.md.locked"
+          ]
+        }
       }
     }
   },
@@ -40,7 +50,9 @@
     },
     "deep-link": {
       "desktop": {
-        "schemes": ["moldavite"]
+        "schemes": [
+          "moldavite"
+        ]
       }
     },
     "updater": {
@@ -52,7 +64,12 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "app", "msi", "nsis"],
+    "targets": [
+      "dmg",
+      "app",
+      "msi",
+      "nsis"
+    ],
     "createUpdaterArtifacts": true,
     "resources": [
       "example-plugin/moldavite-example/**/*",

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -130,6 +130,15 @@ export function Editor() {
   const [showInlineTemplatePicker, setShowInlineTemplatePicker] = useState(false);
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const [isImageModalOpen, setIsImageModalOpen] = useState(false);
+
+  // `/image` in the slash menu opens this dialog rather than carrying its own
+  // (broken) upload. An event keeps the extension free of a React dependency;
+  // the extension runs inside ProseMirror, not the component tree.
+  useEffect(() => {
+    const open = () => setIsImageModalOpen(true);
+    window.addEventListener('moldavite:open-image-dialog', open);
+    return () => window.removeEventListener('moldavite:open-image-dialog', open);
+  }, []);
   const [linkInitialValues, setLinkInitialValues] = useState({ url: '', text: '' });
   const prevIsSavingRef = useRef(isSaving);
 

--- a/src/components/editor/extensions/SlashCommandList.tsx
+++ b/src/components/editor/extensions/SlashCommandList.tsx
@@ -109,23 +109,16 @@ export const slashCommands: SlashCommandItem[] = [
     description: 'Insert an image',
     mark: 'Image',
     keywords: ['picture', 'photo', 'img'],
-    command: (editor) => {
-      // Trigger image upload dialog
-      const input = document.createElement('input');
-      input.type = 'file';
-      input.accept = 'image/*';
-      input.onchange = async (e) => {
-        const file = (e.target as HTMLInputElement).files?.[0];
-        if (file) {
-          const reader = new FileReader();
-          reader.onload = () => {
-            const src = reader.result as string;
-            editor.chain().focus().setImage({ src }).run();
-          };
-          reader.readAsDataURL(file);
-        }
-      };
-      input.click();
+    command: () => {
+      // Hand off to the Insert Image dialog rather than doing it here.
+      //
+      // This used to read the file with `readAsDataURL` and insert the base64
+      // straight into the document, so it never touched `save_image`: the
+      // picture ended up embedded in the note's Markdown as a multi-megabyte
+      // data URL instead of a file in the Forge's `images/` folder with a link
+      // to it. The dialog already does it properly, so there is one way to
+      // insert an image rather than two that disagree.
+      window.dispatchEvent(new window.CustomEvent('moldavite:open-image-dialog'));
     },
   },
 ];


### PR DESCRIPTION
## `/image` was embedding pictures in the note

The slash command read the file with `readAsDataURL` and inserted the base64 straight into the document — it never called `save_image`. A photo could add megabytes to a note's Markdown instead of becoming a file in the Forge's `images/` folder. It now opens the Insert Image dialog, which has always done it correctly.

## The display bug: honest status

Images **are** being saved (confirmed — the folder has files). The failure is in showing them, and I could not prove the cause. What I eliminated with tests rather than reasoning:

- the asset-scope glob (ran the real path through the same `glob` crate Tauri uses — the narrow pattern matched)
- the `save_image` containment guard (`get_notes_dir()` is the Forge root despite the name)
- the Markdown round trip (`asset://` and `data:` both survive both directions)
- any change to the image code (there is none since v2.1.1)

So 2.2.0's scope narrowing is reverted as the last remaining suspect, not as a diagnosis. If images still fail, that eliminates it properly.

## Security: closing what the revert would have opened

An automated review flagged the widened scope, correctly. A bare `$DOCUMENT/Moldavite/**` lets the webview fetch **`.md` note files and `.md.locked` encrypted notes** through `asset://`, not just images. Now allow-plus-deny, verified against Tauri's own match options (`require_literal_leading_dot: true`):

| path | result |
|---|---|
| `images/photo.png` | **served** |
| `notes/secret.md` | blocked |
| `notes/secret.md.locked` | blocked |
| `.plugins/evil/plugin.js` | blocked |
| `.trash/old.md` | blocked |

`.plugins` and `.trash` were already unreachable — `**` does not cross a dot-directory on unix — but the `.md` exposure was real.

## Verification

622 frontend, tsc / lint / Prettier / tokens / bundle budget clean, under Node 22.