### PR TITLE
fix(sidebar): keep Options menus visible and dismiss them on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Moldavite are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **Sidebar Options menus stay inside the window and close when the Index scrolls.** Opening a note's long action menu low in a small window cut off its lower choices, and scrolling the Index left the menu fixed over unrelated content. Note and folder menus now flip or shift away from window edges, gain their own scrollbar when the window is shorter than their contents, and close when the surrounding page scrolls.
+
 ## [2.4.0] - 2026-08-19
 
 ### Added

--- a/src/components/sidebar/ContextMenuSurface.test.tsx
+++ b/src/components/sidebar/ContextMenuSurface.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ContextMenuSurface, fitContextMenuPosition } from './ContextMenuSurface';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('fitContextMenuPosition', () => {
+  it('keeps a menu at the requested point when it fits', () => {
+    expect(
+      fitContextMenuPosition(
+        { x: 20, y: 30 },
+        { width: 80, height: 100 },
+        { width: 400, height: 300 }
+      )
+    ).toEqual({ x: 20, y: 30 });
+  });
+
+  it('flips a menu away from the right and bottom edges', () => {
+    expect(
+      fitContextMenuPosition(
+        { x: 390, y: 290 },
+        { width: 160, height: 120 },
+        { width: 400, height: 300 }
+      )
+    ).toEqual({ x: 230, y: 170 });
+  });
+
+  it('clamps when the menu fits on neither side', () => {
+    expect(
+      fitContextMenuPosition(
+        { x: 60, y: 60 },
+        { width: 100, height: 100 },
+        { width: 120, height: 120 }
+      )
+    ).toEqual({ x: 12, y: 12 });
+  });
+
+  it('keeps an oversized menu anchored to the viewport margin', () => {
+    expect(
+      fitContextMenuPosition(
+        { x: 60, y: 60 },
+        { width: 200, height: 200 },
+        { width: 120, height: 120 }
+      )
+    ).toEqual({ x: 8, y: 8 });
+  });
+});
+
+describe('ContextMenuSurface', () => {
+  function mockGeometry(width = 160, height = 120) {
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(width);
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(height);
+  }
+
+  it('portals to the body and fits the measured menu before paint', () => {
+    vi.stubGlobal('innerWidth', 300);
+    vi.stubGlobal('innerHeight', 200);
+    mockGeometry();
+
+    render(
+      <div data-testid="clipping-parent">
+        <ContextMenuSurface position={{ x: 290, y: 190 }} onClose={vi.fn()}>
+          <button>Action</button>
+        </ContextMenuSurface>
+      </div>
+    );
+
+    const surface = screen.getByRole('button', { name: 'Action' }).parentElement;
+    expect(surface?.parentElement).toBe(document.body);
+    expect(surface).toHaveStyle({ left: '130px', top: '70px' });
+    expect(surface).toHaveClass('sidebar-context-menu');
+  });
+
+  it('repositions when the viewport changes', () => {
+    vi.stubGlobal('innerWidth', 500);
+    vi.stubGlobal('innerHeight', 400);
+    mockGeometry(100, 100);
+
+    render(
+      <ContextMenuSurface position={{ x: 450, y: 350 }} onClose={vi.fn()}>
+        <button>Action</button>
+      </ContextMenuSurface>
+    );
+    const surface = screen.getByRole('button', { name: 'Action' }).parentElement;
+    expect(surface).toHaveStyle({ left: '350px', top: '250px' });
+
+    vi.stubGlobal('innerWidth', 300);
+    vi.stubGlobal('innerHeight', 200);
+    fireEvent(window, new Event('resize'));
+    expect(surface).toHaveStyle({ left: '192px', top: '92px' });
+  });
+
+  it('closes on outside scroll but stays open for its own scrollbar', () => {
+    vi.stubGlobal('innerWidth', 300);
+    vi.stubGlobal('innerHeight', 200);
+    mockGeometry();
+    const onClose = vi.fn();
+    const outsideScroller = document.createElement('div');
+    document.body.appendChild(outsideScroller);
+
+    render(
+      <ContextMenuSurface position={{ x: 20, y: 20 }} onClose={onClose}>
+        <button>Action</button>
+      </ContextMenuSurface>
+    );
+    const surface = screen.getByRole('button', { name: 'Action' }).parentElement as HTMLElement;
+
+    fireEvent.scroll(surface);
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.scroll(outsideScroller);
+    expect(onClose).toHaveBeenCalledOnce();
+    outsideScroller.remove();
+  });
+
+  it('contains portal clicks and removes lifecycle listeners on unmount', () => {
+    vi.stubGlobal('innerWidth', 300);
+    vi.stubGlobal('innerHeight', 200);
+    mockGeometry();
+    const onClose = vi.fn();
+    const documentClick = vi.fn();
+    document.addEventListener('click', documentClick);
+
+    const { unmount } = render(
+      <ContextMenuSurface position={{ x: 20, y: 20 }} onClose={onClose}>
+        <button>Action</button>
+      </ContextMenuSurface>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Action' }));
+    expect(documentClick).not.toHaveBeenCalled();
+
+    unmount();
+    fireEvent.scroll(document);
+    expect(onClose).not.toHaveBeenCalled();
+    document.removeEventListener('click', documentClick);
+  });
+});

--- a/src/components/sidebar/ContextMenuSurface.tsx
+++ b/src/components/sidebar/ContextMenuSurface.tsx
@@ -28,11 +28,9 @@ export function fitContextMenuPosition(
     y = point.y - menu.height;
   }
 
-  const maxX = Math.max(EDGE, viewport.width - menu.width - EDGE);
-  const maxY = Math.max(EDGE, viewport.height - menu.height - EDGE);
   return {
-    x: Math.max(EDGE, Math.min(x, maxX)),
-    y: Math.max(EDGE, Math.min(y, maxY)),
+    x: Math.max(EDGE, Math.min(x, viewport.width - menu.width - EDGE)),
+    y: Math.max(EDGE, Math.min(y, viewport.height - menu.height - EDGE)),
   };
 }
 

