### PR TITLE
release: 2.5.1 — the icon rail leaves Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.5.1] - 2026-09-04
+
+### Fixed
+
+- **Picking another rail item closes Settings.** The icon rail stays clickable above the Settings sheet so its Settings button can stay lit, but Index, Search, Agenda, Graph, Timeline, Home and Trash ran underneath the sheet and left it open until Esc or the X. They now close Settings first, the way picking another tab would.
+
 ## [2.5.0] - 2026-09-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.5.0"
+version = "2.5.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/layout/IconRail.test.tsx
+++ b/src/components/layout/IconRail.test.tsx
@@ -175,6 +175,23 @@ describe('IconRail', () => {
     expect(useSettingsStore.getState().isSettingsOpen).toBe(true);
   });
 
+  it('leaves Settings when another rail destination is picked', () => {
+    // The rail is clickable above the Settings scrim, so a rail click has to
+    // close the sheet itself; before #121 the action ran underneath it.
+    render(<IconRail />);
+    fireEvent.click(screen.getByRole('button', { name: 'Settings (Command Comma)' }));
+    expect(useSettingsStore.getState().isSettingsOpen).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Graph (Command Shift G)' }));
+    expect(useSettingsStore.getState().isSettingsOpen).toBe(false);
+    expect(useGraphStore.getState().isOpen).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings (Command Comma)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Timeline' }));
+    expect(useSettingsStore.getState().isSettingsOpen).toBe(false);
+    expect(useTimelineStore.getState().isOpen).toBe(true);
+  });
+
   it('toggles pinned columns and ignores a surface whose mode is off', () => {
     useSettingsStore.getState().setIndexMode('pinned');
     useSettingsStore.getState().setAgendaMode('off');

--- a/src/components/layout/IconRail.tsx
+++ b/src/components/layout/IconRail.tsx
@@ -64,6 +64,13 @@ export function IconRail() {
   const agendaMode = useSettingsStore((state) => state.agendaMode);
   const isSettingsOpen = useSettingsStore((state) => state.isSettingsOpen);
   const setIsSettingsOpen = useSettingsStore((state) => state.setIsSettingsOpen);
+  /**
+   * The rail sits above the Settings scrim so its Settings button can stay lit
+   * while the sheet is up. Every other rail destination replaces Settings, the
+   * way picking another tab would; otherwise the action runs underneath the
+   * sheet and the click looks like it did nothing (#121).
+   */
+  const leaveSettings = () => setIsSettingsOpen(false);
   const { activeOverlay, isSidebarHidden, isRightPanelHidden, toggleIndex, toggleAgenda } =
     useOverlayStore();
   const quickSwitcherOpen = useQuickSwitcherStore((state) => state.isOpen);
@@ -83,6 +90,7 @@ export function IconRail() {
 
   const handleIndex = (event: MouseEvent<HTMLButtonElement>) => {
     if (indexMode === 'off') return;
+    leaveSettings();
     if (indexMode === 'overlay' && activeOverlay !== 'index') {
       captureImpactOrigin(event.currentTarget);
     }
@@ -90,6 +98,7 @@ export function IconRail() {
   };
 
   const handleHome = async () => {
+    leaveSettings();
     if (activeOverlay === null && activeTabId === null) return;
 
     await flushPendingAutosave();
@@ -99,6 +108,7 @@ export function IconRail() {
 
   const handleAgenda = (event: MouseEvent<HTMLButtonElement>) => {
     if (agendaMode === 'off') return;
+    leaveSettings();
     if (agendaMode === 'overlay' && activeOverlay !== 'agenda') {
       captureImpactOrigin(event.currentTarget);
     }
@@ -106,11 +116,13 @@ export function IconRail() {
   };
 
   const handleQuickSwitcher = (event: MouseEvent<HTMLButtonElement>) => {
+    leaveSettings();
     if (!quickSwitcherOpen) captureImpactOrigin(event.currentTarget);
     toggleQuickSwitcher();
   };
 
   const handleTrash = (event: MouseEvent<HTMLButtonElement>) => {
+    leaveSettings();
     setTrashAnchor(event.currentTarget);
     setTrashOpen((open) => !open);
   };
@@ -173,7 +185,10 @@ export function IconRail() {
             label="Graph (Command Shift G)"
             tooltip={`Graph · ${formatShortcut('⌘⇧G')}`}
             active={graphOpen}
-            onClick={toggleGraph}
+            onClick={() => {
+              leaveSettings();
+              toggleGraph();
+            }}
           >
             <Network {...iconProps} />
           </RailButton>
@@ -181,7 +196,10 @@ export function IconRail() {
             label="Timeline"
             tooltip="Timeline"
             active={timelineOpen}
-            onClick={toggleTimeline}
+            onClick={() => {
+              leaveSettings();
+              toggleTimeline();
+            }}
           >
             <Clock {...iconProps} />
           </RailButton>


### PR DESCRIPTION
## Summary

- Every non-Settings rail destination (Index, Search, Agenda, Graph, Timeline, Home, Trash) closes the Settings sheet before it acts. The rail sits above the Settings scrim on purpose so its Settings button stays lit, which also meant those actions ran underneath the sheet and left it open until Esc or the X (#121). No store changes; one wrapper in `src/components/layout/IconRail.tsx`.
- Bump Moldavite from `2.5.0` to `2.5.1` across all five release manifests and add the dated changelog section used by GitHub Releases and the What's New popup.

## Verification

- New test in `IconRail.test.tsx`: open Settings, click Graph, Settings is closed and the graph is open; same for Timeline.
- `npm test`: 732 passed, 97 files. `npx tsc --noEmit`, `npm run lint -- --max-warnings 16` (0 errors, 16 existing), `npm run format:check`, `npm run check:tokens`, `npm run build && npm run check:size`: clean.
- `node scripts/bump-version.mjs --check`: all five manifests agree.
- Not exercised in a GUI; the reporter reproduced the original on Windows and macOS on 2.5.0.

Closes #121