### PR TITLE
Run checks on every pull request, whatever its base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: Checks
 on:
   push:
     branches: [main]
+  # Every pull request, whatever its base. A PR stacked on another branch
+  # used to get no checks at all, so its first CI run happened after it merged.
   pull_request:
-    branches: [main]
 
 # Fork PRs get a read-only token. Nothing here needs to write.
 permissions:


### PR DESCRIPTION
## Summary

- `ci.yml` filtered `pull_request` on base `main`, so a PR stacked on another branch got no checks at all; #118 today never ran `build-linux` until it was folded into #117. The filter is removed; pushes still trigger only on `main`.

## Verification

- The workflow parses. This PR targets `main`, so it does not exercise the new case itself; the next stacked PR does.