### PR TITLE
release: 2.2.5 — Forge caret beside the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.2.5] - 2026-08-16
+
+### Fixed
+
+- **The Forge switcher's arrow sat on top of the Index overlay's close button.** The arrow was pinned to the far right of a full-width control, and in the overlay "far right" is the whole window. It now sits beside the Forge name, where it cannot collide with anything at any width — and where it reads as what it is: press the Forge name to switch Forge.
+
 ## [2.2.4] - 2026-08-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.2.4"
+version = "2.2.5"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/sidebar/ForgeSwitcher.test.tsx
+++ b/src/components/sidebar/ForgeSwitcher.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ForgeSwitcher } from './ForgeSwitcher';
+import { useForgeStore } from '@/stores';
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+describe('ForgeSwitcher', () => {
+  beforeEach(() => {
+    useForgeStore.setState({ forges: [], active: 'Default', loading: false } as never);
+  });
+
+  // The caret used to sit at the far right of a full-width button. "Far right"
+  // is the width of whatever hosts the sidebar, and in the Index overlay that
+  // is the entire window — so it landed on top of the overlay's close button.
+  // Keeping it beside the name is what makes that impossible, and it reads as
+  // an affordance on the name rather than a glyph in a corner owning nothing.
+  it('keeps the caret beside the Forge name, not pushed to the far edge', () => {
+    render(<ForgeSwitcher onManage={() => {}} />);
+
+    const trigger = screen.getByRole('button', { name: /Default/ });
+    expect(trigger.className).not.toContain('justify-between');
+
+    const label = screen.getByText('Default');
+    const caret = screen.getByText('↓');
+    // Siblings under the same span, so no amount of available width can
+    // separate them.
+    expect(caret.parentElement).toBe(label.parentElement);
+  });
+
+  it('still announces itself as the Forge picker', () => {
+    render(<ForgeSwitcher onManage={() => {}} />);
+    const trigger = screen.getByRole('button', { name: /Default/ });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('title', 'Switch Forge');
+  });
+});

--- a/src/components/sidebar/ForgeSwitcher.tsx
+++ b/src/components/sidebar/ForgeSwitcher.tsx
@@ -105,7 +105,13 @@ export function ForgeSwitcher({ onManage }: ForgeSwitcherProps) {
             return !v;
           });
         }}
-        className="w-full flex items-center justify-between gap-2 px-1 pb-3 text-left"
+        // Left-aligned, with the caret beside the name rather than pushed to the
+        // far edge. Full width means "far edge" is the width of whatever is
+        // hosting the sidebar — in the Index overlay that is the whole window,
+        // so the caret landed on top of the overlay's close button. Beside the
+        // name it also reads as what it is: press the Forge name to switch
+        // Forge, rather than a lone glyph in the corner belonging to nothing.
+        className="w-full flex items-center gap-2 px-1 pb-3 text-left"
         style={{
           color: 'var(--text-primary)',
           borderBottom: '1px solid var(--border-default)',
@@ -118,11 +124,15 @@ export function ForgeSwitcher({ onManage }: ForgeSwitcherProps) {
         aria-expanded={open}
         title="Switch Forge"
       >
-        <span className="flex min-w-0 items-center gap-3">
+        <span className="flex min-w-0 items-center gap-2">
           <span className="truncate">{label}</span>
-        </span>
-        <span aria-hidden="true" className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
-          ↓
+          <span
+            aria-hidden="true"
+            className="flex-shrink-0 text-[10px]"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            ↓
+          </span>
         </span>
       </button>
 


### PR DESCRIPTION
The last collision in the Index overlay header, and the one I had not looked at: the Forge switcher's own caret.

Its button is full width with `justify-between`, so the caret sits at the far right of whatever hosts the sidebar. In the pinned column that is a few hundred pixels. In the Index overlay it is the entire window — so it landed on the close button, which is why the corner still looked wrong after the hint and the × were finally separated.

Beside the name it cannot collide at any width, and it reads as an affordance on the name rather than a glyph in a corner belonging to nothing. Mauro's suggestion and the better design.

Test asserts the caret and the label share a parent, so no amount of available width can separate them. Verified it fails with `justify-between` restored.

635 frontend tests, tsc / lint / Prettier / tokens / bundle budget clean.