--- a/src/components/sidebar/ContextMenuSurface.tsx
+++ b/src/components/sidebar/ContextMenuSurface.tsx
@@ -1,0 +1,92 @@
+/**
+ * Shared viewport-aware surface for pointer-positioned sidebar menus. Portaling
+ * keeps fixed coordinates independent of sidebar transforms and clipping.
+ */
+import { useLayoutEffect, useRef, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { applyImpactOrigin, type ImpactPoint } from '@/lib/impactOrigin';
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+const EDGE = 8;
+
+export function fitContextMenuPosition(
+  point: ImpactPoint,
+  menu: Size,
+  viewport: Size
+): ImpactPoint {
+  let x = point.x;
+  let y = point.y;
+
+  if (x + menu.width + EDGE > viewport.width && point.x - menu.width >= EDGE) {
+    x = point.x - menu.width;
+  }
+  if (y + menu.height + EDGE > viewport.height && point.y - menu.height >= EDGE) {
+    y = point.y - menu.height;
+  }
+
+  const maxX = Math.max(EDGE, viewport.width - menu.width - EDGE);
+  const maxY = Math.max(EDGE, viewport.height - menu.height - EDGE);
+  return {
+    x: Math.max(EDGE, Math.min(x, maxX)),
+    y: Math.max(EDGE, Math.min(y, maxY)),
+  };
+}
+
+interface ContextMenuSurfaceProps {
+  position: ImpactPoint;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function ContextMenuSurface({ position, onClose, children }: ContextMenuSurfaceProps) {
+  const surfaceRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+
+    const place = () => {
+      const fitted = fitContextMenuPosition(
+        position,
+        { width: surface.offsetWidth, height: surface.offsetHeight },
+        { width: window.innerWidth, height: window.innerHeight }
+      );
+      surface.style.left = `${fitted.x}px`;
+      surface.style.top = `${fitted.y}px`;
+    };
+    const closeOnOutsideScroll = (event: Event) => {
+      if (event.target === surface) return;
+      onClose();
+    };
+
+    place();
+    applyImpactOrigin(surface, position);
+    window.addEventListener('resize', place);
+    window.addEventListener('scroll', closeOnOutsideScroll, true);
+    return () => {
+      window.removeEventListener('resize', place);
+      window.removeEventListener('scroll', closeOnOutsideScroll, true);
+    };
+  }, [onClose, position]);
+
+  return createPortal(
+    <div
+      ref={surfaceRef}
+      // The flex column is required for WebKit shrink-to-fit sizing when a
+      // menu contains both full-width actions and a plain separator.
+      className="sidebar-context-menu fixed z-[9999] flex flex-col py-1 min-w-[160px] modal-content-enter impact-surface"
+      style={{
+        left: position.x,
+        top: position.y,
+      }}
+      onClick={(event) => event.stopPropagation()}
+    >
+      {children}
+    </div>,
+    document.body
+  );
+}

