### PR TITLE
fix(sidebar): keep long note titles clear of Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Moldavite are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Long note names stop before the sidebar's Options control.** Narrowing the Index could let a note title continue underneath Options instead of ending in an ellipsis, leaving both labels printed over each other. The complete title is still available to assistive technology; only its visual width is shortened.
+
 ## [2.4.0] - 2026-08-19
 
 ### Added

--- a/src/components/sidebar/DraggableNoteItem.test.tsx
+++ b/src/components/sidebar/DraggableNoteItem.test.tsx
@@ -30,6 +30,27 @@ describe('DraggableNoteItem', () => {
     expect(screen.getByText('Hello')).toBeInTheDocument();
   });
 
+  it('truncates long titles before Options without shortening the accessible name', () => {
+    const title = 'An exceptionally long note title that cannot fit beside the options action';
+    render(
+      <DraggableNoteItem
+        note={{ ...baseNote, name: `${title}.md`, path: `notes/${title}.md` }}
+        isActive={false}
+        onClick={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+    );
+
+    const row = screen.getByRole('button', { name: title });
+    const visibleTitle = screen.getByText(title);
+
+    expect(visibleTitle).toHaveTextContent(title);
+    expect(visibleTitle).toHaveClass('min-w-0', 'truncate');
+    expect(visibleTitle.parentElement).toHaveClass('min-w-0');
+    expect(row).toHaveAccessibleName(title);
+    expect(row.style.paddingRight).toBe('3.5rem');
+  });
+
   it('reveals Note options when the control receives keyboard focus', () => {
     render(
       <DraggableNoteItem

--- a/src/components/sidebar/DraggableNoteItem.tsx
+++ b/src/components/sidebar/DraggableNoteItem.tsx
@@ -153,9 +153,12 @@ function DraggableNoteItemImpl({
         role="button"
         tabIndex={0}
         onKeyDown={(e) => e.key === 'Enter' && handleClick(e as unknown as React.MouseEvent)}
-        className={`note-card sidebar-item-animated w-full text-left text-sm pr-14 focus-ring cursor-pointer${
+        className={`note-card sidebar-item-animated w-full text-left text-sm focus-ring cursor-pointer${
           isActive ? ' note-card-active' : ''
         }${isSelected ? ' is-selected' : ''}`}
+        // `.note-card` uses a padding shorthand that outranks Tailwind's
+        // layered utilities. Keep the overlaid Options action clear here.
+        style={{ paddingRight: '3.5rem' }}
         aria-pressed={isSelected || undefined}
       >
         {/* `min-w-0` on both: a flex item's default minimum is its content


### PR DESCRIPTION
## Problem

A long note title in a narrow Index continued underneath the overlaid **Options** control, leaving both labels painted over each other.

The title already had the correct `min-w-0` and ellipsis chain. The missing clearance came from the cascade: `.note-card` uses an unlayered padding shorthand, which outranks Tailwind's layered `pr-14` utility and reduced the intended right padding to 12px.

## Change

Reserve the Options area directly on `DraggableNoteItem`, where the overlaid action exists. The visual title still uses CSS truncation; the stored title, DOM text, and accessible name remain complete.

The inline right padding is deliberate: it survives both the base `.note-card` shorthand and compact mode without adding action clearance to other note-card variants.

## Regression coverage

`DraggableNoteItem.test.tsx` now verifies that a long title:

- keeps its complete DOM text and accessible name;
- retains the shrinkable ellipsis classes;
- reserves 3.5rem for Options.

## Verification

- `npm test`: 657 passed
- `npm run lint -- --max-warnings 16`: 0 errors, 16 existing warnings
- `npm run format:check`: clean
- `npm run check:tokens`: clean, 143 tokens across 329 files
- `npm run build && npm run check:size`: clean, app 597.5 KB raw / 164.8 KB gz
- `cargo clippy --lib --all-targets -- -D warnings`: clean
- `cargo test --lib`: 361 passed
- `node scripts/bump-version.mjs --check`: all five manifests synchronized

## Manual check

The focused jsdom test cannot prove WebKit geometry because Vitest disables CSS processing. A Tauri development build will remain open for a narrow-Index hover check before merge.

## Scope

No note names, paths, navigation, drag-and-drop behavior, or accessibility labels change. The context-menu viewport and scrolling defects are intentionally reserved for the second focused PR.