### PR TITLE
release: 2.2.8 — Settings that paints its own backgrounds, and Esc to leave a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.2.8] - 2026-08-17
+
+### Added
+
+- **Esc closes the note you are reading.** Press it with a note open and you land back on the wordmark screen — or on the next tab, if you had several open. It gives way to anything else that wants the key first: a dialog, the Index or Agenda, a slash menu, a sidebar selection waiting to be cleared, or a text field you are typing in. It appears in the shortcut list under ⌘/ with everything else.
+
+### Fixed
+
+- **The Obsidian import window had no background of its own.** The Settings page behind it showed straight through, so the vault counts, the Forge name field and the buttons all landed on top of unrelated text. One blanket rule that flattens backgrounds inside Settings had been outranking every exception written for it, which also left the monogram on the About tab invisible and killed the hover highlight on rows and tabs. Those are back too.
+- **Info tooltips in Settings were unreadable.** The little (i) popovers drew their text with no background at all, over whatever happened to sit underneath. They now use the same solid surface as the rest of the app's floating panels.
+- **Browsing community plugins always failed with a connection error.** The address the plugin directory is served from was missing from the app's own security policy, so the request was blocked before it ever left Moldavite — and then reported as if the network were at fault.
+- **The install buttons for the two bundled plugins stayed on screen after installing them.** Pressing one again could only produce an error, because a bundled install refuses to overwrite what is already there. Each button now disappears once its plugin is installed, and comes back if you uninstall it.
+- **Sidebar settings showed an empty "Layout" heading.** Both width sliders only apply to a pinned column, so with the Index and Agenda as overlays the group had nothing in it. It now appears only when there is something to adjust.
+
 ## [2.2.7] - 2026-08-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.2.7"
