### PR TITLE
release: 2.5.0 — Linux, hardening, and lighter builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [2.5.0] - 2026-09-04
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.4.2"
+version = "2.5.0"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bump Moldavite from `2.4.2` to `2.5.0` across all five release manifests.
- Publish #117: the security and path-validation fixes, Argon2id v3 note locks, plugin `net.fetch` through Rust, selector-based store subscriptions, the release profile and lighter bundle, window state and the update-check opt-out, the frontmatter-stacking fix, cleared dependency advisories with `cargo audit` at zero, MSRV 1.88, and Linux AppImage and deb builds in beta. Closes the Linux request (#116); the WordPress account login (#98) shipped in 2.1.0 and was closed as such.
- Turn the Unreleased changelog section into the dated `2.5.0` section used by both GitHub Releases and the in-app What's New popup.

## Verification

- `node scripts/bump-version.mjs --check`: all five manifests agree.
- `node scripts/extract-changelog.mjs 2.5.0` returns the section.
- CI on this PR is the build evidence; #117 was green on all 16 jobs at its final head, including the Windows and Linux installer builds.
- No GUI run on any platform; CI is the evidence. Windows and Linux remain beta.
- Google Calendar stays compiled out of release builds until the Google OAuth secrets exist (#96).