### PR TITLE
release: 2.2.6 — image selection ring and default size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.2.6] - 2026-08-16
+
+### Changed
+
+- **Selecting an image draws a ring around it instead of covering it.** Clicking an image used to paint a solid block of colour over the whole picture, hiding the thing you had just clicked on. It now gets a thin ring, with the alignment and delete controls above it as before.
+- **Images start at a readable size.** A picture used to be inserted at its natural size, so a phone screenshot arrived thousands of pixels wide and pushed the note's text out of the way. New images are drawn at a sensible width and can still be dragged to any size. Nothing is written to the note by this, so images already in your notes are untouched.
+
 ## [2.2.5] - 2026-08-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.2.5"
+version = "2.2.6"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/editor/extensions/ResizableImage.tsx
+++ b/src/components/editor/extensions/ResizableImage.tsx
@@ -19,6 +19,17 @@ declare module '@tiptap/core' {
   }
 }
 
+/**
+ * How wide an image is drawn when nobody has resized it.
+ *
+ * The attribute defaults to null, which rendered every picture at its natural
+ * size — a phone screenshot arrived several thousand pixels wide and pushed the
+ * note's text out of the way. This is a rendering default only: it is not
+ * written to the note, so resizing still stores a real width and images already
+ * in your notes keep whatever they had.
+ */
+const DEFAULT_IMAGE_WIDTH = 420;
+
 function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
@@ -99,7 +110,7 @@ function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
           ref={imageRef}
           src={src}
           alt={alt || ''}
-          style={{ width: currentWidth ? `${currentWidth}px` : 'auto' }}
+          style={{ width: `${currentWidth || DEFAULT_IMAGE_WIDTH}px`, maxWidth: '100%' }}
           className="resizable-image"
           draggable={false}
         />

--- a/src/index.css
+++ b/src/index.css
@@ -4048,8 +4048,26 @@ html.welcome-asteroid-cursor-active:not(.welcome-asteroid-yielded) * {
   transition: opacity var(--dur-micro) var(--ease-standard);
 }
 
+/* Selecting an image used to paint the browser's own selection wash across it
+   — a solid blue rectangle over the picture, which reads as "something broke"
+   rather than "this is selected", and hides the thing you are looking at. A
+   ring around it says the same thing and leaves the image visible. The
+   alignment controls appear above it at the same moment. */
 .resizable-image-container.selected {
-  outline: 1px solid var(--border-strong);
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.resizable-image-container ::selection,
+.resizable-image::selection {
+  background: transparent;
+}
+
+/* Stop the image being dragged into a text selection while it is the selected
+   node; that is what let the wash paint over it in the first place. */
+.resizable-image-container.selected .resizable-image {
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .resizable-image-container.resizing {


### PR DESCRIPTION
Two image changes, both confirmed by eye against the shipped CSS before merging.

**Selection is a ring, not a wash.** Clicking an image painted WebKit's own selection highlight across it — a solid rectangle over the picture, which reads as breakage and hides what you just clicked. The app's own fill rule only ever covered task items, so this came from the browser. Now a 2px accent ring with an offset, and the image is taken out of the text selection while it is the selected node so nothing paints over it. The L/C/R alignment controls were always there; they were hard to notice under the wash.

**Images render at 420px unless resized.** The `width` attribute defaulted to `null`, so every picture drew at natural size — a phone screenshot arrives a few thousand pixels wide and shoves the note's text aside. This is a rendering default only: never written to the note, so resizing still stores a real width and images already in notes keep whatever they had. Resizing starts from the rendered width, so dragging is unaffected.

635 frontend tests, tsc / lint / Prettier / tokens / bundle budget clean.