### PR TITLE
release: 2.4.1 — sidebar title and menu fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [2.4.1] - 2026-08-25
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.4.0"
+version = "2.4.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bump Moldavite from `2.4.0` to `2.4.1` across all five version manifests.
- Publish the two approved sidebar fixes: long note names no longer overlap Options, and note/folder Options menus stay visible and close when the Index scrolls.
- Turn the combined changelog entries into the dated `2.4.1` release section used by both GitHub Releases and the in-app “What’s New” popup.

## Verification

- `npm test`: 665 passed
- `npm run lint -- --max-warnings 16`: 0 errors, 16 existing warnings
- `npm run format:check`: clean
- `npm run check:tokens`: clean, 143 tokens across 331 files
- `npm run build && npm run check:size`: clean, app 597.3 KB raw / 165.0 KB gz
- `cargo clippy --lib --all-targets -- -D warnings`: clean
- `cargo test --lib`: 361 passed
- `node scripts/bump-version.mjs --check`: all five manifests synchronized at `2.4.1`
- `node scripts/extract-changelog.mjs 2.4.1`: both release notes extracted
- Extension `npm test && npm run build`: 10 passed; Chrome and Firefox bundles built