### PR TITLE
release: 2.4.2 — safer note operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.4.2] - 2026-08-25
+
+### Fixed
+
+- **Moving, renaming or trashing a note cannot leave its latest edit behind.** Those operations now wait for the note's pending save, carry its conflict history to the new path and hold anything typed while the file is moving until that path is ready. Tabs, colours, pins, recent notes, selection, manual sidebar order and WordPress publishing all follow the same note instead of staying attached to its old address. Moldavite also waits for that work before closing, and moving a note no longer reports its own filesystem change as an outside edit.
+- **Web and email links open where they belong.** Clicking an `http`, `https` or `mailto` link in the editor now hands it to the system browser or mail app, including a middle-click. Links to other Moldavite notes still open inside Moldavite.
+- **Drag feedback no longer promises a move the app will refuse.** Notes and folders show a restrained source state and a precise valid target, then mark only a successful drop. Daily, weekly, locked, same-folder, self and nested-folder drops are rejected before the target lights up, while locked notes can still be reordered where that is allowed.
+- **Restoring a trashed note restores its identity as well as its file.** An open note disappears immediately when it enters trash and returns if the operation fails. A restored weekly note goes back to Weekly rather than Notes; its colour and WordPress post mapping return too, so publishing it again updates the same post. Expired and permanently deleted trash entries now discard those archived mappings instead of leaving them behind.
+
 ## [2.4.1] - 2026-08-25
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.4.1"
+version = "2.4.2"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bump Moldavite from `2.4.1` to `2.4.2` across all five release manifests.
- Publish the transactional move, rename, trash and shutdown fixes from #114, along with system-browser links and truthful drag feedback.
- Add the dated `2.4.2` changelog section used by both GitHub Releases and the in-app “What’s New” popup.

## Verification

- `npm test`: 710 passed
- `npm run lint -- --max-warnings 16`: 0 errors, 16 existing warnings
- `npm run format:check`: clean
- `npm run check:tokens`: clean, 143 tokens across 335 files
- `npm run build && npm run check:size`: clean, app 606.8 KB raw / 167.8 KB gz
- `cargo clippy --lib --all-targets -- -D warnings`: clean
- `cargo test --lib`: 365 passed
- `node scripts/bump-version.mjs --check`: all five manifests synchronized at `2.4.2`
- `node scripts/extract-changelog.mjs 2.4.2`: all four release notes extracted
- Extension `npm test && npm run build`: 10 passed; Chrome and Firefox bundles built