+version = "2.2.8"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.2.7"
+version = "2.2.8"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",
@@ -27,7 +27,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' blob: plugin://localhost http://plugin.localhost; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' plugin://localhost http://plugin.localhost https://github.com https://objects.githubusercontent.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'",
+      "csp": "default-src 'self'; script-src 'self' blob: plugin://localhost http://plugin.localhost; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; connect-src 'self' plugin://localhost http://plugin.localhost https://github.com https://objects.githubusercontent.com https://raw.githubusercontent.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'",
       "assetProtocol": {
         "enable": true,
         "scope": {

--- a/src/components/ChromeShortcutHost.test.tsx
+++ b/src/components/ChromeShortcutHost.test.tsx
@@ -2,11 +2,14 @@ import { fireEvent, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   useGraphStore,
+  useNoteSelectionStore,
+  useNoteStore,
   useOverlayStore,
   useQuickSwitcherStore,
   useSettingsStore,
   useTimelineStore,
 } from '@/stores';
+import type { Note } from '@/types';
 import { ChromeShortcutHost } from './ChromeShortcutHost';
 
 describe('ChromeShortcutHost modes', () => {
@@ -78,9 +81,28 @@ describe('ChromeShortcutHost surfaces', () => {
       isSidebarHidden: false,
       isRightPanelHidden: false,
     });
+    useNoteStore.setState({ openTabs: [], activeTabId: null, currentNote: null });
+    useNoteSelectionStore.getState().clear();
   });
 
   const escape = () => fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+
+  const note: Note = {
+    id: 'note-1',
+    title: 'Note',
+    content: '',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    isDaily: false,
+    isWeekly: false,
+  };
+
+  const openNote = () =>
+    useNoteStore.setState({ openTabs: [note], activeTabId: note.id, currentNote: note });
+
+  /** Escape with nothing focused, which is what the browser targets at body. */
+  const escapeFromNote = (init: { shiftKey?: boolean } = {}) =>
+    fireEvent.keyDown(document.body, { key: 'Escape', code: 'Escape', ...init });
 
   const surfaces = [
     { name: 'index', open: () => useOverlayStore.getState().openIndex(false) },
@@ -100,6 +122,64 @@ describe('ChromeShortcutHost surfaces', () => {
     expect(useGraphStore.getState().isOpen).toBe(false);
     expect(useTimelineStore.getState().isOpen).toBe(false);
     expect(useQuickSwitcherStore.getState().isOpen).toBe(false);
+  });
+
+  it('closes the open note on Escape, not the note under an active surface', () => {
+    render(<ChromeShortcutHost />);
+    openNote();
+
+    // An overlay owns Escape first: the note survives.
+    useOverlayStore.getState().openIndex(false);
+    escapeFromNote();
+    expect(useNoteStore.getState().activeTabId).toBe('note-1');
+
+    escapeFromNote();
+    expect(useNoteStore.getState().activeTabId).toBeNull();
+    expect(useNoteStore.getState().currentNote).toBeNull();
+  });
+
+  it('leaves the note alone while anything else wants Escape', () => {
+    render(<ChromeShortcutHost />);
+
+    const cases: Array<[string, () => () => void]> = [
+      [
+        'a dialog is on screen',
+        () => {
+          const dialog = document.createElement('div');
+          dialog.setAttribute('role', 'dialog');
+          document.body.appendChild(dialog);
+          return () => dialog.remove();
+        },
+      ],
+      [
+        'a bulk selection is waiting to be cleared',
+        () => {
+          useNoteSelectionStore.getState().replace(['note-1']);
+          return () => useNoteSelectionStore.getState().clear();
+        },
+      ],
+    ];
+
+    for (const [, setup] of cases) {
+      openNote();
+      const teardown = setup();
+      escapeFromNote();
+      expect(useNoteStore.getState().activeTabId).toBe('note-1');
+      teardown();
+    }
+
+    // Handled by something closer to the event — ProseMirror marks its own
+    // suggestion menus this way.
+    openNote();
+    const claimEscape = (event: KeyboardEvent) => event.preventDefault();
+    document.body.addEventListener('keydown', claimEscape);
+    escapeFromNote();
+    document.body.removeEventListener('keydown', claimEscape);
+    expect(useNoteStore.getState().activeTabId).toBe('note-1');
+
+    // A modifier means it is some other shortcut, not "leave the note".
+    escapeFromNote({ shiftKey: true });
+    expect(useNoteStore.getState().activeTabId).toBe('note-1');
   });
 
   it('toggles Search and Graph from the keyboard like their rail buttons', () => {

--- a/src/components/ChromeShortcutHost.tsx
+++ b/src/components/ChromeShortcutHost.tsx
@@ -1,10 +1,41 @@
 import { useEffect } from 'react';
-import { useGraphStore, useOverlayStore, useQuickSwitcherStore, useSettingsStore } from '@/stores';
+import {
+  useGraphStore,
+  useNoteSelectionStore,
+  useNoteStore,
+  useOverlayStore,
+  useQuickSwitcherStore,
+  useSettingsStore,
+} from '@/stores';
+
+/**
+ * Esc leaves the open note, landing back on the wordmark screen when it was the
+ * last one. Esc is the most contested key in the app, so it only acts when
+ * nothing else wants it: no handler has already claimed the event (ProseMirror
+ * marks its own suggestion menus that way), no dialog is on screen, no bulk
+ * selection is waiting to be cleared, and focus is in the note itself rather
+ * than in a field, a menu, or a toolbar button.
+ */
+function closeActiveNote(event: KeyboardEvent) {
+  if (event.defaultPrevented) return;
+  if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+
+  const target = event.target as HTMLElement | null;
+  const inNote = target === document.body || Boolean(target?.closest?.('.tiptap'));
+  if (!inNote) return;
+  if (document.querySelector('[role="dialog"], [aria-modal="true"]')) return;
+  if (useNoteSelectionStore.getState().selectedIds.size > 0) return;
+
+  const { activeTabId, closeTab } = useNoteStore.getState();
+  if (!activeTabId) return;
+  event.preventDefault();
+  closeTab(activeTabId);
+}
 
 /**
  * Keyboard handling for the navigation surfaces — ⌘\ (Index), ⌘⌥\ (Agenda),
- * ⌘P (Search), ⌘⇧G (Graph), Esc (close the active one) — and ⌘. (focus mode).
- * Mount once near the app root.
+ * ⌘P (Search), ⌘⇧G (Graph), Esc (close the active one, or the open note when
+ * none is up) — and ⌘. (focus mode). Mount once near the app root.
  *
  * The listener lives here rather than in `useKeyboardShortcuts` for the same
  * reason `ShortcutHelpHost` does: that hook is owned by the editor tree, which
@@ -19,9 +50,13 @@ import { useGraphStore, useOverlayStore, useQuickSwitcherStore, useSettingsStore
 export function ChromeShortcutHost() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && useOverlayStore.getState().activeOverlay) {
-        e.preventDefault();
-        useOverlayStore.getState().closeOverlay();
+      if (e.key === 'Escape') {
+        if (useOverlayStore.getState().activeOverlay) {
+          e.preventDefault();
+          useOverlayStore.getState().closeOverlay();
+        } else {
+          closeActiveNote(e);
+        }
         return;
       }
 

--- a/src/components/settings/common/InfoTooltip.tsx
+++ b/src/components/settings/common/InfoTooltip.tsx
@@ -95,7 +95,8 @@ export function InfoTooltip({ text }: InfoTooltipProps) {
               left: pos.left,
               width: TOOLTIP_WIDTH,
               transform: pos.placement === 'top' ? 'translateY(-100%)' : undefined,
-              backgroundColor: 'transparent',
+              // Floats over content, so it has to be opaque to stay readable.
+              backgroundColor: 'var(--bg-elevated)',
               border: '1px solid var(--border-default)',
               color: 'var(--text-secondary)',
               zIndex: 10000,

--- a/src/components/settings/sections/PluginsSection.tsx
+++ b/src/components/settings/sections/PluginsSection.tsx
@@ -248,6 +248,9 @@ export function PluginsSection() {
     }
   };
 
+  /** Bundled installs refuse to overwrite, so hide the button once it is in. */
+  const isInstalled = (id: string) => plugins.some((info) => info.manifest.id === id);
+
   const statusText = (info: PluginInfo): string => {
     if (info.status === 'invalid') return 'Invalid';
     if (info.status === 'incompatible') return 'Incompatible';
@@ -400,35 +403,39 @@ export function PluginsSection() {
         style={{ backgroundColor: 'transparent', borderRadius: 'var(--radius-md)' }}
       >
         <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={handleInstallWordPress}
-            disabled={busy}
-            className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors"
-            style={{
-              backgroundColor: 'transparent',
-              borderRadius: 'var(--radius-sm)',
-              color: 'var(--text-primary)',
-            }}
-          >
-            <Download aria-hidden="true" className="w-4 h-4" />
-            Install Publish to WordPress
-          </button>
-          <button
-            type="button"
-            onClick={handleInstallExample}
-            disabled={busy}
-            className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors"
-            style={{
-              backgroundColor: 'transparent',
-              border: '1px solid var(--border-default)',
-              borderRadius: 'var(--radius-sm)',
-              color: 'var(--text-secondary)',
-            }}
-          >
-            <Download aria-hidden="true" className="w-4 h-4" />
-            Install example plugin
-          </button>
+          {!isInstalled('moldavite-wordpress') && (
+            <button
+              type="button"
+              onClick={handleInstallWordPress}
+              disabled={busy}
+              className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors"
+              style={{
+                backgroundColor: 'transparent',
+                borderRadius: 'var(--radius-sm)',
+                color: 'var(--text-primary)',
+              }}
+            >
+              <Download aria-hidden="true" className="w-4 h-4" />
+              Install Publish to WordPress
+            </button>
+          )}
+          {!isInstalled('moldavite-example') && (
+            <button
+              type="button"
+              onClick={handleInstallExample}
+              disabled={busy}
+              className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium transition-colors"
+              style={{
+                backgroundColor: 'transparent',
+                border: '1px solid var(--border-default)',
+                borderRadius: 'var(--radius-sm)',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              <Download aria-hidden="true" className="w-4 h-4" />
+              Install example plugin
+            </button>
+          )}
           <button
             type="button"
             onClick={() => void browseCommunityPlugins()}

--- a/src/components/settings/sections/SidebarSection.tsx
+++ b/src/components/settings/sections/SidebarSection.tsx
@@ -76,76 +76,78 @@ export function SidebarSection() {
         />
       </section>
 
-      {/* Layout */}
-      <section className="settings-section">
-        <div className="flex items-center gap-1">
-          <SectionHeading>Layout</SectionHeading>
-          <InfoTooltip text="Control the width of sidebars. Wider sidebars show more note titles, narrower gives more editor space." />
-        </div>
-
-        {/* Only meaningful when the Index is a pinned column. As an overlay it
-            is full-window, and the rail is a fixed 48px — so an ungated slider
-            here is a control that silently does nothing. */}
-        {settings.indexMode === 'pinned' && (
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-1">
-                <label
-                  htmlFor="sidebar-width-range"
-                  className="text-xs"
-                  style={{ color: 'var(--text-tertiary)' }}
-                >
-                  Sidebar Width
-                </label>
-                <InfoTooltip text="Width of the pinned Index column in pixels. Range: 200px (compact) to 400px (spacious)." />
-              </div>
-              <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-                {settings.sidebarWidth}px
-              </span>
-            </div>
-            <input
-              id="sidebar-width-range"
-              type="range"
-              min="200"
-              max="400"
-              step="10"
-              value={settings.sidebarWidth}
-              onChange={(e) => settings.setSidebarWidth(Number(e.target.value))}
-              className="settings-range w-full appearance-none cursor-pointer"
-            />
+      {/* Layout — only meaningful for a pinned column. As an overlay the Index
+          is full-window and the rail is a fixed 48px, so an ungated slider is a
+          control that silently does nothing; with neither pinned the whole
+          group is empty, so it does not render at all. */}
+      {(settings.indexMode === 'pinned' || settings.agendaMode === 'pinned') && (
+        <section className="settings-section">
+          <div className="flex items-center gap-1">
+            <SectionHeading>Layout</SectionHeading>
+            <InfoTooltip text="Control the width of sidebars. Wider sidebars show more note titles, narrower gives more editor space." />
           </div>
-        )}
 
-        {settings.agendaMode === 'pinned' && (
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-1">
-                <label
-                  htmlFor="right-panel-width-range"
-                  className="text-xs"
-                  style={{ color: 'var(--text-tertiary)' }}
-                >
-                  Right Panel Width
-                </label>
-                <InfoTooltip text="Width of the right panel (calendar/timeline) in pixels. Range: 250px to 500px." />
+          {settings.indexMode === 'pinned' && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-1">
+                  <label
+                    htmlFor="sidebar-width-range"
+                    className="text-xs"
+                    style={{ color: 'var(--text-tertiary)' }}
+                  >
+                    Sidebar Width
+                  </label>
+                  <InfoTooltip text="Width of the pinned Index column in pixels. Range: 200px (compact) to 400px (spacious)." />
+                </div>
+                <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
+                  {settings.sidebarWidth}px
+                </span>
               </div>
-              <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-                {settings.rightPanelWidth}px
-              </span>
+              <input
+                id="sidebar-width-range"
+                type="range"
+                min="200"
+                max="400"
+                step="10"
+                value={settings.sidebarWidth}
+                onChange={(e) => settings.setSidebarWidth(Number(e.target.value))}
+                className="settings-range w-full appearance-none cursor-pointer"
+              />
             </div>
-            <input
-              id="right-panel-width-range"
-              type="range"
-              min="250"
-              max="500"
-              step="10"
-              value={settings.rightPanelWidth}
-              onChange={(e) => settings.setRightPanelWidth(Number(e.target.value))}
-              className="settings-range w-full appearance-none cursor-pointer"
-            />
-          </div>
-        )}
-      </section>
+          )}
+
+          {settings.agendaMode === 'pinned' && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-1">
+                  <label
+                    htmlFor="right-panel-width-range"
+                    className="text-xs"
+                    style={{ color: 'var(--text-tertiary)' }}
+                  >
+                    Right Panel Width
+                  </label>
+                  <InfoTooltip text="Width of the right panel (calendar/timeline) in pixels. Range: 250px to 500px." />
+                </div>
+                <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
+                  {settings.rightPanelWidth}px
+                </span>
+              </div>
+              <input
+                id="right-panel-width-range"
+                type="range"
+                min="250"
+                max="500"
+                step="10"
+                value={settings.rightPanelWidth}
+                onChange={(e) => settings.setRightPanelWidth(Number(e.target.value))}
+                className="settings-range w-full appearance-none cursor-pointer"
+              />
+            </div>
+          )}
+        </section>
+      )}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1227,10 +1227,14 @@ time,
   box-shadow: none;
 }
 
+/* The `:not()` arguments are wrapped in `:where()` on purpose: bare `:not(.x)`
+   adds a class to the specificity, and at (0,4,0) this blanket reset outranked
+   every `.settings-dialog .thing { background: … !important }` exception below
+   it — the import wizard and its scrim rendered with no background at all. */
 .settings-dialog
-  :where(div, section, button, input, select, textarea, span):not(.settings-preset-swatch):not(
-    .settings-update-dot
-  ):not(.settings-calendar-swatch) {
+  :where(div, section, button, input, select, textarea, span):not(
+    :where(.settings-preset-swatch, .settings-update-dot, .settings-calendar-swatch)
+  ) {
   background-color: transparent !important;
   border-radius: 0 !important;
   box-shadow: none !important;

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -38,7 +38,8 @@ export type ShortcutId =
   | 'toggleSidebar'
   | 'toggleRightPanel'
   | 'toggleFocusMode'
-  | 'clearSelection';
+  | 'clearSelection'
+  | 'closeNote';
 
 export interface Shortcut {
   id: ShortcutId;
@@ -177,6 +178,13 @@ export const SHORTCUTS: Shortcut[] = [
     keys: ['⌘', '.'],
     description: 'Focus mode — hide all chrome',
     category: 'navigation',
+  },
+
+  {
+    id: 'closeNote',
+    keys: ['Esc'],
+    description: 'Close the open note',
+    category: 'files',
   },
 
   // Selection


### PR DESCRIPTION
Six fixes found while testing the app, plus one small shortcut.

### Fixed

- **The Obsidian import wizard had no background of its own** — the Settings page behind it showed straight through its own text. Root cause was the cascade, not layout: the Cream redesign's blanket "no backgrounds inside Settings" rule was written with three bare `:not()` arms, putting it at specificity (0,4,0) — above every `.settings-dialog .thing { background: … !important }` exception written for it at (0,2,0). Wrapping those arms in `:where()` drops it to (0,1,0), which is what the element list one line above was already doing. Verified in a real engine rather than on paper: same DOM, old rule computes to `rgba(0,0,0,0)`, new rule to the base colour. The same rule had also been erasing the About tab's monogram and every hover highlight on rows and tabs.
- **Info tooltips were unreadable** — a separate instance of the same flattening. They portal to `document.body`, so no cascade rule reached them, and the component hardcoded a transparent background. Over content, a tooltip has to be opaque.
- **Community plugins never loaded.** `connect-src` listed `github.com` and `objects.githubusercontent.com` but not `raw.githubusercontent.com`, which is where the registry and every plugin file live. The fetch was blocked before it left the app and then reported as a connection problem, which sends you looking at the network instead of the policy.
- **The two bundled-plugin install buttons stayed on screen after installing**, where pressing one could only ever produce an error — a bundled install refuses to overwrite by design. The button was the bug, not the guard.
- **Sidebar settings drew a "Layout" heading over nothing** whenever neither the Index nor the Agenda was pinned, since both sliders are gated on a pinned column.

### Added

- **Esc leaves the open note**, landing on the wordmark screen when it was the last tab. It gives way to anything else that wants the key first: an active surface, any dialog, a ProseMirror suggestion menu, a bulk selection waiting to be cleared, or a focused text field. It lives in `ChromeShortcutHost` rather than the editor tree, for the same reason the other chrome shortcuts do — it has to work when no editor is mounted — and it is registered in `lib/shortcuts.ts` so ⌘/ lists it without a second edit.

### Verification

`npm test` 637/637 (the new Escape test fails with the handler disabled and passes with it), `npm run lint` clean, `npm run build`, `check:size` and `check:tokens` pass, and `bump-version.mjs --check` confirms all five manifests agree on 2.2.8. No Rust changed, so `cargo test` was not run — the only backend-side edit is the CSP string in `tauri.conf.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVqfLZqyver2ELWLcBAPx9
