### PR TITLE
Fix transactional note changes and external links

### DIFF
--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -93,7 +93,13 @@ const BUDGETS = [
 // order store plus reorder drop targets on note and folder rows) and the
 // editor footer's two collapse breakpoints, which carry a second row and a
 // folded navigation menu. Measured 595.7 KB raw / 164.1 KB gz.
-const APP_JS_BUDGET = { rawKb: 598, gzipKb: 165 };
+// Bumped 8 KB raw / 3 KB gz for handing editor links to the system browser and
+// transactional note readdressing: serialized moves, autosave holds, path-keyed
+// state migration, and validated drag feedback. Measured 603.5 KB raw / 166.9 KB gz.
+// Bumped 3 KB raw for reversible trash state: optimistic rollback plus archived
+// WordPress mappings keyed by backend trash identity. Measured 606.3 KB raw /
+// 167.6 KB gz; gzip remains within the existing cap.
+const APP_JS_BUDGET = { rawKb: 608, gzipKb: 168 };
 
 async function main() {
   let entries;

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -97,9 +97,9 @@ const BUDGETS = [
 // transactional note readdressing: serialized moves, autosave holds, path-keyed
 // state migration, and validated drag feedback. Measured 603.5 KB raw / 166.9 KB gz.
 // Bumped 3 KB raw for reversible trash state: optimistic rollback plus archived
-// WordPress mappings keyed by backend trash identity. Measured 606.3 KB raw /
-// 167.6 KB gz; gzip remains within the existing cap.
-const APP_JS_BUDGET = { rawKb: 608, gzipKb: 168 };
+// WordPress mappings keyed by backend trash identity. Measured 606.8 KB raw /
+// 167.8 KB gz locally and 168.2 KB gz on Linux CI.
+const APP_JS_BUDGET = { rawKb: 608, gzipKb: 169 };
 
 async function main() {
   let entries;

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
   "permissions": [
     "core:default",
     "core:window:default",
+    "core:window:allow-destroy",
+    "shell:default",
     {
       "identifier": "shell:allow-open",
       "allow": [

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -1062,9 +1062,12 @@ fn visit_note_files(
 pub(crate) fn move_note(
     note_path: String,
     to_folder: Option<String>,
+    base_hash: Option<String>,
     index: State<'_, Arc<BacklinksIndex>>,
+    recent: State<'_, Arc<RecentWrites>>,
 ) -> Result<String, String> {
     let standalone_dir = get_standalone_dir();
+    let source_path = standalone_dir.join(&note_path);
     let (old_filename, final_filename, new_relative_path, dest_path) =
         move_note_in(&standalone_dir, &note_path, to_folder.as_deref())?;
 
@@ -1073,6 +1076,15 @@ pub(crate) fn move_note(
     index.remove_note(&old_filename);
     let content = fs::read_to_string(&dest_path).unwrap_or_default();
     index.update_note(&final_filename, &content);
+
+    if note_path != new_relative_path {
+        recent.record_missing(&source_path);
+        let body = frontmatter::parse_note(&content).body;
+        let content_hash = sha256_hex(&body);
+        if base_hash.as_deref() == Some(content_hash.as_str()) {
+            recent.record(&dest_path, &content_hash);
+        }
+    }
 
     crate::semantic::note_removed(&format!("notes/{}", note_path));
     crate::semantic::note_changed(&format!("notes/{}", new_relative_path));

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -104,6 +104,7 @@ fn trash_item_path(trash_dir: &std::path::Path, item: &TrashedNoteMetadata) -> s
 fn restore_item_on_disk(
     trash_dir: &std::path::Path,
     daily_dir: &std::path::Path,
+    weekly_dir: &std::path::Path,
     standalone_dir: &std::path::Path,
     item: &TrashedNoteMetadata,
 ) -> Result<std::path::PathBuf, String> {
@@ -113,12 +114,14 @@ fn restore_item_on_disk(
     if !source.exists() {
         return Err("Trash file not found on disk".to_string());
     }
-    let root = if item.is_daily {
+    let root = if item.is_weekly {
+        weekly_dir
+    } else if item.is_daily {
         daily_dir
     } else {
         standalone_dir
     };
-    let valid_original_path = if item.is_daily {
+    let valid_original_path = if item.is_daily || item.is_weekly {
         is_safe_existing_filename(&item.original_path)
     } else {
         is_safe_existing_note_path(&item.original_path)
@@ -160,6 +163,7 @@ fn trash_note_on_disk(
     filename: &str,
     bare_filename: bool,
     is_daily: bool,
+    is_weekly: bool,
     id: &str,
     trashed_at: i64,
 ) -> Result<TrashedNoteMetadata, String> {
@@ -190,6 +194,7 @@ fn trash_note_on_disk(
         filename: filename.to_string(),
         original_path: filename.to_string(),
         is_daily,
+        is_weekly,
         is_folder: false,
         contained_files: Vec::new(),
         trashed_at,
@@ -202,7 +207,7 @@ pub(crate) fn trash_note(
     is_daily: bool,
     is_weekly: bool,
     index: State<'_, Arc<BacklinksIndex>>,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let source_dir = if is_weekly {
         get_weekly_dir()
     } else if is_daily {
@@ -224,6 +229,7 @@ pub(crate) fn trash_note(
         &filename,
         is_daily || is_weekly,
         is_daily,
+        is_weekly,
         &id,
         chrono::Utc::now().timestamp(),
     )?;
@@ -242,7 +248,7 @@ pub(crate) fn trash_note(
         &filename, is_daily, is_weekly,
     ));
 
-    Ok(())
+    Ok(id)
 }
 
 #[tauri::command]
@@ -264,6 +270,7 @@ pub(crate) fn list_trash() -> Result<Vec<TrashedNote>, String> {
                 filename: item.filename.clone(),
                 original_path: item.original_path.clone(),
                 is_daily: item.is_daily,
+                is_weekly: item.is_weekly,
                 is_folder: item.is_folder,
                 contained_files: item.contained_files.clone(),
                 trashed_at: item.trashed_at,
@@ -316,7 +323,7 @@ pub(crate) fn read_trashed_note(trash_id: String) -> Result<String, String> {
 pub(crate) fn restore_note(
     trash_id: String,
     index: State<'_, Arc<BacklinksIndex>>,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let mut metadata = read_trash_metadata();
 
     // Find the item in metadata
@@ -337,10 +344,11 @@ pub(crate) fn restore_note(
         return Err("Trash file not found on disk".to_string());
     }
 
-    if item.is_folder {
+    let restored_path = if item.is_folder {
         let dest_path = restore_item_on_disk(
             &get_trash_dir(),
             &get_daily_dir(),
+            &get_weekly_dir(),
             &get_standalone_dir(),
             &item,
         )?;
@@ -353,10 +361,12 @@ pub(crate) fn restore_note(
                 .map(|f| format!("notes/{}/{}", item.original_path, f))
                 .collect(),
         );
+        format!("notes/{}", item.original_path)
     } else {
         let dest_path = restore_item_on_disk(
             &get_trash_dir(),
             &get_daily_dir(),
+            &get_weekly_dir(),
             &get_standalone_dir(),
             &item,
         )?;
@@ -368,15 +378,22 @@ pub(crate) fn restore_note(
         crate::semantic::note_changed(&crate::semantic::note_rel_path(
             &item.original_path,
             item.is_daily,
-            false,
+            item.is_weekly,
         ));
-    }
+        if item.is_weekly {
+            format!("weekly/{}", item.original_path)
+        } else if item.is_daily {
+            format!("daily/{}", item.original_path)
+        } else {
+            format!("notes/{}", item.original_path)
+        }
+    };
 
     // Update metadata
     metadata.items.remove(item_index);
     write_trash_metadata(&metadata)?;
 
-    Ok(())
+    Ok(restored_path)
 }
 
 fn reindex_folder(dir: &std::path::Path, index: &BacklinksIndex) {
@@ -458,33 +475,33 @@ pub(crate) fn empty_trash() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub(crate) fn cleanup_old_trash() -> Result<u32, String> {
+pub(crate) fn cleanup_old_trash() -> Result<Vec<String>, String> {
     let mut metadata = read_trash_metadata();
     let now = chrono::Utc::now().timestamp();
-    let deleted_count = cleanup_old_trash_in(&get_trash_dir(), &mut metadata, now)?;
+    let deleted_ids = cleanup_old_trash_in(&get_trash_dir(), &mut metadata, now)?;
     write_trash_metadata(&metadata)?;
-    Ok(deleted_count)
+    Ok(deleted_ids)
 }
 
 fn cleanup_old_trash_in(
     trash_dir: &std::path::Path,
     metadata: &mut TrashMetadata,
     now: i64,
-) -> Result<u32, String> {
+) -> Result<Vec<String>, String> {
     let seven_days_secs = 7 * 24 * 60 * 60;
-    let mut deleted_count = 0u32;
+    let mut deleted_ids = Vec::new();
 
     // Find expired items
-    let expired_items: Vec<(usize, bool)> = metadata
+    let expired_items: Vec<(usize, bool, String)> = metadata
         .items
         .iter()
         .enumerate()
         .filter(|(_, item)| now - item.trashed_at >= seven_days_secs)
-        .map(|(i, item)| (i, item.is_folder))
+        .map(|(i, item)| (i, item.is_folder, item.id.clone()))
         .collect();
 
     // Delete files/folders and remove from metadata (in reverse to maintain indices)
-    for (i, is_folder) in expired_items.into_iter().rev() {
+    for (i, is_folder, id) in expired_items.into_iter().rev() {
         let item = &metadata.items[i];
         let trash_path = trash_item_path(trash_dir, item);
 
@@ -495,13 +512,14 @@ fn cleanup_old_trash_in(
                 fs::remove_file(&trash_path)
             };
             result.map_err(|e| format!("Failed to delete expired trash item: {e}"))?;
-            deleted_count += 1;
         }
 
         metadata.items.remove(i);
+        deleted_ids.push(id);
     }
 
-    Ok(deleted_count)
+    deleted_ids.reverse();
+    Ok(deleted_ids)
 }
 
 fn collect_folder_files(dir: &std::path::Path, relative_path: &str, files: &mut Vec<String>) {
@@ -579,6 +597,7 @@ fn trash_folder_on_disk(
         filename: folder_name,
         original_path: path.to_string(),
         is_daily: false,
+        is_weekly: false,
         is_folder: true,
         contained_files,
         trashed_at,
@@ -661,11 +680,8 @@ pub(crate) fn restore_note_from_folder(
     }
 
     let standalone_dir = get_standalone_dir();
-    let dest_path = restore_note_from_folder_on_disk(
-        &trash_folder_path,
-        &standalone_dir,
-        &note_filename,
-    )?;
+    let dest_path =
+        restore_note_from_folder_on_disk(&trash_folder_path, &standalone_dir, &note_filename)?;
 
     // Re-index the restored note.
     if let Some(name) = dest_path.file_name().and_then(|s| s.to_str()) {
@@ -741,7 +757,7 @@ mod tests {
                     .unwrap()
                     .as_nanos()
             ));
-            for subdir in ["trash", "daily", "notes"] {
+            for subdir in ["trash", "daily", "weekly", "notes"] {
                 fs::create_dir_all(path.join(subdir)).unwrap();
             }
             Self(path)
@@ -759,6 +775,7 @@ mod tests {
             filename: original_path.clone(),
             original_path,
             is_daily: false,
+            is_weekly: false,
             is_folder: false,
             contained_files: Vec::new(),
             trashed_at,
@@ -810,17 +827,65 @@ mod tests {
         let relative = "Q3: Roadmap./Reports..md";
         fs::write(folder.join("Reports..md"), "legacy body").unwrap();
 
-        let metadata =
-            trash_note_on_disk(&notes, &trash, relative, false, false, "legacy-id", 123).unwrap();
+        let metadata = trash_note_on_disk(
+            &notes,
+            &trash,
+            relative,
+            false,
+            false,
+            false,
+            "legacy-id",
+            123,
+        )
+        .unwrap();
         assert!(!notes.join(relative).exists());
         assert_eq!(
             fs::read_to_string(trash_item_path(&trash, &metadata)).unwrap(),
             "legacy body"
         );
 
-        let restored = restore_item_on_disk(&trash, &daily, &notes, &metadata).unwrap();
+        let restored =
+            restore_item_on_disk(&trash, &daily, &tmp.0.join("weekly"), &notes, &metadata).unwrap();
         assert_eq!(restored, notes.join(relative));
         assert_eq!(fs::read_to_string(restored).unwrap(), "legacy body");
+    }
+
+    #[test]
+    fn weekly_note_restores_to_weekly_directory() {
+        let tmp = TempDir::new("weekly-note");
+        let trash = tmp.0.join("trash");
+        let daily = tmp.0.join("daily");
+        let weekly = tmp.0.join("weekly");
+        let notes = tmp.0.join("notes");
+        let filename = "2026-W34.md";
+        fs::write(weekly.join(filename), "weekly body").unwrap();
+
+        let metadata = trash_note_on_disk(
+            &weekly,
+            &trash,
+            filename,
+            true,
+            false,
+            true,
+            "weekly-id",
+            123,
+        )
+        .unwrap();
+
+        assert!(metadata.is_weekly);
+        let restored = restore_item_on_disk(&trash, &daily, &weekly, &notes, &metadata).unwrap();
+        assert_eq!(restored, weekly.join(filename));
+        assert_eq!(fs::read_to_string(restored).unwrap(), "weekly body");
+    }
+
+    #[test]
+    fn legacy_trash_metadata_defaults_to_non_weekly() {
+        let metadata: TrashMetadata = serde_json::from_str(
+            r#"{"items":[{"id":"legacy","filename":"note.md","original_path":"note.md","is_daily":false,"trashed_at":123}]}"#,
+        )
+        .unwrap();
+
+        assert!(!metadata.items[0].is_weekly);
     }
 
     #[test]
@@ -845,7 +910,7 @@ mod tests {
             items.push(metadata);
         }
         for metadata in &items {
-            restore_item_on_disk(&trash, &daily, &notes, metadata).unwrap();
+            restore_item_on_disk(&trash, &daily, &tmp.0.join("weekly"), &notes, metadata).unwrap();
         }
         assert_eq!(fs::read_dir(&trash).unwrap().count(), 0);
         for i in 0..205 {
@@ -869,7 +934,10 @@ mod tests {
         let mut metadata = TrashMetadata {
             items: vec![expired, fresh.clone()],
         };
-        assert_eq!(cleanup_old_trash_in(&trash, &mut metadata, now).unwrap(), 1);
+        assert_eq!(
+            cleanup_old_trash_in(&trash, &mut metadata, now).unwrap(),
+            vec!["expired"]
+        );
         assert_eq!(metadata.items.len(), 1);
         assert_eq!(metadata.items[0].id, fresh.id);
         assert!(trash_item_path(&trash, &fresh).exists());
@@ -886,13 +954,18 @@ mod tests {
 
         let malicious = item("malicious".into(), outside.to_string_lossy().to_string(), 0);
         fs::write(trash_item_path(&trash, &malicious), "stolen").unwrap();
-        assert!(restore_item_on_disk(&trash, &daily, &notes, &malicious).is_err());
+        assert!(
+            restore_item_on_disk(&trash, &daily, &tmp.0.join("weekly"), &notes, &malicious)
+                .is_err()
+        );
         assert_eq!(fs::read_to_string(&outside).unwrap(), "keep");
         assert!(trash_item_path(&trash, &malicious).exists());
 
         let legitimate = item("legitimate".into(), "Projects/Deep/note.md".into(), 0);
         fs::write(trash_item_path(&trash, &legitimate), "restored").unwrap();
-        let restored = restore_item_on_disk(&trash, &daily, &notes, &legitimate).unwrap();
+        let restored =
+            restore_item_on_disk(&trash, &daily, &tmp.0.join("weekly"), &notes, &legitimate)
+                .unwrap();
         assert_eq!(restored, notes.join("Projects/Deep/note.md"));
         assert_eq!(fs::read_to_string(restored).unwrap(), "restored");
     }
@@ -935,13 +1008,19 @@ mod tests {
             filename: "Deep".into(),
             original_path: "Projects/Deep".into(),
             is_daily: false,
+            is_weekly: false,
             is_folder: true,
             contained_files: vec!["Nested/note (conflict 2026-07-13 1200).md".into()],
             trashed_at: 0,
         };
-        let restored =
-            restore_item_on_disk(&trash, &tmp.0.join("daily"), &tmp.0.join("notes"), &folder)
-                .unwrap();
+        let restored = restore_item_on_disk(
+            &trash,
+            &tmp.0.join("daily"),
+            &tmp.0.join("weekly"),
+            &tmp.0.join("notes"),
+            &folder,
+        )
+        .unwrap();
         assert_eq!(
             fs::read_to_string(restored.join("Nested/secret.md.locked")).unwrap(),
             "ciphertext"
@@ -966,8 +1045,7 @@ mod tests {
         fs::write(outside.join("secret.md"), "outside secret").unwrap();
         symlink(&outside, trash_folder.join("link")).unwrap();
 
-        let result =
-            restore_note_from_folder_on_disk(&trash_folder, &standalone, "link/secret.md");
+        let result = restore_note_from_folder_on_disk(&trash_folder, &standalone, "link/secret.md");
 
         assert!(result.is_err());
         assert_eq!(

--- a/src-tauri/src/forge_watcher.rs
+++ b/src-tauri/src/forge_watcher.rs
@@ -4,11 +4,11 @@
 //! note file is created, modified, or removed by an external process, and a
 //! `forges:changed` event when a direct child Forge is added, removed, or renamed.
 //!
-//! Writes performed by Moldavite itself are short-circuited when the file body
-//! still matches the hash recorded after the write, so the UI doesn't
-//! double-refresh after its own saves. Entries are short-lived hints, not
-//! durable state; paths are normalized relative to the watched Forge and
-//! hidden/internal files never emit events.
+//! Mutations performed by Moldavite itself are short-circuited when the current
+//! file state still matches the content or absence recorded after the operation,
+//! so the UI doesn't double-refresh after its own saves and moves. Entries are
+//! short-lived hints, not durable state; paths are normalized relative to the
+//! watched Forge and hidden/internal files never emit events.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -29,9 +29,15 @@ use crate::paths::{get_forges_root, get_notes_dir};
 const SELF_WRITE_MAX_AGE: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+enum ExpectedDiskState {
+    ContentHash(String),
+    Missing,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct RecentWrite {
     recorded_at: Instant,
-    content_hash: String,
+    expected: ExpectedDiskState,
 }
 
 /// Records writes Moldavite itself initiated, keyed by absolute path.
@@ -48,12 +54,25 @@ impl RecentWrites {
     /// Record the logical body hash written to `path`. Watcher events are
     /// suppressed only while the current on-disk body still has this hash.
     pub fn record(&self, path: &Path, content_hash: &str) {
+        self.record_expected(
+            path,
+            ExpectedDiskState::ContentHash(content_hash.to_string()),
+        );
+    }
+
+    /// Record a path Moldavite just removed or moved away from. A recreated
+    /// file does not match this expectation and is emitted as an external edit.
+    pub fn record_missing(&self, path: &Path) {
+        self.record_expected(path, ExpectedDiskState::Missing);
+    }
+
+    fn record_expected(&self, path: &Path, expected: ExpectedDiskState) {
         if let Ok(mut map) = self.inner.lock() {
             map.insert(
                 path.to_path_buf(),
                 RecentWrite {
                     recorded_at: Instant::now(),
-                    content_hash: content_hash.to_string(),
+                    expected,
                 },
             );
             // Opportunistic GC.
@@ -70,9 +89,9 @@ impl RecentWrites {
         }
     }
 
-    /// Returns true only when `path` still contains the body we wrote.
-    /// Read failures and mismatches evict the hint so external changes flow
-    /// through instead of being hidden behind stale self-write state.
+    /// Returns true only when `path` still matches the content or absence we
+    /// recorded. Read failures and mismatches evict the hint so external changes
+    /// flow through instead of being hidden behind stale self-mutation state.
     pub fn matches_current_content(&self, path: &Path) -> bool {
         let recorded = {
             let Ok(mut map) = self.inner.lock() else {
@@ -88,14 +107,16 @@ impl RecentWrites {
             recorded
         };
 
-        let current_hash = match std::fs::read_to_string(path) {
-            Ok(raw) => sha256_hex(&frontmatter::parse_note(&raw).body),
-            Err(_) => {
-                self.evict_if_unchanged(path, &recorded);
-                return false;
-            }
+        let matches = match &recorded.expected {
+            ExpectedDiskState::ContentHash(content_hash) => std::fs::read_to_string(path)
+                .map(|raw| sha256_hex(&frontmatter::parse_note(&raw).body) == *content_hash)
+                .unwrap_or(false),
+            ExpectedDiskState::Missing => matches!(
+                std::fs::metadata(path),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound
+            ),
         };
-        if current_hash == recorded.content_hash {
+        if matches {
             true
         } else {
             self.evict_if_unchanged(path, &recorded);
@@ -436,6 +457,28 @@ mod tests {
     }
 
     #[test]
+    fn expected_missing_file_is_suppressed() {
+        let tmp = TempDir::new("expected-missing");
+        let path = tmp.path().join("moved.md");
+        let recent = RecentWrites::new();
+        recent.record_missing(&path);
+
+        assert!(recent.matches_current_content(&path));
+    }
+
+    #[test]
+    fn recreated_missing_file_is_delivered_and_evicted() {
+        let tmp = TempDir::new("recreated-missing");
+        let path = tmp.path().join("moved.md");
+        let recent = RecentWrites::new();
+        recent.record_missing(&path);
+        crate::persist::write_atomic(&path, b"recreated externally", Some(0o600)).unwrap();
+
+        assert!(!recent.matches_current_content(&path));
+        assert!(!recent.inner.lock().unwrap().contains_key(&path));
+    }
+
+    #[test]
     fn expired_entry_is_delivered_and_evicted() {
         let tmp = TempDir::new("expired");
         let path = tmp.path().join("note.md");
@@ -445,7 +488,7 @@ mod tests {
             path.clone(),
             RecentWrite {
                 recorded_at: Instant::now() - SELF_WRITE_MAX_AGE - Duration::from_secs(1),
-                content_hash: sha256_hex("written body"),
+                expected: ExpectedDiskState::ContentHash(sha256_hex("written body")),
             },
         );
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -41,6 +41,7 @@ pub(crate) struct TrashedNote {
     pub(crate) filename: String,
     pub(crate) original_path: String,
     pub(crate) is_daily: bool,
+    pub(crate) is_weekly: bool,
     pub(crate) is_folder: bool,
     pub(crate) contained_files: Vec<String>,
     pub(crate) trashed_at: i64,
@@ -58,6 +59,8 @@ pub(crate) struct TrashedNoteMetadata {
     pub(crate) filename: String,
     pub(crate) original_path: String,
     pub(crate) is_daily: bool,
+    #[serde(default)]
+    pub(crate) is_weekly: bool,
     #[serde(default)]
     pub(crate) is_folder: bool,
     #[serde(default)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
   },
   "plugins": {
     "shell": {
-      "open": "(?:https://github\\.com/mauropereiira/Moldavite/releases|https://github\\.com/mauropereiira/Moldavite/blob/main/docs/PLUGINS\\.md|https://github\\.com/mauropereiira/Moldavite/tree/main/extension|https://www\\.google\\.com/calendar/event\\?eid=.+|x-apple\\.systempreferences:com\\.apple\\.preference\\.security\\?Privacy_Calendars|https://accounts\\.google\\.com/o/oauth2/v2/auth\\?.+|https://public-api\\.wordpress\\.com/oauth2/authorize\\?.+)"
+      "open": "(?:https?://[^\\s]+|mailto:[^\\s]+|x-apple\\.systempreferences:com\\.apple\\.preference\\.security\\?Privacy_Calendars)"
     },
     "deep-link": {
       "desktop": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { lazy, Suspense, useEffect } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import {
   Layout,
   ToastContainer,
@@ -27,6 +29,7 @@ import {
 } from './stores';
 import { fixNotePermissions } from './lib/fileSystem';
 import { useAutoLock, useForgeWatcher, usePluginDeepLinks, usePluginHost } from './hooks';
+import { registerAutosaveCloseGuard } from './lib/autosaveFlush';
 
 const SettingsModal = lazy(() =>
   import('./components/settings').then((module) => ({ default: module.SettingsModal }))
@@ -65,6 +68,26 @@ function App() {
   useEffect(() => {
     void initializeSemantic();
   }, [initializeSemantic]);
+
+  // Native close must wait for path-changing operations and their held edits.
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    const appWindow = getCurrentWindow();
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void registerAutosaveCloseGuard(appWindow)
+      .then((stopListening) => {
+        if (disposed) stopListening();
+        else unlisten = stopListening;
+      })
+      .catch((error) => console.error('[App] Failed to register close guard:', error));
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
 
   // Apply theme on mount and when it changes
   useEffect(() => {

--- a/src/components/editor/Editor.test.tsx
+++ b/src/components/editor/Editor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { DependencyList } from 'react';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +15,7 @@ const tiptapHarness = vi.hoisted(() => ({
 
 const safeInvoke = vi.hoisted(() => vi.fn());
 const convertFileSrc = vi.hoisted(() => vi.fn((path: string) => `asset://${path}`));
+const shellOpen = vi.hoisted(() => vi.fn());
 
 vi.mock('@tiptap/react', async () => {
   const actual = await vi.importActual<typeof import('@tiptap/react')>('@tiptap/react');
@@ -65,6 +66,10 @@ vi.mock('@/lib/ipc', () => ({
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
   convertFileSrc: (path: string) => convertFileSrc(path),
+}));
+
+vi.mock('@tauri-apps/plugin-shell', () => ({
+  open: (...args: unknown[]) => shellOpen(...args),
 }));
 
 // Stable across renders so a test can assert what the shortcut handlers do,
@@ -210,6 +215,20 @@ async function renderEditor(currentNote: Note, otherNotes: Note[] = []) {
   return { editor, scrollContainer };
 }
 
+async function clickEditorElement(element: HTMLElement) {
+  const original = Object.getOwnPropertyDescriptor(document, 'elementFromPoint');
+  Object.defineProperty(document, 'elementFromPoint', {
+    configurable: true,
+    value: () => element,
+  });
+  try {
+    await userEvent.setup().click(element);
+  } finally {
+    if (original) Object.defineProperty(document, 'elementFromPoint', original);
+    else Reflect.deleteProperty(document, 'elementFromPoint');
+  }
+}
+
 beforeEach(() => {
   tiptapHarness.editor = null;
   tiptapHarness.setContentCalls = [];
@@ -218,6 +237,7 @@ beforeEach(() => {
   tiptapHarness.afterSetContent = null;
   safeInvoke.mockReset();
   convertFileSrc.mockClear();
+  shellOpen.mockReset().mockResolvedValue(undefined);
   useNoteStore.setState({
     notes: [],
     openTabs: [],
@@ -292,6 +312,40 @@ describe('Editor layout settings', () => {
   });
 });
 
+describe('Editor links', () => {
+  it.each([
+    ['web URL', 'https://example.com/docs?from=moldavite'],
+    ['email address', 'mailto:hello@example.com'],
+  ])('opens an embedded %s with the system handler', async (_label, href) => {
+    await renderEditor(note('notes/links.md', `<p><a href="${href}">Open link</a></p>`));
+
+    await clickEditorElement(screen.getByRole('link', { name: 'Open link' }));
+
+    expect(shellOpen).toHaveBeenCalledOnce();
+    expect(shellOpen).toHaveBeenCalledWith(href);
+  });
+
+  it('does not open unsupported link schemes', async () => {
+    await renderEditor(note('notes/links.md', '<p><a href="tel:+15551234567">Call</a></p>'));
+
+    await clickEditorElement(screen.getByRole('link', { name: 'Call' }));
+
+    expect(shellOpen).not.toHaveBeenCalled();
+  });
+
+  it('opens a middle-clicked web link with the system handler', async () => {
+    const href = 'https://example.com/middle-click';
+    await renderEditor(note('notes/links.md', `<p><a href="${href}">Open link</a></p>`));
+
+    fireEvent(
+      screen.getByRole('link', { name: 'Open link' }),
+      new MouseEvent('auxclick', { bubbles: true, button: 1, cancelable: true })
+    );
+
+    expect(shellOpen).toHaveBeenCalledWith(href);
+  });
+});
+
 describe('Editor content synchronization', () => {
   it('loads note content without emitting an editor update', async () => {
     const currentNote = note('notes/first.md', '<p>First note body</p>');
@@ -356,6 +410,35 @@ describe('Editor content synchronization', () => {
       expect(scrollContainer.scrollTop).toBe(180);
       expect(editor.state.selection.from).toBe(3);
       expect(editor.state.selection.to).toBe(7);
+    });
+    expect(tiptapHarness.setTextSelectionCalls).toContainEqual([{ from: 3, to: 7 }]);
+  });
+
+  it('preserves focus, selection, and scroll when the open note moves folders', async () => {
+    const currentNote = note('notes/first.md', '<p>abcdefghi</p>');
+    const { editor, scrollContainer } = await renderEditor(currentNote);
+
+    await waitFor(() => expect(editor.getHTML()).toBe('<p>abcdefghi</p>'));
+    editor.commands.focus();
+    editor.commands.setTextSelection({ from: 3, to: 7 });
+    scrollContainer.scrollTop = 190;
+    tiptapHarness.setTextSelectionCalls = [];
+    tiptapHarness.blurCallCount = 0;
+    tiptapHarness.afterSetContent = () => {
+      scrollContainer.scrollTop = 0;
+    };
+
+    act(() => {
+      useNoteStore
+        .getState()
+        .renameNoteReferences(currentNote.id, 'notes/Projects/first.md', 'first');
+    });
+
+    await waitFor(() => {
+      expect(scrollContainer.scrollTop).toBe(190);
+      expect(editor.state.selection).toMatchObject({ from: 3, to: 7 });
+      expect(editor.isFocused).toBe(true);
+      expect(useNoteStore.getState().currentNote?.readdressedFrom).toBeUndefined();
     });
     expect(tiptapHarness.setTextSelectionCalls).toContainEqual([{ from: 3, to: 7 }]);
   });

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -72,6 +72,7 @@ import { useToast } from '@/hooks/useToast';
 import { markdownToHtml, processAndSaveImage } from '@/lib';
 import { looksLikeMarkdown } from '@/lib/markdownPaste';
 import { convertFileSrc } from '@tauri-apps/api/core';
+import { open as shellOpen } from '@tauri-apps/plugin-shell';
 import { WelcomeEmptyState } from '@/components/ui/EmptyState';
 import { EmptyNoteTemplatePicker } from '@/components/templates/EmptyNoteTemplatePicker';
 import { TemplatePickerModal } from '@/components/templates/TemplatePickerModal';
@@ -291,6 +292,21 @@ export function Editor() {
     setShowDeleteConfirm(false);
   };
 
+  const openExternalEditorLink = (event: MouseEvent): boolean => {
+    if (!(event.target instanceof Element)) return false;
+    const href = event.target.closest('a[href]')?.getAttribute('href');
+    if (!href) return false;
+
+    event.preventDefault();
+    if (/^(https?|mailto):/i.test(href)) {
+      void shellOpen(href).catch((error) => {
+        console.error('[Editor] Failed to open external link:', error);
+        toast.error('Failed to open link');
+      });
+    }
+    return true;
+  };
+
   const editor = useEditor(
     {
       extensions: [
@@ -309,7 +325,9 @@ export function Editor() {
           allowBase64: true,
         }),
         Link.configure({
-          openOnClick: true,
+          // Browser-style window.open does not leave a Tauri WebView. Link
+          // clicks are handed to the system browser in editorProps below.
+          openOnClick: false,
           autolink: true,
           protocols: ['http', 'https', 'mailto'],
           HTMLAttributes: {
@@ -741,6 +759,13 @@ export function Editor() {
           class: 'focus:outline-none min-h-full',
           spellcheck: spellCheck ? 'true' : 'false',
         },
+        handleClick: (_view, _position, event) => {
+          return event.button === 0 && openExternalEditorLink(event);
+        },
+        handleDOMEvents: {
+          auxclick: (_view, event) =>
+            event instanceof MouseEvent && event.button === 1 && openExternalEditorLink(event),
+        },
         handlePaste: (view, event) => {
           const clipboard = event.clipboardData;
           if (!clipboard) return false;
@@ -893,16 +918,23 @@ export function Editor() {
     // editor rebuild, where TipTap is recreated because a setting in its
     // dependency list changed. Both leave the reader on the same note, so
     // neither should throw them back to the top.
-    const isSameNote = !!note && previous.noteId !== null && previous.noteId === currentNoteId;
-    // Selection can only be carried across an external reload. On a rebuild the
-    // instance below is a fresh one and the old editor's selection is already
-    // gone, so there is nothing to read back.
-    const isExternalReload = isSameNote && previous.editor === editor;
+    const isReaddressedNote =
+      !!note && previous.noteId !== null && note.readdressedFrom === previous.noteId;
+    const isSameNote =
+      !!note &&
+      previous.noteId !== null &&
+      (previous.noteId === currentNoteId || isReaddressedNote);
+    // Selection can only be carried when the same editor instance survives an
+    // external reload or path change. A rebuilt instance has no old selection.
+    const preserveEditorState = isSameNote && previous.editor === editor;
     lastAppliedRef.current = {
       editor,
       noteId: currentNoteId ?? null,
       externalRev: note?.externalRev,
     };
+    if (isReaddressedNote && currentNoteId) {
+      useNoteStore.getState().acknowledgeNoteReaddress(currentNoteId);
+    }
 
     try {
       if (note) {
@@ -916,10 +948,10 @@ export function Editor() {
               // switch keeps the original behaviour: top of the note, no
               // selection carried over from the previous one.
               const scrollTop = isSameNote ? (scrollContainerRef.current?.scrollTop ?? 0) : 0;
-              const selection = isExternalReload
+              const selection = preserveEditorState
                 ? { from: editor.state.selection.from, to: editor.state.selection.to }
                 : null;
-              const keepFocus = isExternalReload && editor.isFocused;
+              const keepFocus = preserveEditorState && editor.isFocused;
 
               // Clear and set content, then blur to clear any selection.
               // emitUpdate:false because TipTap v3 defaults it to true, which

--- a/src/components/editor/WordPressMenu.test.tsx
+++ b/src/components/editor/WordPressMenu.test.tsx
@@ -38,6 +38,7 @@ describe('WordPressMenu', () => {
       chosenSiteId: null,
       error: null,
       postsByNote: {},
+      trashedPostsById: {},
     });
     useNoteStore.setState({
       currentNote: {
@@ -199,6 +200,23 @@ describe('WordPressMenu', () => {
     expect(postsByNote['9:notes/old.md']).toBeUndefined();
     // Unrelated notes are untouched.
     expect(postsByNote['7:notes/other.md']).toBe(99);
+  });
+
+  it('archives and restores every published-post mapping for a trashed note', () => {
+    useWordPressStore.setState({
+      postsByNote: { '7:notes/old.md': 42, '9:notes/old.md': 7, '7:notes/other.md': 99 },
+    });
+
+    useWordPressStore.getState().noteTrashed('notes/old.md', 'trash-1');
+
+    expect(useWordPressStore.getState().postsByNote).toEqual({ '7:notes/other.md': 99 });
+    useWordPressStore.getState().noteRestored('trash-1', 'notes/restored.md');
+    expect(useWordPressStore.getState().postsByNote).toEqual({
+      '7:notes/other.md': 99,
+      '7:notes/restored.md': 42,
+      '9:notes/restored.md': 7,
+    });
+    expect(useWordPressStore.getState().trashedPostsById).toEqual({});
   });
 
   // Signing out of one account must not leave its post ids behind to be

--- a/src/components/sidebar/DraggableNoteItem.test.tsx
+++ b/src/components/sidebar/DraggableNoteItem.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DraggableNoteItem } from './DraggableNoteItem';
 import { useNoteSelectionStore } from '@/stores';
@@ -14,9 +14,22 @@ const baseNote: NoteFile = {
 };
 
 describe('DraggableNoteItem', () => {
+  let dragFrame: ((time: number) => void) | null;
+
   beforeEach(() => {
     useNoteSelectionStore.getState().clear();
+    dragFrame = null;
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: (time: number) => void) => {
+        dragFrame = callback;
+        return 17;
+      })
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
   });
+
+  afterEach(() => vi.unstubAllGlobals());
 
   it('renders the note name without the .md suffix', () => {
     render(
@@ -160,5 +173,60 @@ describe('DraggableNoteItem', () => {
     fireEvent.dragStart(draggable, { dataTransfer });
     expect(dataTransfer.getData('application/x-note-path')).toBe('Hello.md');
     expect(dataTransfer.getData('text/plain')).toBe('Hello.md');
+  });
+
+  it('dims the source only on the frame after the native drag preview is captured', () => {
+    render(
+      <DraggableNoteItem
+        note={baseNote}
+        isActive={false}
+        onClick={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+    );
+    const draggable = screen.getByRole('button', { name: /Hello/i }).parentElement as HTMLElement;
+    const dataTransfer = {
+      setData: vi.fn(),
+      getData: vi.fn(() => ''),
+      effectAllowed: '',
+      types: [] as string[],
+    };
+
+    fireEvent.dragStart(draggable, { dataTransfer });
+    expect(draggable).not.toHaveClass('sidebar-note-drag-source');
+
+    act(() => dragFrame?.(16));
+    expect(draggable).toHaveClass('sidebar-note-drag-source');
+
+    fireEvent.dragEnd(draggable, { dataTransfer });
+    expect(draggable).not.toHaveClass('sidebar-note-drag-source');
+  });
+
+  it.each([
+    ['daily', { ...baseNote, path: 'daily/2026-08-25.md', isDaily: true }],
+    ['weekly', { ...baseNote, path: 'weekly/2026-W35.md', isWeekly: true }],
+    ['locked', { ...baseNote, isLocked: true }],
+  ])('does not advertise %s notes as movable into standalone folders', (_label, note) => {
+    render(
+      <DraggableNoteItem note={note} isActive={false} onClick={vi.fn()} onContextMenu={vi.fn()} />
+    );
+
+    const draggable = screen.getByRole('button', { name: /Hello/i }).parentElement as HTMLElement;
+    expect(draggable).toHaveAttribute('draggable', 'false');
+  });
+
+  it('keeps a locked standalone note draggable when manual reordering is available', () => {
+    render(
+      <DraggableNoteItem
+        note={{ ...baseNote, isLocked: true }}
+        isActive={false}
+        onClick={vi.fn()}
+        onContextMenu={vi.fn()}
+        onReorder={vi.fn()}
+      />
+    );
+
+    const draggable = screen.getByRole('button', { name: /Hello/i }).parentElement as HTMLElement;
+    expect(draggable).toHaveAttribute('draggable', 'true');
   });
 });

--- a/src/components/sidebar/DraggableNoteItem.tsx
+++ b/src/components/sidebar/DraggableNoteItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { NoteFile } from '@/types';
 import { useNoteSelectionStore } from '@/stores';
 import type { DropPlace } from '@/stores/sidebarOrderStore';
@@ -20,7 +20,20 @@ function folderOfRelativePath(relative: string): string | null {
  * enough — and the drop itself still reads `dataTransfer`, which is the
  * authoritative copy.
  */
-let draggedNote: { path: string; folderPath?: string } | null = null;
+let draggedNote: { path: string; folderPath: string | null; canMoveToFolder: boolean } | null =
+  null;
+
+export function canDropDraggedNoteIntoFolder(folderPath: string): boolean {
+  return (
+    draggedNote !== null &&
+    draggedNote.canMoveToFolder &&
+    !isSameFolder(draggedNote.folderPath, folderPath)
+  );
+}
+
+export function canDropDraggedNoteIntoRoot(): boolean {
+  return draggedNote?.canMoveToFolder === true && draggedNote.folderPath !== null;
+}
 
 interface DraggableNoteItemProps {
   note: NoteFile;
@@ -57,6 +70,23 @@ function DraggableNoteItemImpl({
   // update. This is what keeps the memoized list efficient when a user
   // shift-selects a 500-note range.
   const isSelected = useNoteSelectionStore((s) => s.selectedIds.has(note.path));
+  const canMoveToFolder =
+    note.path.startsWith('notes/') && !note.isDaily && !note.isWeekly && !note.isLocked;
+  const [isDragging, setIsDragging] = useState(false);
+  const dragFrameRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (dragFrameRef.current !== null) {
+        window.cancelAnimationFrame(dragFrameRef.current);
+      }
+      if (draggedNote?.path === note.path) {
+        draggedNote = null;
+      }
+    },
+    [note.path]
+  );
+
   const handleClick = (e: React.MouseEvent) => {
     // Cmd/Ctrl-click toggles and shift-click extends the selection. We route
     // both through `onSelectionClick` so the parent can keep track of the
@@ -79,6 +109,7 @@ function DraggableNoteItemImpl({
   };
   const handleContextMenu = (e: React.MouseEvent) => onContextMenu(note, e);
   const handleDragStart = (e: React.DragEvent) => {
+    if (!canMoveToFolder && !onReorder) return;
     // Store the note path for drag-and-drop
     // Strip "notes/" prefix for the relative path within notes folder
     const relativePath = note.path.startsWith('notes/') ? note.path.slice(6) : note.path;
@@ -89,10 +120,29 @@ function DraggableNoteItemImpl({
     // does not live under `notes/`.
     e.dataTransfer.setData('application/x-note-id', note.path);
     e.dataTransfer.effectAllowed = 'move';
-    draggedNote = { path: note.path, folderPath: note.folderPath };
+    draggedNote = {
+      path: note.path,
+      folderPath: folderOfRelativePath(relativePath),
+      canMoveToFolder,
+    };
+    if (dragFrameRef.current !== null) {
+      window.cancelAnimationFrame(dragFrameRef.current);
+    }
+    // The browser snapshots the native drag preview before the next frame.
+    // Deferring the dim keeps that preview fully opaque while changing only
+    // the source row left behind in the sidebar.
+    dragFrameRef.current = window.requestAnimationFrame(() => {
+      dragFrameRef.current = null;
+      setIsDragging(true);
+    });
   };
   const handleDragEnd = () => {
     draggedNote = null;
+    if (dragFrameRef.current !== null) {
+      window.cancelAnimationFrame(dragFrameRef.current);
+      dragFrameRef.current = null;
+    }
+    setIsDragging(false);
   };
 
   // Reorder drop target. Only a note from this same list is a reorder; a note
@@ -132,7 +182,9 @@ function DraggableNoteItemImpl({
 
   return (
     <div
-      className="group relative list-item-stagger"
+      className={`draggable-note-item group relative list-item-stagger${
+        isDragging ? ' sidebar-note-drag-source' : ''
+      }`}
       style={
         {
           paddingLeft: level > 0 ? `${level * 12}px` : undefined,
@@ -140,7 +192,7 @@ function DraggableNoteItemImpl({
         } as React.CSSProperties
       }
       onContextMenu={handleContextMenu}
-      draggable
+      draggable={canMoveToFolder || !!onReorder}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       onDragLeave={onReorder && handleDragLeave}

--- a/src/components/sidebar/FolderItem.dragDrop.test.tsx
+++ b/src/components/sidebar/FolderItem.dragDrop.test.tsx
@@ -1,0 +1,283 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import type { FolderInfo, NoteFile } from '@/types';
+import { DraggableNoteItem } from './DraggableNoteItem';
+import { FolderItem } from './FolderItem';
+
+const sourceNote: NoteFile = {
+  name: 'Source.md',
+  path: 'notes/Inbox/Source.md',
+  folderPath: 'Inbox',
+  isDaily: false,
+  isWeekly: false,
+  isLocked: false,
+};
+
+function createDataTransfer(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial));
+  const types = [...data.keys()];
+  return {
+    data,
+    types,
+    dropEffect: 'none',
+    effectAllowed: '',
+    setData(type: string, value: string) {
+      data.set(type, value);
+      if (!types.includes(type)) types.push(type);
+    },
+    getData(type: string) {
+      return data.get(type) ?? '';
+    },
+  };
+}
+
+function folderRow(name: string): HTMLElement {
+  return screen.getByText(name).closest('.folder-row') as HTMLElement;
+}
+
+function folderItem(folder: FolderInfo, onNoteDrop: (path: string) => Promise<void>) {
+  return (
+    <FolderItem
+      folder={folder}
+      level={0}
+      isExpanded={false}
+      onToggle={vi.fn()}
+      onContextMenu={vi.fn()}
+      onNoteDrop={onNoteDrop}
+      onFolderDrop={vi.fn()}
+      notes={[]}
+      isNoteActive={() => false}
+      onNoteClick={vi.fn()}
+      onNoteContextMenu={vi.fn()}
+    />
+  );
+}
+
+function renderDragTarget({
+  folder = { name: 'Projects', path: 'Projects', children: [] },
+  onNoteDrop = vi.fn().mockResolvedValue(undefined),
+  renderChildren,
+}: {
+  folder?: FolderInfo;
+  onNoteDrop?: (path: string) => Promise<void>;
+  renderChildren?: ReactNode;
+} = {}) {
+  const view = render(
+    <>
+      <DraggableNoteItem
+        note={sourceNote}
+        isActive={false}
+        onClick={vi.fn()}
+        onContextMenu={vi.fn()}
+      />
+      <FolderItem
+        folder={folder}
+        level={0}
+        isExpanded={renderChildren !== undefined}
+        onToggle={vi.fn()}
+        onContextMenu={vi.fn()}
+        onNoteDrop={onNoteDrop}
+        onFolderDrop={vi.fn()}
+        notes={[]}
+        isNoteActive={() => false}
+        onNoteClick={vi.fn()}
+        onNoteContextMenu={vi.fn()}
+        renderChildren={renderChildren}
+      />
+    </>
+  );
+
+  const source = screen.getByRole('button', { name: 'Source' }).parentElement as HTMLElement;
+  const dataTransfer = createDataTransfer();
+  fireEvent.dragStart(source, { dataTransfer });
+  return { ...view, dataTransfer, onNoteDrop, source };
+}
+
+describe('FolderItem note drag feedback', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 1)
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('marks only the direct valid destination, not its ancestor', () => {
+    const child = { name: 'Archive', path: 'Projects/Archive', children: [] };
+    const parent = { name: 'Projects', path: 'Projects', children: [child] };
+    const onNoteDrop = vi.fn().mockResolvedValue(undefined);
+    const childItem = folderItem(child, onNoteDrop);
+    const { dataTransfer, source } = renderDragTarget({
+      folder: parent,
+      onNoteDrop,
+      renderChildren: childItem,
+    });
+
+    fireEvent.dragEnter(folderRow('Archive'), { dataTransfer });
+
+    expect(folderRow('Archive')).toHaveClass('folder-row-note-drop-target');
+    expect(folderRow('Projects')).not.toHaveClass('folder-row-note-drop-target');
+    fireEvent.dragLeave(folderRow('Archive'), { dataTransfer, relatedTarget: document.body });
+    expect(folderRow('Archive')).not.toHaveClass('folder-row-note-drop-target');
+    fireEvent.dragEnd(source, { dataTransfer });
+  });
+
+  it('does not mark or accept same-folder and plain-text drags', () => {
+    const onNoteDrop = vi.fn().mockResolvedValue(undefined);
+    const sameFolder = { name: 'Inbox', path: 'Inbox', children: [] };
+    const { dataTransfer, source } = renderDragTarget({ folder: sameFolder, onNoteDrop });
+    const row = folderRow('Inbox');
+
+    fireEvent.dragEnter(row, { dataTransfer });
+    fireEvent.dragOver(row, { dataTransfer });
+    expect(row).not.toHaveClass('folder-row-note-drop-target');
+    expect(dataTransfer.dropEffect).toBe('none');
+    fireEvent.drop(row, { dataTransfer });
+
+    const plainText = createDataTransfer({ 'text/plain': 'Elsewhere.md' });
+    fireEvent.dragEnter(row, { dataTransfer: plainText });
+    fireEvent.drop(row, { dataTransfer: plainText });
+    expect(row).not.toHaveClass('folder-row-note-drop-target');
+    expect(onNoteDrop).not.toHaveBeenCalled();
+    fireEvent.dragEnd(source, { dataTransfer });
+  });
+
+  it('shows impact only after the move promise resolves, then cleans it up', async () => {
+    let resolveMove!: () => void;
+    const move = new Promise<void>((resolve) => {
+      resolveMove = resolve;
+    });
+    const onNoteDrop = vi.fn(() => move);
+    const view = renderDragTarget({ onNoteDrop });
+    const row = folderRow('Projects');
+
+    fireEvent.drop(row, { dataTransfer: view.dataTransfer });
+    expect(onNoteDrop).toHaveBeenCalledWith('Inbox/Source.md');
+    expect(view.container.querySelector('.folder-note-drop-impact')).not.toBeInTheDocument();
+
+    await act(async () => resolveMove());
+    const impact = await waitFor(() => {
+      const element = view.container.querySelector('.folder-note-drop-impact');
+      expect(element).toBeInTheDocument();
+      return element as HTMLElement;
+    });
+
+    fireEvent.animationEnd(impact);
+    await waitFor(() =>
+      expect(view.container.querySelector('.folder-note-drop-impact')).not.toBeInTheDocument()
+    );
+  });
+
+  it('does not show impact when the move rejects', async () => {
+    const onNoteDrop = vi.fn(() => Promise.reject(new Error('move failed')));
+    const view = renderDragTarget({ onNoteDrop });
+
+    await act(async () => {
+      fireEvent.drop(folderRow('Projects'), { dataTransfer: view.dataTransfer });
+      await Promise.resolve();
+    });
+
+    expect(onNoteDrop).toHaveBeenCalledOnce();
+    expect(view.container.querySelector('.folder-note-drop-impact')).not.toBeInTheDocument();
+  });
+
+  it('skips impact when reduced motion is preferred', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    );
+    const onNoteDrop = vi.fn().mockResolvedValue(undefined);
+    const view = renderDragTarget({ onNoteDrop });
+
+    await act(async () => {
+      fireEvent.drop(folderRow('Projects'), { dataTransfer: view.dataTransfer });
+      await Promise.resolve();
+    });
+
+    expect(onNoteDrop).toHaveBeenCalledOnce();
+    expect(view.container.querySelector('.folder-note-drop-impact')).not.toBeInTheDocument();
+  });
+
+  it('contains a nested folder dropped onto itself', () => {
+    const rootDrop = vi.fn();
+    const child = { name: 'Archive', path: 'Projects/Archive', children: [] };
+    render(
+      <div onDrop={rootDrop}>
+        <FolderItem
+          folder={child}
+          level={1}
+          isExpanded={false}
+          onToggle={vi.fn()}
+          onContextMenu={vi.fn()}
+          onNoteDrop={vi.fn()}
+          onFolderDrop={vi.fn()}
+          notes={[]}
+          isNoteActive={() => false}
+          onNoteClick={vi.fn()}
+          onNoteContextMenu={vi.fn()}
+        />
+      </div>
+    );
+    const dataTransfer = createDataTransfer({
+      'application/x-folder-path': child.path,
+      'text/plain': child.path,
+    });
+
+    fireEvent.drop(folderRow('Archive'), { dataTransfer });
+
+    expect(rootDrop).not.toHaveBeenCalled();
+  });
+
+  it('contains a rejected nested folder move', async () => {
+    const onFolderDrop = vi.fn().mockRejectedValue(new Error('move failed'));
+    const folder = { name: 'Projects', path: 'Projects', children: [] };
+    render(
+      <FolderItem
+        folder={folder}
+        level={0}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onContextMenu={vi.fn()}
+        onNoteDrop={vi.fn()}
+        onFolderDrop={onFolderDrop}
+        notes={[]}
+        isNoteActive={() => false}
+        onNoteClick={vi.fn()}
+        onNoteContextMenu={vi.fn()}
+      />
+    );
+    const dataTransfer = createDataTransfer({
+      'application/x-folder-path': 'Archive',
+      'text/plain': 'Archive',
+    });
+
+    await act(async () => fireEvent.drop(folderRow('Projects'), { dataTransfer }));
+
+    expect(onFolderDrop).toHaveBeenCalledWith('Archive');
+  });
+});

--- a/src/components/sidebar/FolderItem.tsx
+++ b/src/components/sidebar/FolderItem.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { FolderInfo, NoteFile } from '@/types';
 import type { DropPlace } from '@/stores/sidebarOrderStore';
-import { DraggableNoteItem } from './DraggableNoteItem';
+import { canDropDraggedNoteIntoFolder, DraggableNoteItem } from './DraggableNoteItem';
 import { Folder, FolderOpen } from 'lucide-react';
 import { folderDropIntent } from './dropPlacement';
 import { DropIndicator } from './DropIndicator';
@@ -13,8 +13,8 @@ interface FolderItemProps {
   isExpanded: boolean;
   onToggle: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
-  onNoteDrop: (notePath: string) => void;
-  onFolderDrop: (folderPath: string) => void;
+  onNoteDrop: (notePath: string) => Promise<void>;
+  onFolderDrop: (folderPath: string) => Promise<void> | void;
   notes: NoteFile[];
   isNoteActive: (note: NoteFile) => boolean;
   onNoteClick: (note: NoteFile, e: React.MouseEvent) => void;
@@ -49,6 +49,10 @@ function parentOfPath(path: string): string {
  */
 let draggedFolderPath: string | null = null;
 
+export function canDropDraggedFolderIntoRoot(): boolean {
+  return draggedFolderPath?.includes('/') === true;
+}
+
 export function FolderItem({
   folder,
   level,
@@ -69,9 +73,22 @@ export function FolderItem({
   onFolderReorder,
   onNoteReorder,
 }: FolderItemProps) {
-  const [isDragOver, setIsDragOver] = useState(false);
-  const dragCounterRef = useRef(0);
+  const [isNoteDropTarget, setIsNoteDropTarget] = useState(false);
+  const [impactKey, setImpactKey] = useState<number | null>(null);
+  const impactCounterRef = useRef(0);
+  const impactTimeoutRef = useRef<number | null>(null);
+  const isMountedRef = useRef(true);
   const [dropPlace, setDropPlace] = useState<DropPlace | null>(null);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (impactTimeoutRef.current !== null) {
+        window.clearTimeout(impactTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Manual sort: a sibling folder dropped on either END of this header row
   // takes a place beside it. The band through the row's middle still means
@@ -120,51 +137,56 @@ export function FolderItem({
     draggedFolderPath = null;
   };
 
+  const isDirectDropZone = (target: React.DragEvent<HTMLDivElement>['target'], dropZone: Element) =>
+    target instanceof Element && target.closest('[data-folder-note-drop-zone]') === dropZone;
+
   const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current++;
-
-    const hasNoteData = e.dataTransfer.types.includes('application/x-note-path');
-    const hasFolderData = e.dataTransfer.types.includes('application/x-folder-path');
-    const hasTextData = e.dataTransfer.types.includes('text/plain');
-
-    if (hasNoteData || hasFolderData || hasTextData) {
-      setIsDragOver(true);
-    }
+    if (!e.dataTransfer.types.includes('application/x-note-path')) return;
+    const directTarget = isDirectDropZone(e.target, e.currentTarget);
+    setIsNoteDropTarget(directTarget && canDropDraggedNoteIntoFolder(folder.path));
   };
 
   const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
     const hasNoteData = e.dataTransfer.types.includes('application/x-note-path');
     const hasFolderData = e.dataTransfer.types.includes('application/x-folder-path');
-    const hasTextData = e.dataTransfer.types.includes('text/plain');
 
-    if (hasNoteData || hasFolderData || hasTextData) {
+    if (hasNoteData) {
+      const directTarget = isDirectDropZone(e.target, e.currentTarget);
+      const isValid = directTarget && canDropDraggedNoteIntoFolder(folder.path);
+      setIsNoteDropTarget(isValid);
+      if (isValid) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+      }
+      return;
+    }
+
+    if (hasFolderData) {
+      e.preventDefault();
       e.dataTransfer.dropEffect = 'move';
     }
   };
 
   const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current--;
-
-    // Only set isDragOver to false when we've truly left the entire folder area
-    if (dragCounterRef.current === 0) {
-      setIsDragOver(false);
-    }
+    if (!e.dataTransfer.types.includes('application/x-note-path')) return;
+    const nextZone =
+      e.relatedTarget instanceof Element
+        ? e.relatedTarget.closest('[data-folder-note-drop-zone]')
+        : null;
+    if (nextZone !== e.currentTarget) setIsNoteDropTarget(false);
   };
 
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragOver(false);
+  const handleDrop = async (e: React.DragEvent) => {
+    setIsNoteDropTarget(false);
 
     // Check for folder drop first
     const folderPath = e.dataTransfer.getData('application/x-folder-path');
     if (folderPath) {
+      e.preventDefault();
       const isSelf = folderPath === folder.path;
       if (isSelf) {
         // Can't drop folder on itself
+        e.stopPropagation();
         return;
       }
 
@@ -189,27 +211,53 @@ export function FolderItem({
       // Accept the drop - move folder into this folder
       // This includes deeper descendants (grandchildren, etc.) being moved up
       e.stopPropagation();
-      onFolderDrop(folderPath);
+      try {
+        await onFolderDrop(folderPath);
+      } catch {
+        // useFolders owns the move error toast.
+      }
       return;
     }
 
-    // For notes, always stop propagation
-    e.stopPropagation();
+    // Only a note originating in this sidebar is a note move. In particular,
+    // text dragged from another app must not masquerade as a note path.
+    if (!e.dataTransfer.types.includes('application/x-note-path')) return;
 
-    // Try custom note type, fall back to text/plain
-    let notePath = e.dataTransfer.getData('application/x-note-path');
-    if (!notePath) {
-      notePath = e.dataTransfer.getData('text/plain');
+    // For internal notes, always stop propagation so a nested folder is the
+    // only destination considered under the pointer.
+    e.stopPropagation();
+    const notePath = e.dataTransfer.getData('application/x-note-path');
+    if (!notePath || !canDropDraggedNoteIntoFolder(folder.path)) return;
+
+    e.preventDefault();
+    try {
+      await onNoteDrop(notePath);
+    } catch {
+      // useFolders owns the move error toast; this component only suppresses
+      // success feedback for the rejected move.
+      return;
     }
-    if (notePath) {
-      // Don't allow dropping a note into its own folder
-      const noteFolder = notePath.includes('/')
-        ? notePath.substring(0, notePath.lastIndexOf('/'))
-        : null;
-      if (noteFolder !== folder.path) {
-        onNoteDrop(notePath);
+
+    if (!isMountedRef.current) return;
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      if (impactTimeoutRef.current !== null) {
+        window.clearTimeout(impactTimeoutRef.current);
+        impactTimeoutRef.current = null;
       }
+      setImpactKey(null);
+      return;
     }
+
+    const nextImpactKey = ++impactCounterRef.current;
+    setImpactKey(nextImpactKey);
+    if (impactTimeoutRef.current !== null) {
+      window.clearTimeout(impactTimeoutRef.current);
+    }
+    impactTimeoutRef.current = window.setTimeout(() => {
+      setImpactKey((current) => (current === nextImpactKey ? null : current));
+      impactTimeoutRef.current = null;
+    }, 400);
   };
 
   // Filter notes that belong to this folder
@@ -217,6 +265,7 @@ export function FolderItem({
 
   return (
     <div
+      data-folder-note-drop-zone=""
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
@@ -226,11 +275,12 @@ export function FolderItem({
       <div
         className={`folder-row group relative flex items-center gap-2 py-1.5 pr-14 cursor-pointer transition-colors sidebar-item-animated${
           showShapeMark ? ' list-item-stagger' : ''
-        }${isExpanded ? ' folder-row-expanded' : ''}`}
+        }${isExpanded ? ' folder-row-expanded' : ''}${
+          isNoteDropTarget ? ' folder-row-note-drop-target' : ''
+        }`}
         style={
           {
             paddingLeft: `${14 + level * 12}px`,
-            borderLeftColor: isDragOver ? 'var(--border-strong)' : undefined,
             '--index': Math.min(index, 10),
           } as React.CSSProperties
         }
@@ -254,6 +304,21 @@ export function FolderItem({
         onDrop={onFolderReorder && handleRowDrop}
       >
         <DropIndicator place={dropPlace} />
+        {impactKey !== null && (
+          <span
+            key={impactKey}
+            aria-hidden="true"
+            className="folder-note-drop-impact"
+            style={{ left: `${20 + level * 12}px` }}
+            onAnimationEnd={() => {
+              if (impactTimeoutRef.current !== null) {
+                window.clearTimeout(impactTimeoutRef.current);
+                impactTimeoutRef.current = null;
+              }
+              setImpactKey((current) => (current === impactKey ? null : current));
+            }}
+          />
+        )}
         <span
           aria-hidden="true"
           className={`sidebar-caret ${isExpanded ? 'sidebar-caret-expanded' : ''}`}

--- a/src/components/sidebar/FolderTree.tsx
+++ b/src/components/sidebar/FolderTree.tsx
@@ -9,7 +9,7 @@ interface FolderTreeProps {
   expandedFolders: string[];
   onToggleFolder: (path: string) => void;
   onFolderContextMenu: (e: React.MouseEvent, folder: FolderInfo) => void;
-  onNoteDrop: (notePath: string, toFolder: string) => void;
+  onNoteDrop: (notePath: string, toFolder: string) => Promise<void>;
   onFolderDrop: (folderPath: string, toFolder: string) => void;
   isNoteActive: (note: NoteFile) => boolean;
   onNoteClick: (note: NoteFile, e: React.MouseEvent) => void;

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -82,7 +82,7 @@ export function Sidebar({
     renameNote,
     refresh: refreshNotes,
   } = useNotes();
-  const { currentNote, setSelectedDate, removeTabByPath } = useNoteStore();
+  const { currentNote, setSelectedDate } = useNoteStore();
   const lock = useSidebarLock();
   const {
     setIsSettingsOpen,
@@ -168,10 +168,6 @@ export function Sidebar({
   // Track target folder for new note creation
   const [createNoteInFolder, setCreateNoteInFolder] = useState<string | null>(null);
 
-  // Root-level drop zones (notes section accepts notes, folders section
-  // accepts folders). Lives in a dedicated hook.
-  const dnd = useSidebarDnd({ moveNoteToFolder, moveFolderToFolder });
-
   // Initialize folders
   useEffect(() => {
     initializeFolders();
@@ -196,6 +192,20 @@ export function Sidebar({
   const [showManageForges, setShowManageForges] = useState(false);
   const [showBulkTrashConfirm, setShowBulkTrashConfirm] = useState(false);
   const [showBulkExportModal, setShowBulkExportModal] = useState(false);
+
+  const moveNoteAndTrackAnchor = useCallback(
+    async (notePath: string, toFolder?: string) => {
+      const oldPath = notePath.startsWith('notes/') ? notePath : `notes/${notePath}`;
+      const newPath = await moveNoteToFolder(notePath, toFolder);
+      if (selectionAnchorRef.current === oldPath) selectionAnchorRef.current = newPath;
+      return newPath;
+    },
+    [moveNoteToFolder]
+  );
+
+  // Root-level drop zones (notes section accepts notes, folders section
+  // accepts folders). Lives in a dedicated hook.
+  const dnd = useSidebarDnd({ moveNoteToFolder: moveNoteAndTrackAnchor, moveFolderToFolder });
 
   // Manual sort: the user drags notes and folders into place and we replay
   // that arrangement. Daily notes are excluded by construction — they never
@@ -457,12 +467,7 @@ export function Sidebar({
           ? noteToDelete.path.slice(6)
           : noteToDelete.name;
       }
-      await trashNote(relativePath, noteToDelete.isDaily || false);
-
-      // Close the tab, don't just null `currentNote` — a surviving tab still
-      // holds the deleted note's body, and editing it autosaves the file back
-      // onto disk while a copy sits in the trash.
-      removeTabByPath(noteToDelete.path);
+      await trashNote(relativePath, noteToDelete.isDaily || false, noteToDelete.isWeekly || false);
     } catch (error) {
       console.error('[Sidebar] Trash failed:', error);
     } finally {
@@ -507,7 +512,7 @@ export function Sidebar({
       ? noteToMove.path.slice(6)
       : noteToMove.path;
 
-    await moveNoteToFolder(relativePath, folderPath ?? undefined);
+    await moveNoteAndTrackAnchor(relativePath, folderPath ?? undefined);
     setNoteToMove(null);
     setShowMoveToFolder(false);
   };
@@ -569,7 +574,7 @@ export function Sidebar({
   };
 
   const handleNoteDrop = async (notePath: string, toFolder: string) => {
-    await moveNoteToFolder(notePath, toFolder);
+    await moveNoteAndTrackAnchor(notePath, toFolder);
   };
 
   const handleFolderDrop = async (folderPath: string, toFolder: string) => {
@@ -647,11 +652,13 @@ export function Sidebar({
     const selected = resolveSelectedNotes();
     setShowBulkMoveModal(false);
     if (selected.length === 0) return;
+    selectionClear();
+    selectionAnchorRef.current = null;
 
     const results = await Promise.allSettled(
       selected.map((n) => {
         const relative = n.path.startsWith('notes/') ? n.path.slice(6) : n.path;
-        return moveNoteToFolder(relative, folderPath ?? undefined);
+        return moveNoteAndTrackAnchor(relative, folderPath ?? undefined);
       })
     );
     const failed = results.filter((r) => r.status === 'rejected').length;
@@ -660,7 +667,6 @@ export function Sidebar({
     } else {
       toast.success(`Moved ${selected.length} note${selected.length === 1 ? '' : 's'}`);
     }
-    selectionClear();
   };
 
   const handleBulkTrashConfirm = async () => {
@@ -675,14 +681,10 @@ export function Sidebar({
           : n.path.startsWith('notes/')
             ? n.path.slice(6)
             : n.name;
-        return trashNote(relative, n.isDaily || false);
+        return trashNote(relative, n.isDaily || false, n.isWeekly || false);
       })
     );
     const failed = results.filter((r) => r.status === 'rejected').length;
-
-    // Close a tab for every trashed note, not just the active one — any tab
-    // left open still holds the note's body and would write it back on edit.
-    selected.forEach((n) => removeTabByPath(n.path));
 
     if (failed > 0) {
       toast.error(`Failed to trash ${failed} note${failed === 1 ? '' : 's'}`);

--- a/src/components/sidebar/SidebarFolderTree.tsx
+++ b/src/components/sidebar/SidebarFolderTree.tsx
@@ -14,7 +14,7 @@ interface SidebarFolderTreeProps {
   onToggleFolder: (path: string) => void;
   onFolderContextMenu: (e: React.MouseEvent, folder: FolderInfo) => void;
   onNewFolder: () => void;
-  onNoteDrop: (notePath: string, toFolder: string) => void;
+  onNoteDrop: (notePath: string, toFolder: string) => Promise<void>;
   onFolderDrop: (folderPath: string, toFolder: string) => void;
   isNoteActive: (note: NoteFile) => boolean;
   onNoteClick: (note: NoteFile, e: React.MouseEvent) => void;

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -25,6 +25,7 @@ import {
 import {
   registerAutosaveBaselineReset,
   registerAutosaveFlush,
+  registerAutosavePathChange,
   registerAutosavePendingProbe,
 } from '@/lib/autosaveFlush';
 import type { Note, NoteFile } from '@/types';
@@ -61,6 +62,8 @@ export function useAutoSave() {
    * against the note it actually belongs to.
    */
   const pendingRef = useRef<Note | null>(null);
+  const heldPathChangeNoteRef = useRef<Note | null>(null);
+  const pathChangeRef = useRef<{ oldId: string; newId?: string } | null>(null);
 
   /**
    * Write one note to disk immediately. Takes the note explicitly rather than
@@ -208,6 +211,16 @@ export function useAutoSave() {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
+    const held = heldPathChangeNoteRef.current;
+    const transition = pathChangeRef.current;
+    if (
+      held &&
+      held.id !== transition?.oldId &&
+      (transition?.newId === undefined || held.id !== transition.newId)
+    ) {
+      await persistNote(held);
+      if (heldPathChangeNoteRef.current === held) heldPathChangeNoteRef.current = null;
+    }
     const pending = pendingRef.current;
     if (pending) await persistNote(pending);
   }, [persistNote]);
@@ -215,10 +228,96 @@ export function useAutoSave() {
   // Expose the flush so a Forge switch can await it before reloading the window.
   useEffect(() => registerAutosaveFlush(flushPending), [flushPending]);
 
-  const pendingProbe = useCallback(() => pendingRef.current?.id ?? null, []);
+  const pendingProbe = useCallback(
+    () => heldPathChangeNoteRef.current?.id ?? pendingRef.current?.id ?? null,
+    []
+  );
   useEffect(() => registerAutosavePendingProbe(pendingProbe), [pendingProbe]);
 
+  const queuePending = useCallback(
+    (note: Note) => {
+      if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
+      pendingRef.current = note;
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null;
+        void persistNote(note).catch(() => {});
+      }, autoSaveDelay);
+    },
+    [autoSaveDelay, persistNote]
+  );
+
+  const beginPathChange = useCallback((noteId: string) => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    pathChangeRef.current = { oldId: noteId };
+  }, []);
+  const commitPathChange = useCallback(
+    async (oldId: string, newId: string) => {
+      const transition = pathChangeRef.current;
+      if (transition?.oldId !== oldId) return;
+      transition.newId = newId;
+      if (heldPathChangeNoteRef.current?.id === oldId) {
+        heldPathChangeNoteRef.current = { ...heldPathChangeNoteRef.current, id: newId };
+      }
+      if (lastNoteIdRef.current === oldId) lastNoteIdRef.current = newId;
+      try {
+        while (heldPathChangeNoteRef.current?.id === newId) {
+          const held = heldPathChangeNoteRef.current;
+          await persistNote(held);
+          if (heldPathChangeNoteRef.current === held) heldPathChangeNoteRef.current = null;
+        }
+      } catch (error) {
+        const held = heldPathChangeNoteRef.current;
+        if (held?.id === newId) {
+          heldPathChangeNoteRef.current = null;
+          queuePending(held);
+        }
+        throw error;
+      } finally {
+        if (pathChangeRef.current === transition) pathChangeRef.current = null;
+      }
+    },
+    [persistNote, queuePending]
+  );
+  const abortPathChange = useCallback(
+    async (noteId: string) => {
+      const transition = pathChangeRef.current;
+      if (transition?.oldId !== noteId) return;
+      try {
+        while (heldPathChangeNoteRef.current?.id === noteId) {
+          const held = heldPathChangeNoteRef.current;
+          await persistNote(held);
+          if (heldPathChangeNoteRef.current === held) heldPathChangeNoteRef.current = null;
+        }
+      } catch (error) {
+        const held = heldPathChangeNoteRef.current;
+        if (held?.id === noteId) {
+          heldPathChangeNoteRef.current = null;
+          queuePending(held);
+        }
+        throw error;
+      } finally {
+        if (pathChangeRef.current === transition) pathChangeRef.current = null;
+      }
+    },
+    [persistNote, queuePending]
+  );
+  useEffect(
+    () =>
+      registerAutosavePathChange({
+        begin: beginPathChange,
+        commit: commitPathChange,
+        abort: abortPathChange,
+      }),
+    [abortPathChange, beginPathChange, commitPathChange]
+  );
+
   const resetBaseline = useCallback((noteId: string, content: string) => {
+    if (heldPathChangeNoteRef.current?.id === noteId) {
+      heldPathChangeNoteRef.current = null;
+    }
     if (pendingRef.current?.id === noteId) {
       if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
@@ -247,6 +346,13 @@ export function useAutoSave() {
   }, [cancelPendingDebounce]);
 
   const discardPending = useCallback((noteId: string, content: string) => {
+    const transition = pathChangeRef.current;
+    if (transition?.oldId === noteId || transition?.newId === noteId) {
+      pathChangeRef.current = null;
+    }
+    if (heldPathChangeNoteRef.current?.id === noteId) {
+      heldPathChangeNoteRef.current = null;
+    }
     if (pendingRef.current?.id === noteId) {
       if (timeoutRef.current !== null) clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
@@ -290,28 +396,32 @@ export function useAutoSave() {
       return;
     }
 
+    const pathChange = pathChangeRef.current;
+    if (
+      (currentNote.id === pathChange?.oldId || currentNote.id === pathChange?.newId) &&
+      currentNote.content !== lastContentRef.current
+    ) {
+      heldPathChangeNoteRef.current = currentNote;
+      return;
+    }
+    if (heldPathChangeNoteRef.current?.id === currentNote.id) {
+      heldPathChangeNoteRef.current = currentNote;
+      return;
+    }
+
     // Don't save if content hasn't changed
     if (currentNote.content === lastContentRef.current) {
       return;
     }
 
-    // Clear previous timeout
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-
-    pendingRef.current = currentNote;
-    timeoutRef.current = setTimeout(() => {
-      timeoutRef.current = null;
-      void persistNote(currentNote).catch(() => {});
-    }, autoSaveDelay);
+    queuePending(currentNote);
 
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
     };
-  }, [currentNote, getState, autoSaveDelay, persistNote, flushPending]);
+  }, [currentNote, getState, flushPending, queuePending]);
 
   // Unmount (app close, Forge switch reload) must also settle what is owed.
   // Kept separate from the effect above, whose cleanup runs on every keystroke.

--- a/src/hooks/useFolders.test.tsx
+++ b/src/hooks/useFolders.test.tsx
@@ -1,0 +1,161 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFolders } from './useFolders';
+import { useNoteColorsStore } from '@/stores/noteColorsStore';
+import { useNoteSelectionStore } from '@/stores/noteSelectionStore';
+import { useNoteStore } from '@/stores/noteStore';
+import { useQuickSwitcherStore } from '@/stores/quickSwitcherStore';
+import { useSidebarOrderStore } from '@/stores/sidebarOrderStore';
+import { useToastStore } from '@/stores/toastStore';
+import { useWordPressStore } from '@/stores/wordpressStore';
+import type { Note, NoteFile } from '@/types';
+
+const fileSystem = vi.hoisted(() => ({
+  listFolders: vi.fn(),
+  createFolder: vi.fn(),
+  renameFolder: vi.fn(),
+  deleteFolder: vi.fn(),
+  moveNote: vi.fn(),
+  moveFolder: vi.fn(),
+  listNotes: vi.fn(),
+}));
+const autosave = vi.hoisted(() => ({
+  acquireAutosavePathChange: vi.fn(),
+  abortAutosavePathChange: vi.fn(),
+  beginAutosavePathChange: vi.fn(),
+  commitAutosavePathChange: vi.fn(),
+  flushPendingAutosave: vi.fn(),
+  getPendingAutosaveNoteId: vi.fn(),
+}));
+
+vi.mock('@/lib/fileSystem', () => fileSystem);
+vi.mock('@/lib/autosaveFlush', () => autosave);
+
+const oldFile: NoteFile = {
+  name: 'Draft.md',
+  path: 'notes/Draft.md',
+  isDaily: false,
+  isWeekly: false,
+  isLocked: false,
+};
+const openNote: Note = {
+  id: oldFile.path,
+  title: 'Draft',
+  content: '<p>Latest body</p>',
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  isDaily: false,
+  isWeekly: false,
+  isPinned: true,
+};
+const movedFile: NoteFile = {
+  ...oldFile,
+  name: 'Draft (2).md',
+  path: 'notes/Projects/Draft (2).md',
+  folderPath: 'Projects',
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.clearAllMocks();
+  fileSystem.listFolders.mockResolvedValue([]);
+  fileSystem.listNotes.mockResolvedValue([movedFile]);
+  fileSystem.moveNote.mockResolvedValue(movedFile.path);
+  autosave.flushPendingAutosave.mockResolvedValue(undefined);
+  autosave.acquireAutosavePathChange.mockResolvedValue(vi.fn());
+  autosave.getPendingAutosaveNoteId.mockReturnValue(null);
+  autosave.abortAutosavePathChange.mockResolvedValue(undefined);
+  autosave.commitAutosavePathChange.mockResolvedValue(undefined);
+  useNoteStore.setState({
+    notes: [oldFile],
+    openTabs: [openNote],
+    activeTabId: oldFile.path,
+    currentNote: openNote,
+    recentNoteIds: [oldFile.path],
+    unlockedNotes: new Set(),
+    externallyChanged: new Map(),
+    isLoading: false,
+    isSaving: false,
+  });
+  useNoteColorsStore.setState({ colors: { [oldFile.path]: 'cosmos' }, isLoading: false });
+  useNoteSelectionStore.setState({ selectedIds: new Set([oldFile.path]) });
+  useQuickSwitcherStore.setState({ pinnedNoteIds: [oldFile.path] });
+  useSidebarOrderStore.setState({ noteOrder: [oldFile.path], folderOrder: [] });
+  useWordPressStore.setState({ postsByNote: { [`42:${oldFile.path}`]: 99 } });
+  useToastStore.setState({ toasts: [] });
+});
+
+describe('useFolders note moves', () => {
+  it('settles autosave and migrates every path-keyed reference to the returned path', async () => {
+    const { result } = renderHook(() => useFolders());
+
+    await act(() => result.current.moveNoteToFolder('Draft.md', 'Projects'));
+
+    expect(autosave.flushPendingAutosave).toHaveBeenCalledOnce();
+    expect(fileSystem.moveNote).toHaveBeenCalledWith('Draft.md', 'Projects');
+    expect(autosave.beginAutosavePathChange).toHaveBeenCalledWith(oldFile.path);
+    expect(autosave.commitAutosavePathChange).toHaveBeenCalledWith(oldFile.path, movedFile.path);
+    expect(autosave.flushPendingAutosave.mock.invocationCallOrder[0]).toBeLessThan(
+      fileSystem.moveNote.mock.invocationCallOrder[0]
+    );
+
+    const state = useNoteStore.getState();
+    expect(state.notes).toEqual([movedFile]);
+    expect(state.openTabs[0]).toMatchObject({ id: movedFile.path, title: 'Draft (2)' });
+    expect(state.currentNote).toBe(state.openTabs[0]);
+    expect(state.activeTabId).toBe(movedFile.path);
+    expect(state.recentNoteIds).toEqual([movedFile.path]);
+    expect(useNoteColorsStore.getState().colors).toEqual({ [movedFile.path]: 'cosmos' });
+    expect([...useNoteSelectionStore.getState().selectedIds]).toEqual([movedFile.path]);
+    expect(useQuickSwitcherStore.getState().pinnedNoteIds).toEqual([movedFile.path]);
+    expect(useSidebarOrderStore.getState().noteOrder).toEqual([movedFile.path]);
+    expect(useWordPressStore.getState().postsByNote).toEqual({ [`42:${movedFile.path}`]: 99 });
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts[toasts.length - 1]).toMatchObject({
+      type: 'success',
+      message: 'Note moved',
+    });
+  });
+
+  it('does not move a note whose pending autosave failed to settle', async () => {
+    autosave.getPendingAutosaveNoteId.mockReturnValue(oldFile.path);
+    const { result } = renderHook(() => useFolders());
+
+    await expect(
+      act(() => result.current.moveNoteToFolder('notes/Draft.md', 'Projects'))
+    ).rejects.toThrow('Save pending changes before moving a note');
+
+    expect(fileSystem.moveNote).not.toHaveBeenCalled();
+    expect(useNoteStore.getState().currentNote?.id).toBe(oldFile.path);
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts[toasts.length - 1]).toMatchObject({ type: 'error' });
+  });
+
+  it('resumes the old autosave address when the disk move fails', async () => {
+    fileSystem.moveNote.mockRejectedValue(new Error('move failed'));
+    const { result } = renderHook(() => useFolders());
+
+    await expect(
+      act(() => result.current.moveNoteToFolder('Draft.md', 'Projects'))
+    ).rejects.toThrow('move failed');
+
+    expect(autosave.abortAutosavePathChange).toHaveBeenCalledWith(oldFile.path);
+    expect(autosave.commitAutosavePathChange).not.toHaveBeenCalled();
+    expect(useNoteStore.getState().currentNote?.id).toBe(oldFile.path);
+  });
+
+  it('keeps a committed move successful when the list refresh fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fileSystem.listNotes.mockRejectedValue(new Error('refresh failed'));
+    const { result } = renderHook(() => useFolders());
+
+    await expect(act(() => result.current.moveNoteToFolder('Draft.md', 'Projects'))).resolves.toBe(
+      movedFile.path
+    );
+
+    expect(useNoteStore.getState().currentNote?.id).toBe(movedFile.path);
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts[toasts.length - 1]).toMatchObject({ type: 'success', message: 'Note moved' });
+    consoleError.mockRestore();
+  });
+});

--- a/src/hooks/useFolders.ts
+++ b/src/hooks/useFolders.ts
@@ -5,7 +5,14 @@
  */
 
 import { useCallback } from 'react';
-import { useFolderStore, useNoteStore } from '@/stores';
+import {
+  useFolderStore,
+  useNoteColorsStore,
+  useNoteSelectionStore,
+  useNoteStore,
+  useQuickSwitcherStore,
+  useSidebarOrderStore,
+} from '@/stores';
 import {
   listFolders,
   createFolder as createFolderApi,
@@ -15,6 +22,15 @@ import {
   moveFolder as moveFolderApi,
   listNotes,
 } from '@/lib/fileSystem';
+import {
+  acquireAutosavePathChange,
+  abortAutosavePathChange,
+  beginAutosavePathChange,
+  commitAutosavePathChange,
+  flushPendingAutosave,
+  getPendingAutosaveNoteId,
+} from '@/lib/autosaveFlush';
+import { useWordPressStore } from '@/stores/wordpressStore';
 import { useToast } from './useToast';
 
 export function useFolders() {
@@ -121,16 +137,62 @@ export function useFolders() {
    */
   const moveNoteToFolder = useCallback(
     async (notePath: string, toFolder?: string) => {
+      let heldAutosavePath: string | null = null;
+      const releasePathChange = await acquireAutosavePathChange();
       try {
-        const newPath = await moveNoteApi(notePath, toFolder);
-        // Refresh notes to reflect new paths
-        const notes = await listNotes();
-        setNotes(notes);
+        const oldPath = notePath.startsWith('notes/') ? notePath : `notes/${notePath}`;
+        const backendPath = oldPath.slice('notes/'.length);
+
+        await flushPendingAutosave();
+        if (getPendingAutosaveNoteId() !== null) {
+          throw new Error('Save pending changes before moving a note');
+        }
+        if (useNoteStore.getState().currentNote?.id === oldPath) {
+          beginAutosavePathChange(oldPath);
+          heldAutosavePath = oldPath;
+        }
+
+        const newPath = await moveNoteApi(backendPath, toFolder);
+        if (newPath !== oldPath) {
+          const newName = newPath.split('/').pop() || newPath;
+          const newTitle = newName.replace(/\.md$/, '');
+          useNoteStore.getState().renameNoteReferences(oldPath, newPath, newTitle);
+        }
+        if (heldAutosavePath) {
+          const committingPath = heldAutosavePath;
+          heldAutosavePath = null;
+          await commitAutosavePathChange(committingPath, newPath).catch((error) => {
+            console.error('[useFolders] Failed to save an edit made during move:', error);
+          });
+        }
+        if (newPath !== oldPath) {
+          try {
+            useNoteColorsStore.getState().renameColor(oldPath, newPath);
+            useNoteSelectionStore.getState().rename(oldPath, newPath);
+            useQuickSwitcherStore.getState().renamePinnedNote(oldPath, newPath);
+            useSidebarOrderStore.getState().renameNote(oldPath, newPath);
+            useWordPressStore.getState().notePathChanged(oldPath, newPath);
+          } catch (error) {
+            console.error('[useFolders] Failed to migrate secondary note references:', error);
+          }
+        }
+        // The move is already committed and renameNoteReferences carries enough
+        // metadata to keep the sidebar coherent if this best-effort refresh fails.
+        try {
+          setNotes(await listNotes());
+        } catch (error) {
+          console.error('[useFolders] Failed to refresh notes after move:', error);
+        }
         toast.success('Note moved');
         return newPath;
       } catch (error) {
+        if (heldAutosavePath) {
+          await abortAutosavePathChange(heldAutosavePath).catch(() => {});
+        }
         toast.error(String(error));
         throw error;
+      } finally {
+        releasePathChange();
       }
     },
     [setNotes, toast]

--- a/src/hooks/useNotes.externalWrites.test.tsx
+++ b/src/hooks/useNotes.externalWrites.test.tsx
@@ -1,11 +1,21 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getLastPersistedMarkdown, readNoteWithMeta } from '@/lib/fileSystem';
-import { getPendingAutosaveNoteId } from '@/lib/autosaveFlush';
+import {
+  beginAutosavePathChange,
+  commitAutosavePathChange,
+  flushPendingAutosave,
+  getPendingAutosaveNoteId,
+} from '@/lib/autosaveFlush';
 import { useForgeStore } from '@/stores/forgeStore';
+import { useNoteColorsStore } from '@/stores/noteColorsStore';
+import { useNoteSelectionStore } from '@/stores/noteSelectionStore';
 import { useNoteStore } from '@/stores/noteStore';
+import { useQuickSwitcherStore } from '@/stores/quickSwitcherStore';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { useSidebarOrderStore } from '@/stores/sidebarOrderStore';
 import { useTemplateStore } from '@/stores/templateStore';
+import { useWordPressStore } from '@/stores/wordpressStore';
 import type { Note, NoteFile } from '@/types';
 
 const invokeMock = vi.fn();
@@ -15,7 +25,8 @@ vi.mock('@/lib/ipc', () => ({
 }));
 
 import { useNotes } from './useNotes';
-import { useAutoSave } from './useAutoSave';
+import { discardPendingAutosaveForNote, useAutoSave } from './useAutoSave';
+import { useTrash } from './useTrash';
 
 beforeEach(() => {
   localStorage.clear();
@@ -26,6 +37,8 @@ beforeEach(() => {
       return { content: '', color: null, contentHash: 'empty-hash' };
     }
     if (command === 'create_note') return 'created.md';
+    if (command === 'list_trash') return [];
+    if (command === 'trash_note') return 'trash-1';
     return undefined;
   });
   useTemplateStore.setState({ defaultDailyTemplate: null });
@@ -237,5 +250,384 @@ describe('useNotes external-write bases', () => {
     expect(state.openTabs.map((tab) => tab.id)).toEqual([survivor.id]);
     expect(state.activeTabId).toBe(survivor.id);
     expect(state.currentNote?.id).toBe(survivor.id);
+  });
+
+  it('readdresses edits made while an active note is moving', async () => {
+    const note: Note = {
+      id: 'notes/moving.md',
+      title: 'moving',
+      content: '<p>saved body</p>',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      isDaily: false,
+      isWeekly: false,
+    };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'write_note') {
+        return { contentHash: 'moved-write', conflictCopy: null };
+      }
+      return undefined;
+    });
+    const hook = renderHook(() => useAutoSave());
+
+    act(() => {
+      useNoteStore.setState({
+        notes: [],
+        openTabs: [note],
+        activeTabId: note.id,
+        currentNote: note,
+      });
+    });
+    beginAutosavePathChange(note.id);
+    act(() => {
+      useNoteStore.getState().updateNoteContent('<p>edit during move</p>', note.id);
+    });
+    await waitFor(() => expect(getPendingAutosaveNoteId()).toBe(note.id));
+
+    const newId = 'notes/Projects/moving.md';
+    act(() => useNoteStore.getState().renameNoteReferences(note.id, newId, 'moving'));
+    await act(() => commitAutosavePathChange(note.id, newId));
+    hook.unmount();
+
+    const writes = invokeMock.mock.calls.filter(([command]) => command === 'write_note');
+    expect(writes).toHaveLength(1);
+    expect(writes[0][1]).toMatchObject({
+      filename: 'Projects/moving.md',
+      content: 'edit during move',
+    });
+    expect(getPendingAutosaveNoteId()).toBeNull();
+  });
+
+  it('keeps the moved edit separate when another note is edited during the move', async () => {
+    const moving: Note = {
+      id: 'notes/moving-and-switching.md',
+      title: 'moving-and-switching',
+      content: '<p>saved moving body</p>',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      isDaily: false,
+      isWeekly: false,
+    };
+    const other: Note = {
+      ...moving,
+      id: 'notes/other.md',
+      title: 'other',
+      content: '<p>saved other body</p>',
+    };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'write_note') {
+        return { contentHash: 'write-hash', conflictCopy: null };
+      }
+      return undefined;
+    });
+    const hook = renderHook(() => useAutoSave());
+
+    act(() => {
+      useNoteStore.setState({
+        notes: [],
+        openTabs: [moving, other],
+        activeTabId: moving.id,
+        currentNote: moving,
+      });
+    });
+    beginAutosavePathChange(moving.id);
+    act(() => {
+      useNoteStore.getState().updateNoteContent('<p>moving edit</p>', moving.id);
+    });
+    await waitFor(() => expect(getPendingAutosaveNoteId()).toBe(moving.id));
+
+    act(() => useNoteStore.getState().switchTab(other.id));
+    act(() => {
+      useNoteStore.getState().updateNoteContent('<p>other edit</p>', other.id);
+    });
+    const newId = 'notes/Projects/moving-and-switching.md';
+    act(() => useNoteStore.getState().renameNoteReferences(moving.id, newId, moving.title));
+    await act(() => commitAutosavePathChange(moving.id, newId));
+
+    expect(getPendingAutosaveNoteId()).toBe(other.id);
+    await act(() => flushPendingAutosave());
+    hook.unmount();
+
+    const writes = invokeMock.mock.calls
+      .filter(([command]) => command === 'write_note')
+      .map(([, args]) => args as Record<string, unknown>);
+    expect(writes).toEqual([
+      expect.objectContaining({
+        filename: 'Projects/moving-and-switching.md',
+        content: 'moving edit',
+      }),
+      expect.objectContaining({ filename: 'other.md', content: 'other edit' }),
+    ]);
+  });
+
+  it('keeps a moved edit pending when its first destination save fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const moving: Note = {
+      id: 'notes/retry-move.md',
+      title: 'retry-move',
+      content: '<p>saved body</p>',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      isDaily: false,
+      isWeekly: false,
+    };
+    let failWrite = true;
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'write_note') {
+        if (failWrite) throw new Error('disk full');
+        return { contentHash: 'retry-hash', conflictCopy: null };
+      }
+      return undefined;
+    });
+    const hook = renderHook(() => useAutoSave());
+
+    act(() => {
+      useNoteStore.setState({
+        openTabs: [moving],
+        activeTabId: moving.id,
+        currentNote: moving,
+      });
+    });
+    beginAutosavePathChange(moving.id);
+    act(() => {
+      useNoteStore.getState().updateNoteContent('<p>must retry</p>', moving.id);
+    });
+    const newId = 'notes/Projects/retry-move.md';
+    act(() => useNoteStore.getState().renameNoteReferences(moving.id, newId, moving.title));
+
+    await expect(act(() => commitAutosavePathChange(moving.id, newId))).rejects.toThrow(
+      'disk full'
+    );
+    expect(getPendingAutosaveNoteId()).toBe(newId);
+
+    failWrite = false;
+    await act(() => flushPendingAutosave());
+    hook.unmount();
+    consoleError.mockRestore();
+
+    expect(getPendingAutosaveNoteId()).toBeNull();
+    const writes = invokeMock.mock.calls.filter(([command]) => command === 'write_note');
+    expect(writes).toHaveLength(2);
+    expect(writes[1][1]).toMatchObject({
+      filename: 'Projects/retry-move.md',
+      content: 'must retry',
+    });
+  });
+
+  it('discards a held moved edit after the note is explicitly deleted', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const moving: Note = {
+      id: 'notes/delete-after-move.md',
+      title: 'delete-after-move',
+      content: '<p>saved body</p>',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      isDaily: false,
+      isWeekly: false,
+    };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'write_note') throw new Error('disk full');
+      return undefined;
+    });
+    const hook = renderHook(() => useAutoSave());
+
+    act(() => {
+      useNoteStore.setState({
+        openTabs: [moving],
+        activeTabId: moving.id,
+        currentNote: moving,
+      });
+    });
+    beginAutosavePathChange(moving.id);
+    act(() => {
+      useNoteStore.getState().updateNoteContent('<p>delete me</p>', moving.id);
+    });
+    const newId = 'notes/Projects/delete-after-move.md';
+    act(() => useNoteStore.getState().renameNoteReferences(moving.id, newId, moving.title));
+    await expect(act(() => commitAutosavePathChange(moving.id, newId))).rejects.toThrow(
+      'disk full'
+    );
+
+    discardPendingAutosaveForNote(newId, '<p>delete me</p>');
+    await act(() => flushPendingAutosave());
+    hook.unmount();
+    consoleError.mockRestore();
+
+    expect(getPendingAutosaveNoteId()).toBeNull();
+    expect(invokeMock.mock.calls.filter(([command]) => command === 'write_note')).toHaveLength(1);
+  });
+
+  it('does not trash a note whose moved edit still cannot be saved', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const moving: Note = {
+      id: 'notes/trash-after-move.md',
+      title: 'trash-after-move',
+      content: '<p>saved body</p>',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      isDaily: false,
+      isWeekly: false,
+    };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'write_note') throw new Error('disk full');
+      if (command === 'list_notes' || command === 'list_trash') return [];
+      return undefined;
+    });
+    const hook = renderHook(() => {
+      useAutoSave();
+      return useTrash();
+    });
+
+    act(() => {
+      useNoteStore.setState({
+        openTabs: [moving],
+        activeTabId: moving.id,
+        currentNote: moving,
+      });
+    });
+    beginAutosavePathChange(moving.id);
+    act(() => {
+      useNoteStore.getState().updateNoteContent('<p>trash me</p>', moving.id);
+    });
+    const newId = 'notes/Projects/trash-after-move.md';
+    act(() => useNoteStore.getState().renameNoteReferences(moving.id, newId, moving.title));
+    await expect(act(() => commitAutosavePathChange(moving.id, newId))).rejects.toThrow(
+      'disk full'
+    );
+
+    await expect(
+      act(() => hook.result.current.trashNote('Projects/trash-after-move.md', false))
+    ).rejects.toThrow('Save pending changes before moving a note to trash');
+    expect(getPendingAutosaveNoteId()).toBe(newId);
+    hook.unmount();
+    consoleError.mockRestore();
+
+    expect(useNoteStore.getState().openTabs).toHaveLength(1);
+    expect(invokeMock.mock.calls.filter(([command]) => command === 'write_note')).toHaveLength(2);
+    expect(invokeMock.mock.calls.some(([command]) => command === 'trash_note')).toBe(false);
+  });
+
+  it('keeps the saved tab when trashing the note fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const note: Note = {
+      id: 'notes/failed-trash.md',
+      title: 'failed-trash',
+      content: '<p>saved body</p>',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      isDaily: false,
+      isWeekly: false,
+    };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'trash_note') throw new Error('trash unavailable');
+      if (command === 'write_note')
+        return { contentHash: 'saved-before-trash', conflictCopy: null };
+      return undefined;
+    });
+    const hook = renderHook(() => {
+      useAutoSave();
+      return useTrash();
+    });
+
+    act(() => {
+      useNoteStore.setState({
+        openTabs: [note],
+        activeTabId: note.id,
+        currentNote: note,
+      });
+    });
+    act(() => {
+      useNoteStore.getState().updateNoteContent('<p>unsaved edit</p>', note.id);
+    });
+    await waitFor(() => expect(getPendingAutosaveNoteId()).toBe(note.id));
+
+    await expect(
+      act(() => hook.result.current.trashNote('failed-trash.md', false))
+    ).rejects.toThrow('trash unavailable');
+    expect(getPendingAutosaveNoteId()).toBeNull();
+    hook.unmount();
+    consoleError.mockRestore();
+
+    expect(useNoteStore.getState().openTabs.map((tab) => tab.id)).toEqual([note.id]);
+    expect(useNoteStore.getState().currentNote?.content).toBe('<p>unsaved edit</p>');
+  });
+
+  it('forgets every path-keyed reference after trash succeeds', async () => {
+    const note: Note = {
+      id: 'notes/trash-cleanup.md',
+      title: 'trash-cleanup',
+      content: '<p>saved body</p>',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      isDaily: false,
+      isWeekly: false,
+    };
+    const noteFile: NoteFile = {
+      name: 'trash-cleanup.md',
+      path: note.id,
+      isDaily: false,
+      isWeekly: false,
+      isLocked: false,
+    };
+    useNoteStore.setState({
+      notes: [noteFile],
+      openTabs: [note],
+      activeTabId: note.id,
+      currentNote: note,
+      recentNoteIds: [note.id],
+      unlockedNotes: new Set([note.id]),
+    });
+    useNoteColorsStore.setState({ colors: { [note.id]: 'cosmos' } });
+    useNoteSelectionStore.setState({ selectedIds: new Set([note.id]) });
+    useQuickSwitcherStore.setState({ pinnedNoteIds: [note.id] });
+    useSidebarOrderStore.setState({ noteOrder: [note.id] });
+    useWordPressStore.setState({
+      postsByNote: { [`7:${note.id}`]: 42 },
+      trashedPostsById: {},
+    });
+    const hook = renderHook(() => {
+      useAutoSave();
+      return useTrash();
+    });
+
+    await act(() => hook.result.current.trashNote('trash-cleanup.md', false));
+
+    expect(useNoteStore.getState()).toMatchObject({
+      notes: [],
+      openTabs: [],
+      activeTabId: null,
+      currentNote: null,
+      recentNoteIds: [],
+    });
+    expect(useNoteStore.getState().unlockedNotes.has(note.id)).toBe(false);
+    expect(useNoteColorsStore.getState().colors[note.id]).toBeUndefined();
+    expect(useNoteSelectionStore.getState().selectedIds.has(note.id)).toBe(false);
+    expect(useQuickSwitcherStore.getState().pinnedNoteIds).not.toContain(note.id);
+    expect(useSidebarOrderStore.getState().noteOrder).not.toContain(note.id);
+    expect(useWordPressStore.getState().postsByNote).toEqual({});
+    expect(useWordPressStore.getState().trashedPostsById).toEqual({
+      'trash-1': { [`7:${note.id}`]: 42 },
+    });
+  });
+
+  it('forgets WordPress mappings for expired trash items', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'cleanup_old_trash') return ['expired-trash'];
+      if (command === 'list_trash') return [];
+      return undefined;
+    });
+    useWordPressStore.setState({
+      trashedPostsById: {
+        'expired-trash': { '7:notes/expired.md': 42 },
+        'fresh-trash': { '7:notes/fresh.md': 43 },
+      },
+    });
+    const hook = renderHook(() => useTrash());
+
+    await act(() => hook.result.current.cleanupOld());
+
+    expect(useWordPressStore.getState().trashedPostsById).toEqual({
+      'fresh-trash': { '7:notes/fresh.md': 43 },
+    });
   });
 });

--- a/src/hooks/useNotes.rename.test.tsx
+++ b/src/hooks/useNotes.rename.test.tsx
@@ -6,6 +6,7 @@ import { useNoteColorsStore } from '@/stores/noteColorsStore';
 import { useNoteSelectionStore } from '@/stores/noteSelectionStore';
 import { useNoteStore } from '@/stores/noteStore';
 import { useQuickSwitcherStore } from '@/stores/quickSwitcherStore';
+import { useSidebarOrderStore } from '@/stores/sidebarOrderStore';
 import { useToastStore } from '@/stores/toastStore';
 import type { Note, NoteFile } from '@/types';
 
@@ -59,6 +60,7 @@ beforeEach(() => {
   useNoteColorsStore.setState({ colors: {}, isLoading: false });
   useNoteSelectionStore.setState({ selectedIds: new Set() });
   useQuickSwitcherStore.setState({ pinnedNoteIds: [], recentSearches: [], isOpen: false });
+  useSidebarOrderStore.setState({ noteOrder: [], folderOrder: [] });
   useToastStore.setState({ toasts: [] });
 });
 
@@ -82,6 +84,7 @@ describe('useNotes rename', () => {
     useNoteColorsStore.setState({ colors: { [file.path]: 'purple' } });
     useNoteSelectionStore.setState({ selectedIds: new Set([file.path]) });
     useQuickSwitcherStore.setState({ pinnedNoteIds: [file.path] });
+    useSidebarOrderStore.setState({ noteOrder: [file.path, 'notes/Other.md'] });
 
     await act(() => hook.result.current.renameNote(file, 'New title'));
 
@@ -101,6 +104,10 @@ describe('useNotes rename', () => {
     expect(useNoteColorsStore.getState().colors).toEqual({ 'notes/New title.md': 'purple' });
     expect([...useNoteSelectionStore.getState().selectedIds]).toEqual(['notes/New title.md']);
     expect(useQuickSwitcherStore.getState().pinnedNoteIds).toEqual(['notes/New title.md']);
+    expect(useSidebarOrderStore.getState().noteOrder).toEqual([
+      'notes/New title.md',
+      'notes/Other.md',
+    ]);
     expect(useToastStore.getState().toasts[0]).toMatchObject({
       type: 'success',
       message: 'Renamed — inbound links updated',

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -14,6 +14,7 @@ import {
   useNoteSelectionStore,
   useNoteStore,
   useQuickSwitcherStore,
+  useSidebarOrderStore,
   useTemplateStore,
   useTaskStatusStore,
   useToastStore,
@@ -45,6 +46,14 @@ import {
 import type { NoteFile } from '@/types';
 import { format, getISOWeek, getISOWeekYear } from 'date-fns';
 import { cancelPendingAutosaveDebounceForNote, discardPendingAutosaveForNote } from './useAutoSave';
+import {
+  acquireAutosavePathChange,
+  abortAutosavePathChange,
+  beginAutosavePathChange,
+  commitAutosavePathChange,
+  flushPendingAutosave,
+  getPendingAutosaveNoteId,
+} from '@/lib/autosaveFlush';
 
 /**
  * Manages note operations including loading, creating, and deleting notes.
@@ -547,25 +556,45 @@ export function useNotes() {
 
       if (newPath === oldPath) return;
 
+      const releasePathChange = await acquireAutosavePathChange();
+      let heldAutosavePath: string | null = null;
       try {
+        await flushPendingAutosave();
+        if (getPendingAutosaveNoteId() !== null) {
+          throw new Error('Save pending changes before renaming a note');
+        }
         if (getState().currentNote?.id === oldPath) {
-          await flushCurrentNote();
+          beginAutosavePathChange(oldPath);
+          heldAutosavePath = oldPath;
         }
         await renameNoteFile(oldFilename, newFilename, false, false);
 
         useNoteStore.getState().renameNoteReferences(oldPath, newPath, newTitle);
+        if (heldAutosavePath) {
+          const committingPath = heldAutosavePath;
+          heldAutosavePath = null;
+          await commitAutosavePathChange(committingPath, newPath).catch((error) => {
+            console.error('[useNotes] Failed to save an edit made during rename:', error);
+          });
+        }
         useNoteColorsStore.getState().renameColor(oldPath, newPath);
         useNoteSelectionStore.getState().rename(oldPath, newPath);
         useQuickSwitcherStore.getState().renamePinnedNote(oldPath, newPath);
+        useSidebarOrderStore.getState().renameNote(oldPath, newPath);
         useWordPressStore.getState().notePathChanged(oldPath, newPath);
         useToastStore.getState().addToast('success', 'Renamed — inbound links updated');
       } catch (error) {
+        if (heldAutosavePath) {
+          await abortAutosavePathChange(heldAutosavePath).catch(() => {});
+        }
         const message = error instanceof Error ? error.message : String(error);
         useToastStore.getState().addToast('error', message);
         throw error;
+      } finally {
+        releasePathChange();
       }
     },
-    [flushCurrentNote, getState]
+    [getState]
   );
 
   /**

--- a/src/hooks/useSidebarDnd.test.tsx
+++ b/src/hooks/useSidebarDnd.test.tsx
@@ -1,0 +1,139 @@
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useSidebarDnd } from './useSidebarDnd';
+import { DraggableNoteItem } from '@/components/sidebar/DraggableNoteItem';
+import { FolderItem } from '@/components/sidebar/FolderItem';
+import type { FolderInfo, NoteFile } from '@/types';
+
+function dropEvent(data: Record<string, string>) {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer: {
+      types: Object.keys(data),
+      dropEffect: 'none',
+      getData: (type: string) => data[type] ?? '',
+    },
+  } as unknown as React.DragEvent;
+}
+
+describe('useSidebarDnd', () => {
+  it('ignores external plain text dropped on the Notes root', async () => {
+    const moveNoteToFolder = vi.fn();
+    const { result } = renderHook(() =>
+      useSidebarDnd({ moveNoteToFolder, moveFolderToFolder: vi.fn() })
+    );
+    const event = dropEvent({ 'text/plain': 'Projects/real-note.md' });
+
+    await act(() => result.current.onRootDrop(event));
+
+    expect(moveNoteToFolder).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('ignores a forged note MIME payload without a live sidebar drag', async () => {
+    const moveNoteToFolder = vi.fn();
+    const { result } = renderHook(() =>
+      useSidebarDnd({ moveNoteToFolder, moveFolderToFolder: vi.fn() })
+    );
+    const event = dropEvent({ 'application/x-note-path': 'Projects/note.md' });
+
+    await act(() => result.current.onRootDrop(event));
+
+    expect(moveNoteToFolder).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('moves only a live internal nested note and contains a handled rejection', async () => {
+    const moveNoteToFolder = vi.fn().mockRejectedValue(new Error('move failed'));
+    const { result } = renderHook(() =>
+      useSidebarDnd({ moveNoteToFolder, moveFolderToFolder: vi.fn() })
+    );
+    const note: NoteFile = {
+      name: 'note.md',
+      path: 'notes/Projects/note.md',
+      folderPath: 'Projects',
+      isDaily: false,
+      isWeekly: false,
+      isLocked: false,
+    };
+    render(
+      <DraggableNoteItem note={note} isActive={false} onClick={vi.fn()} onContextMenu={vi.fn()} />
+    );
+    const dragData = new Map<string, string>();
+    const sourceTransfer = {
+      types: [] as string[],
+      effectAllowed: '',
+      setData(type: string, value: string) {
+        dragData.set(type, value);
+        if (!this.types.includes(type)) this.types.push(type);
+      },
+      getData: (type: string) => dragData.get(type) ?? '',
+    };
+    const source = screen.getByRole('button', { name: 'note' }).parentElement as HTMLElement;
+    fireEvent.dragStart(source, { dataTransfer: sourceTransfer });
+    const event = dropEvent(Object.fromEntries(dragData));
+
+    await act(() => result.current.onRootDrop(event));
+
+    expect(moveNoteToFolder).toHaveBeenCalledWith('Projects/note.md', undefined);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(event.stopPropagation).toHaveBeenCalledOnce();
+    fireEvent.dragEnd(source, { dataTransfer: sourceTransfer });
+  });
+
+  it('ignores a forged folder MIME payload at the folders root', async () => {
+    const moveFolderToFolder = vi.fn();
+    const { result } = renderHook(() =>
+      useSidebarDnd({ moveNoteToFolder: vi.fn(), moveFolderToFolder })
+    );
+    const event = dropEvent({ 'application/x-folder-path': 'Projects/Archive' });
+
+    await act(() => result.current.onFoldersRootDrop(event));
+
+    expect(moveFolderToFolder).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('moves a live nested folder to the folders root', async () => {
+    const moveFolderToFolder = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useSidebarDnd({ moveNoteToFolder: vi.fn(), moveFolderToFolder })
+    );
+    const folder: FolderInfo = { name: 'Archive', path: 'Projects/Archive', children: [] };
+    render(
+      <FolderItem
+        folder={folder}
+        level={1}
+        isExpanded={false}
+        onToggle={vi.fn()}
+        onContextMenu={vi.fn()}
+        onNoteDrop={vi.fn()}
+        onFolderDrop={vi.fn()}
+        notes={[]}
+        isNoteActive={() => false}
+        onNoteClick={vi.fn()}
+        onNoteContextMenu={vi.fn()}
+      />
+    );
+    const dragData = new Map<string, string>();
+    const sourceTransfer = {
+      types: [] as string[],
+      effectAllowed: '',
+      setData(type: string, value: string) {
+        dragData.set(type, value);
+        if (!this.types.includes(type)) this.types.push(type);
+      },
+      getData: (type: string) => dragData.get(type) ?? '',
+    };
+    const source = screen.getByText('Archive').closest('.folder-row') as HTMLElement;
+    fireEvent.dragStart(source, { dataTransfer: sourceTransfer });
+    const event = dropEvent(Object.fromEntries(dragData));
+
+    await act(() => result.current.onFoldersRootDrop(event));
+
+    expect(moveFolderToFolder).toHaveBeenCalledWith(folder.path, undefined);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    fireEvent.dragEnd(source, { dataTransfer: sourceTransfer });
+  });
+});

--- a/src/hooks/useSidebarDnd.ts
+++ b/src/hooks/useSidebarDnd.ts
@@ -5,6 +5,8 @@
  */
 
 import { useRef, useState } from 'react';
+import { canDropDraggedNoteIntoRoot } from '@/components/sidebar/DraggableNoteItem';
+import { canDropDraggedFolderIntoRoot } from '@/components/sidebar/FolderItem';
 
 type MoveNote = (notePath: string, toFolder?: string) => Promise<unknown>;
 type MoveFolder = (folderPath: string, toFolder?: string) => Promise<unknown>;
@@ -32,80 +34,89 @@ export function useSidebarDnd({
 
   // Notes section — accepts notes only.
   const onRootDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    rootDragCounterRef.current++;
     const hasNoteData = e.dataTransfer.types.includes('application/x-note-path');
-    const hasTextData = e.dataTransfer.types.includes('text/plain');
     const hasFolderData = e.dataTransfer.types.includes('application/x-folder-path');
-    if ((hasNoteData || hasTextData) && !hasFolderData) {
+    if (hasNoteData && !hasFolderData && canDropDraggedNoteIntoRoot()) {
+      e.preventDefault();
+      rootDragCounterRef.current++;
       setIsDragOverRoot(true);
     }
   };
 
   const onRootDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
     const hasNoteData = e.dataTransfer.types.includes('application/x-note-path');
-    const hasTextData = e.dataTransfer.types.includes('text/plain');
     const hasFolderData = e.dataTransfer.types.includes('application/x-folder-path');
-    if ((hasNoteData || hasTextData) && !hasFolderData) {
+    if (hasNoteData && !hasFolderData && canDropDraggedNoteIntoRoot()) {
+      e.preventDefault();
       e.dataTransfer.dropEffect = 'move';
     }
   };
 
   const onRootDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
-    rootDragCounterRef.current--;
+    rootDragCounterRef.current = Math.max(0, rootDragCounterRef.current - 1);
     if (rootDragCounterRef.current === 0) {
       setIsDragOverRoot(false);
     }
   };
 
   const onRootDrop = async (e: React.DragEvent) => {
+    const hasNoteData = e.dataTransfer.types.includes('application/x-note-path');
+    const hasFolderData = e.dataTransfer.types.includes('application/x-folder-path');
+    if (!hasNoteData || hasFolderData || !canDropDraggedNoteIntoRoot()) return;
+
     e.preventDefault();
     e.stopPropagation();
     rootDragCounterRef.current = 0;
     setIsDragOverRoot(false);
 
-    const hasFolderData = e.dataTransfer.types.includes('application/x-folder-path');
-    if (hasFolderData) return;
-
-    let notePath = e.dataTransfer.getData('application/x-note-path');
-    if (!notePath) {
-      notePath = e.dataTransfer.getData('text/plain');
-    }
+    const notePath = e.dataTransfer.getData('application/x-note-path');
     // A note already at the root has nowhere to go — the backend treats this
     // as a no-op now, but skipping it also spares the pointless "Note moved"
     // toast and the note-list refresh behind it.
     if (notePath && notePath.includes('/')) {
-      await moveNoteToFolder(notePath, undefined);
+      try {
+        await moveNoteToFolder(notePath, undefined);
+      } catch {
+        // The move workflow owns its error toast.
+      }
     }
   };
 
   // Folders section — accepts folders only.
   const onFoldersRootDragEnter = (e: React.DragEvent) => {
+    if (
+      !e.dataTransfer.types.includes('application/x-folder-path') ||
+      !canDropDraggedFolderIntoRoot()
+    ) {
+      return;
+    }
     e.preventDefault();
     foldersRootDragCounterRef.current++;
-    if (e.dataTransfer.types.includes('application/x-folder-path')) {
-      setIsDragOverFoldersRoot(true);
-    }
+    setIsDragOverFoldersRoot(true);
   };
 
   const onFoldersRootDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-    if (e.dataTransfer.types.includes('application/x-folder-path')) {
-      e.dataTransfer.dropEffect = 'move';
+    if (
+      !e.dataTransfer.types.includes('application/x-folder-path') ||
+      !canDropDraggedFolderIntoRoot()
+    ) {
+      return;
     }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
   };
 
   const onFoldersRootDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
-    foldersRootDragCounterRef.current--;
+    foldersRootDragCounterRef.current = Math.max(0, foldersRootDragCounterRef.current - 1);
     if (foldersRootDragCounterRef.current === 0) {
       setIsDragOverFoldersRoot(false);
     }
   };
 
   const onFoldersRootDrop = async (e: React.DragEvent) => {
+    if (!canDropDraggedFolderIntoRoot()) return;
     e.preventDefault();
     e.stopPropagation();
     foldersRootDragCounterRef.current = 0;
@@ -113,7 +124,11 @@ export function useSidebarDnd({
 
     const folderPath = e.dataTransfer.getData('application/x-folder-path');
     if (folderPath) {
-      await moveFolderToFolder(folderPath, undefined);
+      try {
+        await moveFolderToFolder(folderPath, undefined);
+      } catch {
+        // The move workflow owns its error toast.
+      }
     }
   };
 

--- a/src/hooks/useTrash.ts
+++ b/src/hooks/useTrash.ts
@@ -5,7 +5,14 @@
  */
 
 import { useCallback } from 'react';
-import { useTrashStore, useNoteStore } from '@/stores';
+import {
+  useNoteColorsStore,
+  useNoteSelectionStore,
+  useNoteStore,
+  useQuickSwitcherStore,
+  useSidebarOrderStore,
+  useTrashStore,
+} from '@/stores';
 import {
   trashNote as trashNoteApi,
   trashFolder as trashFolderApi,
@@ -20,6 +27,32 @@ import {
 } from '@/lib/fileSystem';
 import { useFolderStore } from '@/stores/folderStore';
 import { useToast } from './useToast';
+import { discardPendingAutosaveForNote } from './useAutoSave';
+import {
+  acquireAutosavePathChange,
+  flushPendingAutosave,
+  getPendingAutosaveNoteId,
+} from '@/lib/autosaveFlush';
+import { useWordPressStore } from '@/stores/wordpressStore';
+import type { Note, NoteFile } from '@/types';
+
+function forgetTrashedNoteReferences(noteId: string): void {
+  useNoteStore.getState().forgetNoteReferences(noteId);
+  useNoteColorsStore.setState((state) => {
+    if (!(noteId in state.colors)) return state;
+    const { [noteId]: _removed, ...colors } = state.colors;
+    return { colors };
+  });
+  useNoteSelectionStore
+    .getState()
+    .replace([...useNoteSelectionStore.getState().selectedIds].filter((id) => id !== noteId));
+  if (useQuickSwitcherStore.getState().pinnedNoteIds.includes(noteId)) {
+    useQuickSwitcherStore.getState().togglePinned(noteId);
+  }
+  useSidebarOrderStore.setState((state) => ({
+    noteOrder: state.noteOrder.filter((id) => id !== noteId),
+  }));
+}
 
 export function useTrash() {
   const { trashedNotes, setTrashedNotes, setLoading, removeFromTrash } = useTrashStore();
@@ -49,11 +82,58 @@ export function useTrash() {
    * Moves a note to the trash.
    * @param filename - The note filename (relative path)
    * @param isDaily - Whether this is a daily note
+   * @param isWeekly - Whether this is a weekly note
    */
   const trashNote = useCallback(
-    async (filename: string, isDaily: boolean) => {
+    async (filename: string, isDaily: boolean, isWeekly: boolean = false) => {
+      const noteId = isDaily
+        ? `daily/${filename}`
+        : isWeekly
+          ? `weekly/${filename}`
+          : `notes/${filename}`;
+      let trashed = false;
+      let closedTab:
+        | {
+            note: Note;
+            index: number;
+            activate: boolean;
+            hadExternalChange: boolean;
+            externalClient: string | null;
+          }
+        | undefined;
+      let removedNoteFile: { note: NoteFile; index: number } | undefined;
+      const releasePathChange = await acquireAutosavePathChange();
+
       try {
-        await trashNoteApi(filename, isDaily);
+        await flushPendingAutosave();
+        if (getPendingAutosaveNoteId() !== null) {
+          throw new Error('Save pending changes before moving a note to trash');
+        }
+        const noteState = useNoteStore.getState();
+        const noteFileIndex = noteState.notes.findIndex((note) => note.path === noteId);
+        if (noteFileIndex >= 0) {
+          removedNoteFile = { note: noteState.notes[noteFileIndex], index: noteFileIndex };
+          useNoteStore.setState((state) => ({
+            notes: state.notes.filter((note) => note.path !== noteId),
+          }));
+        }
+        const tabIndex = noteState.openTabs.findIndex((note) => note.id === noteId);
+        const openNote = tabIndex >= 0 ? noteState.openTabs[tabIndex] : undefined;
+        if (openNote) {
+          closedTab = {
+            note: openNote,
+            index: tabIndex,
+            activate: noteState.activeTabId === noteId,
+            hadExternalChange: noteState.externallyChanged.has(noteId),
+            externalClient: noteState.externallyChanged.get(noteId) ?? null,
+          };
+          noteState.removeTabByPath(noteId);
+        }
+        const trashId = await trashNoteApi(filename, isDaily, isWeekly);
+        trashed = true;
+        discardPendingAutosaveForNote(noteId, closedTab?.note.content ?? '');
+        useWordPressStore.getState().noteTrashed(noteId, trashId);
+        forgetTrashedNoteReferences(noteId);
         // Refresh notes list
         const notes = await listNotes();
         setNotes(notes);
@@ -61,8 +141,31 @@ export function useTrash() {
         await loadTrash();
         toast.success('Note moved to trash');
       } catch (error) {
+        if (!trashed && closedTab) {
+          useNoteStore.getState().restoreTabAt(closedTab.note, closedTab.index, closedTab.activate);
+          if (closedTab.hadExternalChange) {
+            useNoteStore
+              .getState()
+              .markExternallyChanged(noteId, closedTab.externalClient ?? undefined);
+          }
+        }
+        if (!trashed && removedNoteFile) {
+          const noteFileToRestore = removedNoteFile;
+          useNoteStore.setState((state) => {
+            if (state.notes.some((note) => note.path === noteId)) return state;
+            const notes = [...state.notes];
+            notes.splice(
+              Math.min(Math.max(noteFileToRestore.index, 0), notes.length),
+              0,
+              noteFileToRestore.note
+            );
+            return { notes };
+          });
+        }
         toast.error(String(error));
         throw error;
+      } finally {
+        releasePathChange();
       }
     },
     [setNotes, loadTrash, toast]
@@ -75,8 +178,10 @@ export function useTrash() {
   const restoreNote = useCallback(
     async (trashId: string) => {
       try {
-        await restoreNoteApi(trashId);
+        const restoredPath = await restoreNoteApi(trashId);
+        useWordPressStore.getState().noteRestored(trashId, restoredPath);
         removeFromTrash(trashId);
+        await useNoteColorsStore.getState().loadColors();
         // Refresh notes list
         const notes = await listNotes();
         setNotes(notes);
@@ -97,6 +202,7 @@ export function useTrash() {
     async (trashId: string) => {
       try {
         await permanentlyDeleteTrash(trashId);
+        useWordPressStore.getState().forgetTrashedNote(trashId);
         removeFromTrash(trashId);
         toast.success('Note permanently deleted');
       } catch (error) {
@@ -113,6 +219,7 @@ export function useTrash() {
   const emptyTrash = useCallback(async () => {
     try {
       await emptyTrashApi();
+      useWordPressStore.getState().forgetAllTrashedNotes();
       setTrashedNotes([]);
       toast.success('Trash emptied');
     } catch (error) {
@@ -127,8 +234,11 @@ export function useTrash() {
    */
   const cleanupOld = useCallback(async () => {
     try {
-      const deletedCount = await cleanupOldTrash();
-      if (deletedCount > 0) {
+      const deletedIds = await cleanupOldTrash();
+      if (deletedIds.length > 0) {
+        for (const trashId of deletedIds) {
+          useWordPressStore.getState().forgetTrashedNote(trashId);
+        }
         await loadTrash();
       }
     } catch (error) {
@@ -170,6 +280,7 @@ export function useTrash() {
     async (trashId: string, noteFilename: string) => {
       try {
         await restoreNoteFromFolderApi(trashId, noteFilename);
+        await useNoteColorsStore.getState().loadColors();
         // Refresh trash list
         await loadTrash();
         // Refresh notes list

--- a/src/index.css
+++ b/src/index.css
@@ -1028,6 +1028,17 @@ time,
   color: var(--text-primary);
 }
 
+.draggable-note-item {
+  transition:
+    opacity var(--dur-micro) var(--ease-standard),
+    transform var(--dur-press) var(--ease-standard);
+}
+
+.draggable-note-item.sidebar-note-drag-source {
+  opacity: 0.52;
+  transform: scale(0.99);
+}
+
 .note-tag {
   color: var(--text-muted);
   font-size: 10px;
@@ -1053,6 +1064,49 @@ time,
   background: var(--hover-overlay);
   color: var(--text-primary);
   font-weight: 500;
+}
+
+.folder-row-note-drop-target,
+.folder-row-note-drop-target:hover {
+  background: transparent;
+  border-left-color: var(--text-primary);
+  color: var(--text-primary);
+  transform: translateX(2px);
+}
+
+.folder-row-note-drop-target::after {
+  position: absolute;
+  right: 4px;
+  bottom: 0;
+  left: 0;
+  height: 1px;
+  background: var(--border-strong);
+  content: '';
+  opacity: 0.78;
+  pointer-events: none;
+}
+
+@keyframes sidebar-folder-impact {
+  from {
+    opacity: 0.48;
+    transform: translate(-50%, -50%) scale(0.45);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.45);
+  }
+}
+
+.folder-note-drop-impact {
+  position: absolute;
+  top: 50%;
+  z-index: 1;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  pointer-events: none;
+  animation: sidebar-folder-impact var(--dur-slow) var(--ease-standard) both;
 }
 
 /* Sidebar rows sit inside 12px gutters. Pull the interactive band back out

--- a/src/lib/autosaveFlush.test.ts
+++ b/src/lib/autosaveFlush.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  acquireAutosavePathChange,
+  registerAutosaveCloseGuard,
+  registerAutosaveFlush,
+  registerAutosavePendingProbe,
+} from './autosaveFlush';
+
+function closeWindow() {
+  type CloseHandler = (event: { preventDefault: () => void }) => void | Promise<void>;
+  let handler: CloseHandler | undefined;
+  const destroy = vi.fn(async () => {});
+  return {
+    window: {
+      onCloseRequested: vi.fn(async (next: CloseHandler) => {
+        handler = next;
+        return () => {};
+      }),
+      destroy,
+    },
+    destroy,
+    requestClose: async () => {
+      const preventDefault = vi.fn();
+      await handler?.({ preventDefault });
+      return preventDefault;
+    },
+  };
+}
+
+describe('autosave close guard', () => {
+  it('waits for path changes before flushing and closing', async () => {
+    const releasePathChange = await acquireAutosavePathChange();
+    const flush = vi.fn(async () => {});
+    const unregisterFlush = registerAutosaveFlush(flush);
+    const unregisterProbe = registerAutosavePendingProbe(() => null);
+    const native = closeWindow();
+    await registerAutosaveCloseGuard(native.window);
+
+    const close = native.requestClose();
+    await Promise.resolve();
+    expect(flush).not.toHaveBeenCalled();
+    expect(native.destroy).not.toHaveBeenCalled();
+
+    releasePathChange();
+    const preventDefault = await close;
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(flush).toHaveBeenCalledOnce();
+    expect(native.destroy).toHaveBeenCalledOnce();
+    unregisterFlush();
+    unregisterProbe();
+  });
+
+  it('waits for structural work queued while close is already pending', async () => {
+    const releaseFirst = await acquireAutosavePathChange();
+    const flush = vi.fn(async () => {});
+    const unregisterFlush = registerAutosaveFlush(flush);
+    const unregisterProbe = registerAutosavePendingProbe(() => null);
+    const native = closeWindow();
+    await registerAutosaveCloseGuard(native.window);
+
+    const close = native.requestClose();
+    const secondPathChange = acquireAutosavePathChange();
+    releaseFirst();
+    const releaseSecond = await secondPathChange;
+    await Promise.resolve();
+    expect(native.destroy).not.toHaveBeenCalled();
+
+    releaseSecond();
+    await close;
+
+    expect(flush).toHaveBeenCalledTimes(2);
+    expect(native.destroy).toHaveBeenCalledOnce();
+    unregisterFlush();
+    unregisterProbe();
+  });
+
+  it('keeps the window open when a write remains pending', async () => {
+    const unregisterFlush = registerAutosaveFlush(async () => {});
+    const unregisterProbe = registerAutosavePendingProbe(() => 'notes/unsaved.md');
+    const native = closeWindow();
+    await registerAutosaveCloseGuard(native.window);
+
+    const preventDefault = await native.requestClose();
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(native.destroy).not.toHaveBeenCalled();
+    unregisterFlush();
+    unregisterProbe();
+  });
+});

--- a/src/lib/autosaveFlush.ts
+++ b/src/lib/autosaveFlush.ts
@@ -10,10 +10,58 @@
 type Flush = () => Promise<void>;
 type PendingProbe = () => string | null;
 type ResetBaseline = (noteId: string, content: string) => void;
+interface PathChangeController {
+  begin: (noteId: string) => void;
+  commit: (oldId: string, newId: string) => Promise<void>;
+  abort: (noteId: string) => Promise<void>;
+}
+interface AutosaveCloseWindow {
+  onCloseRequested: (
+    handler: (event: { preventDefault: () => void }) => void | Promise<void>
+  ) => Promise<() => void>;
+  destroy: () => Promise<void>;
+}
 
 let flush: Flush | null = null;
 let pendingProbe: PendingProbe | null = null;
 let resetBaseline: ResetBaseline | null = null;
+let pathChangeController: PathChangeController | null = null;
+let structuralChangeTail = Promise.resolve();
+
+/** Serialize operations that temporarily change or remove a note's disk address. */
+export async function acquireAutosavePathChange(): Promise<() => void> {
+  let release!: () => void;
+  const previous = structuralChangeTail;
+  structuralChangeTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  return release;
+}
+
+/** Prevent native close until structural work and every owed write have settled. */
+export function registerAutosaveCloseGuard(appWindow: AutosaveCloseWindow): Promise<() => void> {
+  let closing = false;
+  return appWindow.onCloseRequested(async (event) => {
+    event.preventDefault();
+    if (closing) return;
+    closing = true;
+    try {
+      while (true) {
+        const observedTail = structuralChangeTail;
+        await observedTail;
+        await flushPendingAutosave();
+        if (observedTail !== structuralChangeTail) continue;
+        if (getPendingAutosaveNoteId() === null) {
+          await appWindow.destroy();
+        }
+        break;
+      }
+    } finally {
+      closing = false;
+    }
+  });
+}
 
 /** Register the active flush. Returns an unregister function for cleanup. */
 export function registerAutosaveFlush(fn: Flush): () => void {
@@ -53,4 +101,26 @@ export function registerAutosaveBaselineReset(fn: ResetBaseline): () => void {
 
 export function resetAutosaveBaseline(noteId: string, content: string): void {
   resetBaseline?.(noteId, content);
+}
+
+export function registerAutosavePathChange(controller: PathChangeController): () => void {
+  pathChangeController = controller;
+  return () => {
+    if (pathChangeController === controller) pathChangeController = null;
+  };
+}
+
+/** Hold edits under an address while a structural move is in flight. */
+export function beginAutosavePathChange(noteId: string): void {
+  pathChangeController?.begin(noteId);
+}
+
+/** Readdress and persist any edit made while the file was moving. */
+export async function commitAutosavePathChange(oldId: string, newId: string): Promise<void> {
+  await pathChangeController?.commit(oldId, newId);
+}
+
+/** Resume the old address and persist held edits after a failed move. */
+export async function abortAutosavePathChange(noteId: string): Promise<void> {
+  await pathChangeController?.abort(noteId);
 }

--- a/src/lib/fileSystem.conflict.test.ts
+++ b/src/lib/fileSystem.conflict.test.ts
@@ -18,9 +18,12 @@ import {
   deleteNote,
   getLastPersistedMarkdown,
   lockNote,
+  LockedNoteWriteError,
+  moveNote,
   readNote,
   readNoteWithMeta,
   renameNote,
+  trashNote,
   writeNote,
   type NoteWriteResult,
 } from './fileSystem';
@@ -227,6 +230,127 @@ describe('external-edit conflict hash threading', () => {
 
     expect(commandsBeforeSaveSettled).toEqual(['write_note']);
     expect(commands).toEqual(['write_note', 'delete_note']);
+  });
+
+  it('preserves the conflict baseline under a moved note path', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'read_note') {
+        return { content: 'disk body', color: null, contentHash: 'move-base' };
+      }
+      if (command === 'move_note') return 'notes/Projects/moved.md';
+      return { contentHash: 'move-write', conflictCopy: null };
+    });
+
+    await readNote('moved.md', false, false);
+    await moveNote('moved.md', 'Projects');
+    await writeNote('Projects/moved.md', 'edited after move', false, false);
+
+    expect(lastCallArgs('write_note').baseHash).toBe('move-base');
+    expect(getLastPersistedMarkdown('moved.md', false, false)).toBeUndefined();
+    expect(getLastPersistedMarkdown('Projects/moved.md', false, false)).toBe('edited after move');
+  });
+
+  it('drains an in-flight write before moving the note', async () => {
+    let finishWrite!: () => void;
+    const commands: string[] = [];
+    invokeMock.mockImplementation((command: string) => {
+      commands.push(command);
+      if (command === 'write_note') {
+        return new Promise<NoteWriteResult>((resolve) => {
+          finishWrite = () => resolve({ contentHash: 'saved-before-move', conflictCopy: null });
+        });
+      }
+      if (command === 'move_note') return Promise.resolve('notes/Projects/move-race.md');
+      return Promise.resolve(undefined);
+    });
+
+    const save = writeNote('move-race.md', 'latest body', false, false);
+    const move = moveNote('move-race.md', 'Projects');
+    await Promise.resolve();
+
+    expect(commands).toEqual(['write_note']);
+    finishWrite();
+    await Promise.all([save, move]);
+
+    expect(commands).toEqual(['write_note', 'move_note']);
+  });
+
+  it('rejects a write that starts while the note is moving', async () => {
+    let finishMove!: () => void;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === 'move_note') {
+        return new Promise<string>((resolve) => {
+          finishMove = () => resolve('notes/Projects/move-race.md');
+        });
+      }
+      return Promise.resolve({ contentHash: 'unexpected-write', conflictCopy: null });
+    });
+
+    const move = moveNote('move-race.md', 'Projects');
+    await Promise.resolve();
+
+    await expect(writeNote('move-race.md', 'late edit', false, false)).rejects.toThrow(
+      LockedNoteWriteError
+    );
+    finishMove();
+    await move;
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a stale destination baseline when the source has none', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'read_note') {
+        return { content: 'stale destination', color: null, contentHash: 'stale-base' };
+      }
+      if (command === 'move_note') return 'notes/Projects/moved.md';
+      return { contentHash: 'move-write', conflictCopy: null };
+    });
+
+    await readNote('Projects/moved.md', false, false);
+    await moveNote('moved.md', 'Projects');
+    await writeNote('Projects/moved.md', 'edited after move', false, false);
+
+    expect(lastCallArgs('write_note').baseHash).toBeNull();
+  });
+
+  it('drains an in-flight write before trashing the note', async () => {
+    let finishWrite!: () => void;
+    const commands: string[] = [];
+    invokeMock.mockImplementation((command: string) => {
+      commands.push(command);
+      if (command === 'write_note') {
+        return new Promise<NoteWriteResult>((resolve) => {
+          finishWrite = () => resolve({ contentHash: 'saved-before-trash', conflictCopy: null });
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const save = writeNote('trash-race.md', 'latest body', false, false);
+    const trash = trashNote('trash-race.md', false, false);
+    await Promise.resolve();
+
+    expect(commands).toEqual(['write_note']);
+    finishWrite();
+    await Promise.all([save, trash]);
+
+    expect(commands).toEqual(['write_note', 'trash_note']);
+  });
+
+  it('allows saving again when trashing the note fails', async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'trash_note') throw new Error('trash unavailable');
+      if (command === 'write_note') {
+        return { contentHash: 'saved-after-trash-failure', conflictCopy: null };
+      }
+      return undefined;
+    });
+
+    await expect(trashNote('failed-trash.md', false, false)).rejects.toThrow('trash unavailable');
+    await expect(writeNote('failed-trash.md', 'still editable', false, false)).resolves.toEqual({
+      contentHash: 'saved-after-trash-failure',
+      conflictCopy: null,
+    });
   });
 });
 

--- a/src/lib/fileSystem.ts
+++ b/src/lib/fileSystem.ts
@@ -7,7 +7,7 @@
  * bare filenames; standalone commands use paths relative to `notes/` and must never
  * derive those paths from display titles. The module-level hash registry records the
  * last observed body for optimistic external-edit conflict safety; reads and successful
- * writes are the only operations that advance a note's base hash.
+ * writes advance a note's base hash, while moves preserve it under the new address.
  */
 
 import { safeInvoke as invoke } from './ipc';
@@ -610,12 +610,36 @@ function noteHashKey(filename: string, isDaily: boolean, isWeekly: boolean): str
   return `${isDaily ? 'daily' : isWeekly ? 'weekly' : 'notes'}:${filename}`;
 }
 
-/** Drop the recorded base hash for a note (after delete/rename/move). */
+/** Drop the recorded base hash for a note after its content identity is gone. */
 function forgetNoteBaseHash(filename: string, isDaily: boolean, isWeekly: boolean): void {
   const key = noteHashKey(filename, isDaily, isWeekly);
   noteBaseHashes.delete(key);
   lastPersistedMarkdown.delete(key);
   noteWriteChainHashes.delete(key);
+}
+
+/** Preserve conflict and write-chain state when a note changes address. */
+function readdressNote(
+  oldFilename: string,
+  newFilename: string,
+  isDaily: boolean,
+  isWeekly: boolean
+): void {
+  const oldKey = noteHashKey(oldFilename, isDaily, isWeekly);
+  const newKey = noteHashKey(newFilename, isDaily, isWeekly);
+  if (oldKey === newKey) return;
+
+  const transfer = <T>(registry: Map<string, T>) => {
+    const value = registry.get(oldKey);
+    registry.delete(newKey);
+    if (value !== undefined) registry.set(newKey, value);
+    registry.delete(oldKey);
+  };
+
+  transfer(noteBaseHashes);
+  transfer(lastPersistedMarkdown);
+  transfer(noteWriteChainHashes);
+  transfer(noteWriteGenerations);
 }
 
 export function getLastPersistedMarkdown(
@@ -855,8 +879,16 @@ export async function renameNote(
   isDaily: boolean,
   isWeekly: boolean = false
 ): Promise<void> {
-  await invoke('rename_note', { oldFilename, newFilename, isDaily, isWeekly });
-  forgetNoteBaseHash(oldFilename, isDaily, isWeekly);
+  const key = noteHashKey(oldFilename, isDaily, isWeekly);
+  if (lockedNoteWrites.has(key)) throw new LockedNoteWriteError();
+  lockedNoteWrites.add(key);
+  try {
+    await drainNoteWrites(oldFilename, isDaily, isWeekly);
+    await invoke('rename_note', { oldFilename, newFilename, isDaily, isWeekly });
+    readdressNote(oldFilename, newFilename, isDaily, isWeekly);
+  } finally {
+    lockedNoteWrites.delete(key);
+  }
 }
 
 /**
@@ -1401,9 +1433,18 @@ export async function deleteFolder(path: string, force?: boolean): Promise<void>
  * @returns The new note path
  */
 export async function moveNote(notePath: string, toFolder?: string): Promise<string> {
-  const newPath = await invoke<string>('move_note', { notePath, toFolder });
-  forgetNoteBaseHash(notePath, false, false);
-  return newPath;
+  const key = noteHashKey(notePath, false, false);
+  if (lockedNoteWrites.has(key)) throw new LockedNoteWriteError();
+  lockedNoteWrites.add(key);
+  try {
+    await drainNoteWrites(notePath, false, false);
+    const baseHash = noteWriteChainHashes.get(key) ?? noteBaseHashes.get(key) ?? null;
+    const newPath = await invoke<string>('move_note', { notePath, toFolder, baseHash });
+    readdressNote(notePath, newPath.replace(/^notes\//, ''), false, false);
+    return newPath;
+  } finally {
+    lockedNoteWrites.delete(key);
+  }
 }
 
 /**
@@ -1429,9 +1470,20 @@ export async function trashNote(
   filename: string,
   isDaily: boolean,
   isWeekly: boolean = false
-): Promise<void> {
-  await invoke('trash_note', { filename, isDaily, isWeekly });
-  forgetNoteBaseHash(filename, isDaily, isWeekly);
+): Promise<string> {
+  const key = noteHashKey(filename, isDaily, isWeekly);
+  const wasWriteLocked = lockedNoteWrites.has(key);
+  let trashed = false;
+  lockedNoteWrites.add(key);
+  try {
+    await drainNoteWrites(filename, isDaily, isWeekly);
+    const trashId = await invoke<string>('trash_note', { filename, isDaily, isWeekly });
+    forgetNoteBaseHash(filename, isDaily, isWeekly);
+    trashed = true;
+    return trashId;
+  } finally {
+    if (trashed || !wasWriteLocked) lockedNoteWrites.delete(key);
+  }
 }
 
 /**
@@ -1446,8 +1498,8 @@ export async function listTrash(): Promise<TrashedNote[]> {
  * Restores a note from the trash to its original location.
  * @param trashId - The unique ID of the trashed note
  */
-export async function restoreNote(trashId: string): Promise<void> {
-  await invoke('restore_note', { trashId });
+export async function restoreNote(trashId: string): Promise<string> {
+  return await invoke<string>('restore_note', { trashId });
 }
 
 /**
@@ -1468,9 +1520,9 @@ export async function emptyTrash(): Promise<void> {
 /**
  * Cleans up old trash items (older than 7 days).
  * Should be called on app startup.
- * @returns The number of items deleted
+ * @returns The trash IDs removed from metadata
  */
-export async function cleanupOldTrash(): Promise<number> {
+export async function cleanupOldTrash(): Promise<string[]> {
   return await invoke('cleanup_old_trash');
 }
 

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -53,7 +53,10 @@ interface NoteState {
   markExternallyChanged: (noteId: string, client?: string) => void;
   clearExternallyChanged: (noteId: string) => void;
   renameNoteReferences: (oldPath: string, newPath: string, newTitle: string) => void;
+  acknowledgeNoteReaddress: (noteId: string) => void;
+  forgetNoteReferences: (noteId: string) => void;
   removeTabByPath: (notePath: string) => void;
+  restoreTabAt: (note: Note, index: number, activate: boolean) => void;
   pinTab: (noteId: string) => { success: boolean; message?: string };
   reorderTabs: (fromIndex: number, toIndex: number) => void;
   loadPinnedTabs: () => void;
@@ -361,7 +364,14 @@ export const useNoteStore = create<NoteState>((set, get) => ({
     set((state) => {
       const newName = newPath.split('/').pop() || `${newTitle}.md`;
       const openTabs = state.openTabs.map((tab) =>
-        tab.id === oldPath ? { ...tab, id: newPath, title: newTitle } : tab
+        tab.id === oldPath
+          ? {
+              ...tab,
+              id: newPath,
+              title: newTitle,
+              ...(state.activeTabId === oldPath ? { readdressedFrom: oldPath } : {}),
+            }
+          : tab
       );
       const recentNoteIds = state.recentNoteIds.map((id) => (id === oldPath ? newPath : id));
       const unlockedNotes = new Set(
@@ -390,7 +400,14 @@ export const useNoteStore = create<NoteState>((set, get) => ({
 
       return {
         notes: state.notes.map((note) =>
-          note.path === oldPath ? { ...note, name: newName, path: newPath } : note
+          note.path === oldPath
+            ? {
+                ...note,
+                name: newName,
+                path: newPath,
+                folderPath: newPath.split('/').slice(1, -1).join('/') || undefined,
+              }
+            : note
         ),
         openTabs,
         activeTabId,
@@ -400,6 +417,50 @@ export const useNoteStore = create<NoteState>((set, get) => ({
         externallyChanged,
       };
     }),
+
+  acknowledgeNoteReaddress: (noteId) =>
+    set((state) => {
+      const tab = state.openTabs.find((candidate) => candidate.id === noteId);
+      if (!tab?.readdressedFrom) return state;
+      const openTabs = state.openTabs.map((candidate) => {
+        if (candidate.id !== noteId) return candidate;
+        const updated = { ...candidate };
+        delete updated.readdressedFrom;
+        return updated;
+      });
+      return {
+        openTabs,
+        currentNote:
+          state.activeTabId === noteId
+            ? openTabs.find((candidate) => candidate.id === noteId) || null
+            : state.currentNote,
+      };
+    }),
+
+  forgetNoteReferences: (noteId) => {
+    get().closeTab(noteId);
+    set((state) => {
+      const recentNoteIds = state.recentNoteIds.filter((id) => id !== noteId);
+      const unlockedNotes = new Set(state.unlockedNotes);
+      unlockedNotes.delete(noteId);
+      const externallyChanged = new Map(state.externallyChanged);
+      externallyChanged.delete(noteId);
+      try {
+        localStorage.setItem(
+          namespacedKey('moldavite-recent-notes'),
+          JSON.stringify(recentNoteIds)
+        );
+      } catch (error) {
+        console.error('[noteStore] Failed to forget note references:', error);
+      }
+      return {
+        notes: state.notes.filter((note) => note.path !== noteId),
+        recentNoteIds,
+        unlockedNotes,
+        externallyChanged,
+      };
+    });
+  },
 
   /**
    * Removes a tab by note path (used when a note is deleted).
@@ -411,6 +472,26 @@ export const useNoteStore = create<NoteState>((set, get) => ({
     // `undefined`.
     get().closeTab(notePath);
   },
+
+  restoreTabAt: (note, index, activate) =>
+    set((state) => {
+      if (state.openTabs.some((tab) => tab.id === note.id)) return state;
+      const openTabs = [...state.openTabs];
+      openTabs.splice(Math.min(Math.max(index, 0), openTabs.length), 0, note);
+      try {
+        localStorage.setItem(
+          namespacedKey('moldavite-pinned-tabs'),
+          JSON.stringify(openTabs.filter((tab) => tab.isPinned).map((tab) => tab.id))
+        );
+      } catch (error) {
+        console.error('[noteStore] Failed to restore closed tab:', error);
+      }
+      return {
+        openTabs,
+        activeTabId: activate ? note.id : state.activeTabId,
+        currentNote: activate ? note : state.currentNote,
+      };
+    }),
 
   /**
    * Toggles the pinned state of a tab.

--- a/src/stores/sidebarOrderStore.test.ts
+++ b/src/stores/sidebarOrderStore.test.ts
@@ -103,4 +103,15 @@ describe('useSidebarOrderStore', () => {
     expect(useSidebarOrderStore.getState().folderOrder).toEqual(['Work', 'Archive']);
     expect(useSidebarOrderStore.getState().noteOrder).toEqual(['notes/b.md', 'notes/a.md']);
   });
+
+  it('preserves a note rank when its path changes', () => {
+    useSidebarOrderStore.setState({ noteOrder: ['notes/a.md', 'notes/b.md'] });
+
+    useSidebarOrderStore.getState().renameNote('notes/a.md', 'notes/Projects/a.md');
+
+    expect(useSidebarOrderStore.getState().noteOrder).toEqual([
+      'notes/Projects/a.md',
+      'notes/b.md',
+    ]);
+  });
 });

--- a/src/stores/sidebarOrderStore.ts
+++ b/src/stores/sidebarOrderStore.ts
@@ -26,6 +26,8 @@ interface SidebarOrderState {
   /** Put `dragged` before or after `target` among `siblings` (their current display order). */
   moveNote: (dragged: string, target: string, siblings: string[], place: DropPlace) => void;
   moveFolder: (dragged: string, target: string, siblings: string[], place: DropPlace) => void;
+  /** Preserve a note's manual rank when its path changes. */
+  renameNote: (oldId: string, newId: string) => void;
 
   /** Give an empty arrangement a starting point. Ignored once one exists. */
   seedNotes: (ids: string[]) => void;
@@ -91,6 +93,11 @@ export const useSidebarOrderStore = create<SidebarOrderState>()(
       moveFolder: (dragged, target, siblings, place) =>
         set((state) => ({
           folderOrder: reorderIds(state.folderOrder, siblings, dragged, target, place),
+        })),
+
+      renameNote: (oldId, newId) =>
+        set((state) => ({
+          noteOrder: state.noteOrder.map((id) => (id === oldId ? newId : id)),
         })),
 
       seedNotes: (ids) => set((state) => (state.noteOrder.length > 0 ? state : { noteOrder: ids })),

--- a/src/stores/wordpressStore.ts
+++ b/src/stores/wordpressStore.ts
@@ -42,6 +42,7 @@ interface WordPressState {
   settleAuth: (result: { connected: boolean; error: string | null }) => void;
 
   postsByNote: Record<string, number>;
+  trashedPostsById: Record<string, Record<string, number>>;
   /**
    * Follow a note to its new path so its published post follows too.
    *
@@ -52,6 +53,10 @@ interface WordPressState {
    * post's status, so that could rewrite something already public.
    */
   notePathChanged: (oldPath: string, newPath: string) => void;
+  noteTrashed: (notePath: string, trashId: string) => void;
+  noteRestored: (trashId: string, notePath: string) => void;
+  forgetTrashedNote: (trashId: string) => void;
+  forgetAllTrashedNotes: () => void;
 }
 
 const postKey = (siteId: number, notePath: string) => `${siteId}:${notePath}`;
@@ -73,6 +78,7 @@ export const useWordPressStore = create<WordPressState>()(
       chosenSiteId: null,
       error: null,
       postsByNote: {},
+      trashedPostsById: {},
 
       refresh: async () => {
         try {
@@ -111,7 +117,14 @@ export const useWordPressStore = create<WordPressState>()(
           // Forget the site and the post map too: they belong to the account
           // that just went away, and silently reusing them against a different
           // account would overwrite someone else's posts.
-          set({ connected: false, sites: [], chosenSiteId: null, postsByNote: {}, error: null });
+          set({
+            connected: false,
+            sites: [],
+            chosenSiteId: null,
+            postsByNote: {},
+            trashedPostsById: {},
+            error: null,
+          });
         } catch (error) {
           set({ error: String(error) });
         }
@@ -156,6 +169,44 @@ export const useWordPressStore = create<WordPressState>()(
           return changed ? { postsByNote: moved } : state;
         }),
 
+      noteTrashed: (notePath, trashId) =>
+        set((state) => {
+          const postsByNote: Record<string, number> = {};
+          const archived: Record<string, number> = {};
+          for (const [key, postId] of Object.entries(state.postsByNote)) {
+            if (splitPostKey(key).notePath === notePath) archived[key] = postId;
+            else postsByNote[key] = postId;
+          }
+          return {
+            postsByNote,
+            trashedPostsById:
+              Object.keys(archived).length > 0
+                ? { ...state.trashedPostsById, [trashId]: archived }
+                : state.trashedPostsById,
+          };
+        }),
+
+      noteRestored: (trashId, notePath) =>
+        set((state) => {
+          const archived = state.trashedPostsById[trashId];
+          if (!archived) return state;
+          const postsByNote = { ...state.postsByNote };
+          for (const [key, postId] of Object.entries(archived)) {
+            postsByNote[`${splitPostKey(key).siteId}:${notePath}`] = postId;
+          }
+          const { [trashId]: _restored, ...trashedPostsById } = state.trashedPostsById;
+          return { postsByNote, trashedPostsById };
+        }),
+
+      forgetTrashedNote: (trashId) =>
+        set((state) => {
+          if (!(trashId in state.trashedPostsById)) return state;
+          const { [trashId]: _forgotten, ...trashedPostsById } = state.trashedPostsById;
+          return { trashedPostsById };
+        }),
+
+      forgetAllTrashedNotes: () => set({ trashedPostsById: {} }),
+
       publish: async (note) => {
         const siteId = get().chosenSiteId;
         if (!siteId) throw new Error('Choose a WordPress site first.');
@@ -186,6 +237,7 @@ export const useWordPressStore = create<WordPressState>()(
       partialize: (state) => ({
         chosenSiteId: state.chosenSiteId,
         postsByNote: state.postsByNote,
+        trashedPostsById: state.trashedPostsById,
       }),
     }
   )

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,22 @@ import '@testing-library/jest-dom/vitest';
 import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 
+// Keep storage deterministic across supported Node versions. Node 22 can
+// otherwise expose an unusable getter unless --localstorage-file is configured.
+const storageValues = new Map<string, string>();
+const testStorage = {
+  get length() {
+    return storageValues.size;
+  },
+  clear: () => storageValues.clear(),
+  getItem: (key: string) => storageValues.get(key) ?? null,
+  key: (index: number) => [...storageValues.keys()][index] ?? null,
+  removeItem: (key: string) => storageValues.delete(key),
+  setItem: (key: string, value: string) => storageValues.set(key, value),
+};
+Object.defineProperty(window, 'localStorage', { configurable: true, value: testStorage });
+Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: testStorage });
+
 afterEach(() => {
   cleanup();
 });

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -10,6 +10,7 @@ export interface Note {
   week?: string; // YYYY-Www format for weekly notes (e.g., "2024-W52")
   isPinned?: boolean; // Whether the tab is pinned
   externalRev?: number; // Bumped when disk content replaces an open buffer
+  readdressedFrom?: string; // Transient old path used to preserve editor state across a move/rename
 }
 
 export interface NoteFile {


### PR DESCRIPTION
## Summary

- Open editor web and email links through the system handler, including middle-click, while keeping internal note links inside Moldavite.
- Serialize note moves, renames, trash operations, autosaves, watcher suppression, and native shutdown so edits follow the note instead of racing its old path.
- Preserve tabs, colours, pins, ordering, selection, recent notes, and WordPress post mappings when notes move or enter and leave trash.
- Tighten native drag-and-drop validation and add restrained source, target, and successful-drop feedback.
- Preserve weekly-note identity through trash and clean expired WordPress mapping archives by backend trash ID.

## Testing

- `npm test` (92 files, 710 tests)
- `cargo test --lib` (365 tests)
- `npm run build`
- `npm run check:size` (606.8 KB raw / 167.8 KB gzip)
- `npm run check:tokens`
- `npm run format:check`
- `npm run lint` (0 errors; 16 existing warnings)
- `cargo clippy --lib --all-targets -- -D warnings`
- `rustfmt --edition 2021 --check src/commands/trash.rs src/types.rs`
- `git diff --check`

## Manual testing

- Smoke-tested in the native Tauri development app.