--- a/src/components/sidebar/FolderContextMenu.tsx
+++ b/src/components/sidebar/FolderContextMenu.tsx
@@ -1,5 +1,5 @@
 import type { FolderInfo } from '@/types';
-import { applyImpactOrigin } from '@/lib/impactOrigin';
+import { ContextMenuSurface } from './ContextMenuSurface';
 
 interface FolderContextMenuProps {
   folder: FolderInfo;
@@ -7,16 +7,10 @@ interface FolderContextMenuProps {
   onNewNoteInFolder: (folder: FolderInfo) => void;
   onRename: (folder: FolderInfo) => void;
   onDelete: (folder: FolderInfo) => void;
+  onClose: () => void;
 }
 
-const itemClass = 'w-full px-3 py-2 text-left text-sm transition-colors';
-
-function hoverIn(e: React.MouseEvent<HTMLButtonElement>) {
-  e.currentTarget.style.backgroundColor = 'var(--hover-overlay)';
-}
-function hoverOut(e: React.MouseEvent<HTMLButtonElement>) {
-  e.currentTarget.style.backgroundColor = 'transparent';
-}
+const itemClass = 'shrink-0 w-full px-3 py-2 text-left text-sm transition-colors';
 
 export function FolderContextMenu({
   folder,
@@ -24,33 +18,14 @@ export function FolderContextMenu({
   onNewNoteInFolder,
   onRename,
   onDelete,
+  onClose,
 }: FolderContextMenuProps) {
   return (
-    <div
-      ref={(node) => applyImpactOrigin(node, position)}
-      // `flex flex-col` is load-bearing, not styling. A shrink-to-fit popup
-      // (fixed/absolute, no width) that holds BOTH percentage-width children
-      // and a plain block child — the separator below — is sized to the whole
-      // available width by WebKit instead of to its content: this menu paints
-      // ~1000px wide beside a 360px sidebar. Blink shrink-wraps it, so it
-      // looks correct in every browser check. A flex column sizes from the
-      // items in both engines. `width: max-content` does NOT fix it in WebKit.
-      className="fixed z-[9999] flex flex-col py-1 min-w-[160px] modal-content-enter impact-surface"
-      style={{
-        left: position.x,
-        top: position.y,
-        backgroundColor: 'var(--bg-elevated)',
-        border: '1px solid var(--border-default)',
-        borderRadius: 'var(--radius-sm)',
-      }}
-      onClick={(e) => e.stopPropagation()}
-    >
+    <ContextMenuSurface position={position} onClose={onClose}>
       <button
         onClick={() => onNewNoteInFolder(folder)}
         className={itemClass}
         style={{ color: 'var(--text-primary)' }}
-        onMouseEnter={hoverIn}
-        onMouseLeave={hoverOut}
       >
         New Note in Folder
       </button>
@@ -58,21 +33,17 @@ export function FolderContextMenu({
         onClick={() => onRename(folder)}
         className={itemClass}
         style={{ color: 'var(--text-primary)' }}
-        onMouseEnter={hoverIn}
-        onMouseLeave={hoverOut}
       >
         Rename Folder
       </button>
-      <div className="my-1" style={{ borderTop: '1px solid var(--border-muted)' }} />
+      <div className="my-1 shrink-0" style={{ borderTop: '1px solid var(--border-muted)' }} />
       <button
         onClick={() => onDelete(folder)}
         className={itemClass}
         style={{ color: 'var(--error)' }}
-        onMouseEnter={hoverIn}
-        onMouseLeave={hoverOut}
       >
         Delete Folder
       </button>
-    </div>
+    </ContextMenuSurface>
   );
 }

--- a/src/components/sidebar/NoteContextMenu.tsx
+++ b/src/components/sidebar/NoteContextMenu.tsx
@@ -9,7 +9,7 @@ import {
 import { useToast } from '@/hooks/useToast';
 import { usePdfExportStore, useQuickSwitcherStore } from '@/stores';
 import type { NoteFile } from '@/types';
-import { applyImpactOrigin } from '@/lib/impactOrigin';
+import { ContextMenuSurface } from './ContextMenuSurface';
 
 interface NoteContextMenuProps {
   note: NoteFile;
@@ -25,14 +25,7 @@ interface NoteContextMenuProps {
   onClose: () => void;
 }
 
-const itemClass = 'w-full px-3 py-2 text-left text-sm transition-colors';
-
-function hoverIn(e: React.MouseEvent<HTMLButtonElement>) {
-  e.currentTarget.style.backgroundColor = 'var(--hover-overlay)';
-}
-function hoverOut(e: React.MouseEvent<HTMLButtonElement>) {
-  e.currentTarget.style.backgroundColor = 'transparent';
-}
+const itemClass = 'shrink-0 w-full px-3 py-2 text-left text-sm transition-colors';
 
 export function NoteContextMenu({
   note,
@@ -136,33 +129,13 @@ export function NoteContextMenu({
   };
 
   return (
-    <div
-      ref={(node) => applyImpactOrigin(node, position)}
-      // `flex flex-col` is load-bearing, not styling. A shrink-to-fit popup
-      // (fixed/absolute, no width) that holds BOTH percentage-width children
-      // and a plain block child — the separator below — is sized to the whole
-      // available width by WebKit instead of to its content: this menu paints
-      // ~1000px wide beside a 360px sidebar. Blink shrink-wraps it, so it
-      // looks correct in every browser check. A flex column sizes from the
-      // items in both engines. `width: max-content` does NOT fix it in WebKit.
-      className="fixed z-[9999] flex flex-col py-1 min-w-[160px] modal-content-enter impact-surface"
-      style={{
-        left: position.x,
-        top: position.y,
-        backgroundColor: 'var(--bg-elevated)',
-        border: '1px solid var(--border-default)',
-        borderRadius: 'var(--radius-sm)',
-      }}
-      onClick={(e) => e.stopPropagation()}
-    >
+    <ContextMenuSurface position={position} onClose={onClose}>
       {note.isLocked ? (
         <>
           <button
             onClick={() => onUnlock(note)}
             className={itemClass}
             style={{ color: 'var(--text-primary)' }}
-            onMouseEnter={hoverIn}
-            onMouseLeave={hoverOut}
           >
             View Note
           </button>
@@ -170,8 +143,6 @@ export function NoteContextMenu({
             onClick={() => onPermanentUnlock(note)}
             className={itemClass}
             style={{ color: 'var(--text-primary)' }}
-            onMouseEnter={hoverIn}
-            onMouseLeave={hoverOut}
           >
             Remove Lock
           </button>
@@ -181,8 +152,6 @@ export function NoteContextMenu({
           onClick={() => onLock(note)}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Lock Note
         </button>
@@ -196,8 +165,6 @@ export function NoteContextMenu({
         }}
         className={itemClass}
         style={{ color: 'var(--text-primary)' }}
-        onMouseEnter={hoverIn}
-        onMouseLeave={hoverOut}
       >
         {isPinned(note.path) ? 'Unpin from top bar' : 'Pin to top bar'}
       </button>
@@ -209,8 +176,6 @@ export function NoteContextMenu({
           }}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Open in New Tab
         </button>
@@ -220,8 +185,6 @@ export function NoteContextMenu({
           onClick={handleDuplicate}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Duplicate
         </button>
@@ -234,8 +197,6 @@ export function NoteContextMenu({
           }}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Rename…
         </button>
@@ -245,8 +206,6 @@ export function NoteContextMenu({
           onClick={handleExportMarkdown}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Export as Markdown
         </button>
@@ -256,8 +215,6 @@ export function NoteContextMenu({
           onClick={handleExportPdf}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Export as PDF
         </button>
@@ -267,8 +224,6 @@ export function NoteContextMenu({
           onClick={handleExportPlaintext}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Export as Plaintext
         </button>
@@ -278,13 +233,11 @@ export function NoteContextMenu({
           onClick={() => onMoveToFolder(note)}
           className={itemClass}
           style={{ color: 'var(--text-primary)' }}
-          onMouseEnter={hoverIn}
-          onMouseLeave={hoverOut}
         >
           Move to Folder...
         </button>
       )}
-      <div className="my-1" style={{ borderTop: '1px solid var(--border-muted)' }} />
+      <div className="my-1 shrink-0" style={{ borderTop: '1px solid var(--border-muted)' }} />
       <button
         onClick={(e) => {
           onDelete(e, note);
@@ -292,11 +245,9 @@ export function NoteContextMenu({
         }}
         className={itemClass}
         style={{ color: 'var(--error)' }}
-        onMouseEnter={hoverIn}
-        onMouseLeave={hoverOut}
       >
         Delete Note
       </button>
-    </div>
+    </ContextMenuSurface>
   );
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -833,6 +833,7 @@ export function Sidebar({
           }}
           onRename={handleRenameFolder}
           onDelete={handleDeleteFolder}
+          onClose={closeFolderContextMenu}
         />
       )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -2682,6 +2682,17 @@ button[aria-expanded='true'] .wn-caret {
   animation-name: impact-content-in;
 }
 
+.sidebar-context-menu {
+  max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  background-color: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+}
+
 .modal-content-exit {
   animation: modal-content-out var(--dur-micro) var(--ease-exit) forwards;
 }


### PR DESCRIPTION
## Problem

The note Options menu stored the pointer's viewport coordinates once and rendered a fixed surface there without measuring it. Near the bottom of a small window, the lower actions extended beyond the visible app. Scrolling the Index then moved the source row while leaving that fixed menu over unrelated content until the next click.

Folder Options used the same positioning model. The Index overlay added a second risk: its transform and overflow rules could become the containing block and clipping boundary for a fixed descendant.

## Change

Add one shared `ContextMenuSurface` for note and folder actions. It now:

- portals to `document.body`, keeping fixed coordinates viewport-relative;
- measures the rendered menu before paint;
- flips away from the right or bottom edge when possible, then clamps to an 8px viewport margin;
- limits oversized menus to the viewport and gives them their own scrollbar;
- closes when surrounding content scrolls, while allowing that internal scrollbar to remain open;
- recomputes placement when the viewport resizes;
- preserves the flex-column sizing required by WebKit.

The existing per-button hover handlers were redundant with the app-wide interaction rule, which already applies the same fill with `!important`. Removing them keeps the shared behavior in one design-system rule and keeps this fix within the existing bundle budget.

## Regression coverage

`ContextMenuSurface.test.tsx` covers:

- unchanged placement when the menu fits;
- right/bottom flipping;
- clamping when neither side fits;
- oversized viewport handling;
- body portaling and measured placement;
- resize repositioning;
- outside-scroll dismissal versus internal menu scrolling;
- portal click containment and listener cleanup.

Existing nested sidebar action tests remain green.

## Verification

- `npm test`: 664 passed
- `npm run lint -- --max-warnings 16`: 0 errors, 16 existing warnings
- `npm run format:check`: clean
- `npm run check:tokens`: clean, 143 tokens across 331 files
- `npm run build && npm run check:size`: clean, app 597.4 KB raw / 165.0 KB gz
- `cargo clippy --lib --all-targets -- -D warnings`: clean
- `cargo test --lib`: 361 passed
- `node scripts/bump-version.mjs --check`: all five manifests synchronized

## Manual check

Automated tests cannot prove WKWebView geometry because Vitest uses jsdom with CSS processing disabled. A Tauri development build will remain open for testing at the minimum window size before merge.

## Scope

The existing tag context menu and the broader keyboard-navigation model for context menus are unchanged. This PR is independent of #111 and changes only note/folder menu placement and lifecycle.