### PR TITLE
cargo fmt the crate and gate formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
             run: cargo clippy --lib --all-targets -- -D warnings
           - task: test-rust
             run: cargo test --lib
+          - task: check-fmt-rust
+            run: cargo fmt --check
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
@@ -116,7 +118,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Cache Cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/src-tauri/src/backlinks_index.rs
+++ b/src-tauri/src/backlinks_index.rs
@@ -122,12 +122,7 @@ impl BacklinksIndex {
     }
 
     /// Same as `update_note` but allows injecting a resolver for tests.
-    pub(crate) fn update_note_with(
-        &self,
-        filename: &str,
-        content: &str,
-        resolver: &Resolver,
-    ) {
+    pub(crate) fn update_note_with(&self, filename: &str, content: &str, resolver: &Resolver) {
         let title = extract_title(content, filename);
         let link_names = parse_wiki_links(content);
 
@@ -199,7 +194,11 @@ impl BacklinksIndex {
                 }
             };
             if let Some(entries) = state.by_target.remove(old) {
-                state.by_target.entry(new.to_string()).or_default().extend(entries);
+                state
+                    .by_target
+                    .entry(new.to_string())
+                    .or_default()
+                    .extend(entries);
             }
         }
         // Drop old outbound / entries originating from old and re-insert under new.
@@ -262,10 +261,7 @@ impl BacklinksIndex {
     }
 }
 
-fn remove_from_by_target(
-    by_target: &mut HashMap<String, Vec<Entry>>,
-    from_note: &str,
-) {
+fn remove_from_by_target(by_target: &mut HashMap<String, Vec<Entry>>, from_note: &str) {
     let mut empty_keys: Vec<String> = Vec::new();
     for (k, v) in by_target.iter_mut() {
         v.retain(|e| e.from_note != from_note);
@@ -294,7 +290,10 @@ fn collect_md_files_flat(dir: &Path, out: &mut Vec<(String, String)>) {
         if !path.is_file() || path.extension().and_then(|s| s.to_str()) != Some("md") {
             continue;
         }
-        let Some(filename) = path.file_name().and_then(|s| s.to_str()).map(|s| s.to_string())
+        let Some(filename) = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string())
         else {
             continue;
         };
@@ -334,16 +333,18 @@ fn collect_md_files_recursive(dir: &Path, out: &mut Vec<(String, String)>) {
             }
             collect_md_files_recursive(&path, out);
         } else if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("md") {
-            let Some(filename) =
-                path.file_name().and_then(|s| s.to_str()).map(|s| s.to_string())
+            let Some(filename) = path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
             else {
                 continue;
             };
             match fs::read_to_string(&path) {
                 Ok(content) => {
-                let body = crate::frontmatter::parse_note(&content).body;
-                out.push((filename, body));
-            }
+                    let body = crate::frontmatter::parse_note(&content).body;
+                    out.push((filename, body));
+                }
                 Err(err) => log::warn!("backlinks index: failed to read {:?}: {}", path, err),
             }
         }

--- a/src-tauri/src/browser_host.rs
+++ b/src-tauri/src/browser_host.rs
@@ -223,7 +223,10 @@ fn is_chrome_origin(arg: &str) -> bool {
     else {
         return false;
     };
-    id.len() == 32 && id.bytes().all(|byte| byte.is_ascii_lowercase() && byte <= b'p')
+    id.len() == 32
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() && byte <= b'p')
 }
 
 /// Chrome passes the calling origin first; Firefox passes the manifest path then
@@ -477,7 +480,9 @@ mod tests {
         assert!(!is_browser_host_launch(&args(&[])));
         assert!(!is_browser_host_launch(&args(&["--mcp"])));
         // Not a Chrome ID: IDs are exactly 32 characters from a–p.
-        assert!(!is_browser_host_launch(&args(&["chrome-extension://short/"])));
+        assert!(!is_browser_host_launch(&args(&[
+            "chrome-extension://short/"
+        ])));
         assert!(!is_browser_host_launch(&args(&[
             "chrome-extension://ABCDEFGHIJKLMNOPabcdefghijklmnop/"
         ])));
@@ -502,9 +507,11 @@ mod tests {
 
         assert_eq!(first["path"], "notes/Clippings/How TLS works.md");
         assert_eq!(second["path"], "notes/Clippings/How TLS works (2).md");
-        assert!(std::fs::read_to_string(forge.join(first["path"].as_str().unwrap()))
-            .unwrap()
-            .contains("first"));
+        assert!(
+            std::fs::read_to_string(forge.join(first["path"].as_str().unwrap()))
+                .unwrap()
+                .contains("first")
+        );
 
         let _ = std::fs::remove_dir_all(&forge);
     }

--- a/src-tauri/src/calendar/apple.rs
+++ b/src-tauri/src/calendar/apple.rs
@@ -104,7 +104,10 @@ pub fn is_authorized() -> bool {
 /// shaped `{"error": "..."}`. Parse the payload first so an event or calendar
 /// whose text merely contains the substring `"error"` is never misclassified
 /// as a failure.
-fn parse_swift_json<T: serde::de::DeserializeOwned>(json_str: &str, what: &str) -> Result<T, String> {
+fn parse_swift_json<T: serde::de::DeserializeOwned>(
+    json_str: &str,
+    what: &str,
+) -> Result<T, String> {
     match serde_json::from_str::<T>(json_str) {
         Ok(v) => Ok(v),
         Err(parse_err) => {
@@ -154,8 +157,13 @@ pub fn get_events(
         .map(|cs| cs.as_ptr())
         .unwrap_or(std::ptr::null());
 
-    let json_ptr =
-        unsafe { fetch_events(start_cstring.as_ptr(), end_cstring.as_ptr(), calendar_id_ptr) };
+    let json_ptr = unsafe {
+        fetch_events(
+            start_cstring.as_ptr(),
+            end_cstring.as_ptr(),
+            calendar_id_ptr,
+        )
+    };
 
     if json_ptr.is_null() {
         return Err("Failed to fetch events".to_string());

--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -648,7 +648,10 @@ mod tests {
         // text the +03:00 event looks later; it is actually two hours earlier.
         let apple = event_instant("2026-08-07T07:00:00Z");
         let google = event_instant("2026-08-07T09:00:00+03:00");
-        assert!(google < apple, "instant ordering should ignore the offset text");
+        assert!(
+            google < apple,
+            "instant ordering should ignore the offset text"
+        );
         assert!("2026-08-07T07:00:00Z" < "2026-08-07T09:00:00+03:00");
     }
 

--- a/src-tauri/src/calendar/oauth.rs
+++ b/src-tauri/src/calendar/oauth.rs
@@ -465,7 +465,10 @@ mod tests {
     fn s256_challenge_matches_the_rfc7636_example() {
         // RFC 7636 appendix B.
         let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
-        assert_eq!(challenge_for(verifier), "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+        assert_eq!(
+            challenge_for(verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
     }
 
     #[test]
@@ -526,7 +529,12 @@ mod tests {
 
     #[test]
     fn authorize_url_encodes_and_pins_the_scope() {
-        let url = authorize_url("id.apps.googleusercontent.com", "http://127.0.0.1:5000", "chal", "st");
+        let url = authorize_url(
+            "id.apps.googleusercontent.com",
+            "http://127.0.0.1:5000",
+            "chal",
+            "st",
+        );
         assert!(url.contains("code_challenge=chal"));
         assert!(url.contains("code_challenge_method=S256"));
         assert!(url.contains("access_type=offline"));
@@ -538,13 +546,22 @@ mod tests {
     #[test]
     fn token_is_unusable_once_inside_the_refresh_margin() {
         let now = Instant::now();
-        let fresh = AccessToken { value: "t".into(), expires_at: now + Duration::from_secs(3600) };
+        let fresh = AccessToken {
+            value: "t".into(),
+            expires_at: now + Duration::from_secs(3600),
+        };
         assert!(fresh.is_usable(now));
 
-        let nearly_done = AccessToken { value: "t".into(), expires_at: now + Duration::from_secs(30) };
+        let nearly_done = AccessToken {
+            value: "t".into(),
+            expires_at: now + Duration::from_secs(30),
+        };
         assert!(!nearly_done.is_usable(now));
 
-        let expired = AccessToken { value: "t".into(), expires_at: now };
+        let expired = AccessToken {
+            value: "t".into(),
+            expires_at: now,
+        };
         assert!(!expired.is_usable(now));
     }
 

--- a/src-tauri/src/commands/backlinks.rs
+++ b/src-tauri/src/commands/backlinks.rs
@@ -61,10 +61,7 @@ pub(crate) fn create_note_from_link(
     Ok(filename)
 }
 
-fn create_note_from_link_at(
-    notes_dir: &Path,
-    note_name: &str,
-) -> Result<(String, String), String> {
+fn create_note_from_link_at(notes_dir: &Path, note_name: &str) -> Result<(String, String), String> {
     let filename = note_name_to_filename(note_name);
     // `note_name_to_filename` mirrors the frontend slug contract byte-for-
     // byte and must not change; validate its output instead so a Windows

--- a/src-tauri/src/commands/export_import.rs
+++ b/src-tauri/src/commands/export_import.rs
@@ -175,8 +175,7 @@ fn extract_archive<R: IoRead + Seek>(
             continue;
         }
 
-        let Some((subdir, destination)) =
-            validated_archive_destination(destination_root, &name)
+        let Some((subdir, destination)) = validated_archive_destination(destination_root, &name)
         else {
             return Err(format!("{label} contains unsafe entry path '{name}'"));
         };
@@ -231,9 +230,7 @@ fn create_import_staging_dir(notes_dir: &Path) -> Result<PathBuf, String> {
 
     for _ in 0..32 {
         let suffix = rand::RngCore::next_u64(&mut rand::rngs::OsRng);
-        let path = parent.join(format!(
-            ".{forge_name}.moldavite-import-{suffix:016x}.tmp"
-        ));
+        let path = parent.join(format!(".{forge_name}.moldavite-import-{suffix:016x}.tmp"));
         // Only the Unix branch mutates this, so on Windows `mut` is unused and
         // `-D warnings` fails the build there. Windows inherits the parent
         // directory's ACL, which is the equivalent protection.
@@ -247,7 +244,11 @@ fn create_import_staging_dir(notes_dir: &Path) -> Result<PathBuf, String> {
         match builder.create(&path) {
             Ok(()) => return Ok(path),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(format!("Failed to create import staging directory: {error}")),
+            Err(error) => {
+                return Err(format!(
+                    "Failed to create import staging directory: {error}"
+                ))
+            }
         }
     }
 
@@ -666,14 +667,12 @@ mod tests {
         scaffold(&source);
         fs::write(source.join("notes/note.md"), "private note").unwrap();
 
-        assert!(
-            export_encrypted_backup_to(
-                &source,
-                Path::new("relative.moldavite-backup"),
-                "password"
-            )
-            .is_err()
-        );
+        assert!(export_encrypted_backup_to(
+            &source,
+            Path::new("relative.moldavite-backup"),
+            "password"
+        )
+        .is_err());
 
         let backup = tmp.0.join("vault.moldavite-backup");
         export_encrypted_backup_to(&source, &backup, "password").unwrap();

--- a/src-tauri/src/commands/locking.rs
+++ b/src-tauri/src/commands/locking.rs
@@ -125,10 +125,8 @@ fn lock_note_in(
     let original_path = dir.join(&filename);
     let locked_path = locked_path(&dir, &filename);
 
-    validate_path_within_base(&original_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
-    validate_path_within_base(&locked_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&original_path, &dir).map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&locked_path, &dir).map_err(|_| "Invalid note path".to_string())?;
 
     if !original_path.exists() {
         return Err("Note not found".to_string());
@@ -137,8 +135,7 @@ fn lock_note_in(
         return Err("Note is already locked".to_string());
     }
 
-    validate_path_within_base(&original_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&original_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     let content =
         fs::read_to_string(&original_path).map_err(|e| format!("Failed to read note: {e}"))?;
     let encrypted = encryption::encrypt_note_content(
@@ -146,10 +143,8 @@ fn lock_note_in(
         &password,
         &note_id(&filename, is_daily, is_weekly),
     )?;
-    validate_path_within_base(&original_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
-    validate_path_within_base(&locked_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&original_path, &dir).map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&locked_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     publish_locked_file(
         &original_path,
         &locked_path,
@@ -208,13 +203,11 @@ fn unlock_note_in(
 
     let dir = note_dir(forge_root, is_daily, is_weekly);
     let locked_path = locked_path(&dir, &filename);
-    validate_path_within_base(&locked_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&locked_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     if !locked_path.exists() {
         return Err("Locked note not found".to_string());
     }
-    validate_path_within_base(&locked_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&locked_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     let encrypted =
         fs::read_to_string(&locked_path).map_err(|e| format!("Failed to read locked note: {e}"))?;
 
@@ -281,18 +274,15 @@ fn permanently_unlock_note_in(
     let dir = note_dir(forge_root, is_daily, is_weekly);
     let locked_path = locked_path(&dir, &filename);
     let original_path = dir.join(&filename);
-    validate_path_within_base(&locked_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
-    validate_path_within_base(&original_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&locked_path, &dir).map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&original_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     if !locked_path.exists() {
         return Err("Locked note not found".to_string());
     }
     if original_path.exists() {
         return Err("Note is already unlocked".to_string());
     }
-    validate_path_within_base(&locked_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&locked_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     let encrypted =
         fs::read_to_string(&locked_path).map_err(|e| format!("Failed to read locked note: {e}"))?;
     let decrypted = match encryption::decrypt_note_content(&encrypted, &password, &note_id) {
@@ -315,10 +305,8 @@ fn permanently_unlock_note_in(
         }
     };
 
-    validate_path_within_base(&locked_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
-    validate_path_within_base(&original_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&locked_path, &dir).map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&original_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     publish_unlocked_file(&locked_path, &original_path, &decrypted)?;
 
     let body = crate::frontmatter::parse_note(&decrypted).body;
@@ -496,7 +484,10 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(fs::read_to_string(&original).unwrap(), "plaintext");
-        assert!(!locked.exists(), "failed locking left a published locked copy");
+        assert!(
+            !locked.exists(),
+            "failed locking left a published locked copy"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -593,14 +584,7 @@ mod tests {
         let index = BacklinksIndex::new();
 
         assert_eq!(
-            unlock_note_in(
-                &root,
-                filename.into(),
-                "old password".into(),
-                false,
-                false,
-            )
-            .unwrap(),
+            unlock_note_in(&root, filename.into(), "old password".into(), false, false,).unwrap(),
             plaintext
         );
         permanently_unlock_note_in(

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -331,8 +331,11 @@ where
         Some(value) => Some(value.to_string()),
         None => parsed_incoming.color.or(parsed_existing.color),
     };
-    let serialized =
-        frontmatter::serialize_note(resolved_color.as_deref(), &merged_extra, &parsed_incoming.body);
+    let serialized = frontmatter::serialize_note(
+        resolved_color.as_deref(),
+        &merged_extra,
+        &parsed_incoming.body,
+    );
     write(path, &serialized)?;
     Ok(conflict)
 }
@@ -553,29 +556,28 @@ pub(crate) fn write_note(
     // frontend last read it (and differs from what we're about to write),
     // preserve the disk version as a sibling conflict copy first so the
     // save below can never silently destroy it.
-    let conflict_copy =
-        match save_note_with_conflict_in(
-            &dir,
-            &path,
-            base_hash.as_deref(),
-            &content,
-            color.as_deref(),
-        )? {
-            Some((conflict_name, disk_body)) => {
-                if let Some(parent) = path.parent() {
-                    // The copy is our own write — suppress the watcher echo.
-                    recent.record(&parent.join(&conflict_name), &sha256_hex(&disk_body));
-                }
-                index.update_note(&conflict_name, &disk_body);
-                // Echo back the same folder-relative shape we were addressed with.
-                let rel = match filename.rsplit_once('/') {
-                    Some((folder, _)) => format!("{}/{}", folder, conflict_name),
-                    None => conflict_name,
-                };
-                Some(rel)
+    let conflict_copy = match save_note_with_conflict_in(
+        &dir,
+        &path,
+        base_hash.as_deref(),
+        &content,
+        color.as_deref(),
+    )? {
+        Some((conflict_name, disk_body)) => {
+            if let Some(parent) = path.parent() {
+                // The copy is our own write — suppress the watcher echo.
+                recent.record(&parent.join(&conflict_name), &sha256_hex(&disk_body));
             }
-            None => None,
-        };
+            index.update_note(&conflict_name, &disk_body);
+            // Echo back the same folder-relative shape we were addressed with.
+            let rel = match filename.rsplit_once('/') {
+                Some((folder, _)) => format!("{}/{}", folder, conflict_name),
+                None => conflict_name,
+            };
+            Some(rel)
+        }
+        None => None,
+    };
 
     let content_hash = sha256_hex(&content);
     recent.record(&path, &content_hash);
@@ -749,8 +751,7 @@ pub(crate) fn duplicate_note(
     };
 
     let source_path = dir.join(&filename);
-    validate_path_within_base(&source_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&source_path, &dir).map_err(|_| "Invalid note path".to_string())?;
 
     if !source_path.exists() {
         return Err("Note not found".to_string());
@@ -770,8 +771,7 @@ pub(crate) fn duplicate_note(
     let new_base = portable_derived_stem(source_stem, " (copy)");
     let new_leaf = generate_unique_filename(source_parent, &new_base, "md");
     let new_path = source_parent.join(&new_leaf);
-    validate_path_within_base(&new_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&new_path, &dir).map_err(|_| "Invalid note path".to_string())?;
     let new_filename = match filename.rsplit_once('/') {
         Some((parent, _)) => format!("{parent}/{new_leaf}"),
         None => new_leaf,
@@ -811,8 +811,7 @@ pub(crate) fn export_single_note(
     };
 
     let source_path = dir.join(&filename);
-    validate_path_within_base(&source_path, &dir)
-        .map_err(|_| "Invalid note path".to_string())?;
+    validate_path_within_base(&source_path, &dir).map_err(|_| "Invalid note path".to_string())?;
 
     if !source_path.exists() {
         return Err("Note not found".to_string());
@@ -827,9 +826,7 @@ pub(crate) fn export_single_note(
         .and_then(|s| s.to_str())
         .map(str::to_ascii_lowercase)
         .filter(|extension| matches!(extension.as_str(), "md" | "markdown" | "txt"))
-        .ok_or_else(|| {
-            "Destination must have a .md, .markdown, or .txt extension".to_string()
-        })?;
+        .ok_or_else(|| "Destination must have a .md, .markdown, or .txt extension".to_string())?;
     crate::validation::validate_user_export_path(dest_path, &extension)?;
     write_atomic(dest_path, content.as_bytes(), Some(0o600))?;
 
@@ -890,13 +887,7 @@ pub(crate) fn rename_note(
         get_standalone_dir()
     };
 
-    let new_path = rename_note_in(
-        &dir,
-        &old_filename,
-        &new_filename,
-        is_daily,
-        is_weekly,
-    )?;
+    let new_path = rename_note_in(&dir, &old_filename, &new_filename, is_daily, is_weekly)?;
 
     let content_after_rename = fs::read_to_string(&new_path).unwrap_or_default();
     index.rename_note(
@@ -1302,8 +1293,14 @@ mod tests {
         );
         let parsed = frontmatter::parse_note(&written);
         assert_eq!(parsed.body, "new body");
-        assert!(!parsed.body.starts_with("---"), "body still carries a fence");
-        assert!(parsed.extra.contains_key("aliases"), "caller frontmatter kept");
+        assert!(
+            !parsed.body.starts_with("---"),
+            "body still carries a fence"
+        );
+        assert!(
+            parsed.extra.contains_key("aliases"),
+            "caller frontmatter kept"
+        );
     }
 
     #[test]
@@ -1675,19 +1672,16 @@ mod tests {
         fs::write(tmp.path().join("old.md"), "old").unwrap();
         fs::write(tmp.path().join("existing.md"), "existing").unwrap();
 
-        let result = rename_note_in(
-            tmp.path(),
-            "old.md",
-            "existing.md",
-            false,
-            false,
-        );
+        let result = rename_note_in(tmp.path(), "old.md", "existing.md", false, false);
 
         assert_eq!(
             result,
             Err("A note with this name already exists".to_string())
         );
-        assert_eq!(fs::read_to_string(tmp.path().join("old.md")).unwrap(), "old");
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("old.md")).unwrap(),
+            "old"
+        );
         assert_eq!(
             fs::read_to_string(tmp.path().join("existing.md")).unwrap(),
             "existing"
@@ -1707,13 +1701,7 @@ mod tests {
             false,
         )
         .unwrap();
-        let result = rename_note_in(
-            tmp.path(),
-            "current-name.md",
-            "new..name.md",
-            false,
-            false,
-        );
+        let result = rename_note_in(tmp.path(), "current-name.md", "new..name.md", false, false);
 
         assert_eq!(result, Err("Invalid filename".to_string()));
         assert!(tmp.path().join("current-name.md").exists());
@@ -1776,7 +1764,10 @@ mod tests {
         assert_eq!(relative, "pw.md");
         assert!(notes.join("pw.md").is_file());
         assert!(!notes.join("pw (2).md").exists());
-        assert_eq!(fs::read_to_string(notes.join("pw.md")).unwrap(), "root body");
+        assert_eq!(
+            fs::read_to_string(notes.join("pw.md")).unwrap(),
+            "root body"
+        );
 
         let (_, final_filename, relative, _) =
             move_note_in(&notes, "Projects/note.md", Some("Projects")).unwrap();

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -69,11 +69,7 @@ fn secret_set_with(
     store.set(&secret_account(plugin_id, key)?, value)
 }
 
-fn secret_delete_with(
-    store: &impl SecretStore,
-    plugin_id: &str,
-    key: &str,
-) -> Result<(), String> {
+fn secret_delete_with(store: &impl SecretStore, plugin_id: &str, key: &str) -> Result<(), String> {
     store.delete(&secret_account(plugin_id, key)?)
 }
 

--- a/src-tauri/src/commands/root_files.rs
+++ b/src-tauri/src/commands/root_files.rs
@@ -132,10 +132,10 @@ mod tests {
         let tmp = TempDir::new("whitelist");
         for bad in [
             "notes.md",
-            "agents.md",           // case matters
+            "agents.md", // case matters
             "AGENTS.md.bak",
-            "../AGENTS.md",        // traversal
-            "daily/AGENTS.md",     // subpath
+            "../AGENTS.md",    // traversal
+            "daily/AGENTS.md", // subpath
             "/etc/passwd",
             ".gitignore2",
             ".git",
@@ -202,7 +202,10 @@ mod tests {
     #[test]
     fn read_missing_file_returns_none() {
         let tmp = TempDir::new("missing");
-        assert_eq!(read_forge_root_file_in(tmp.path(), "AGENTS.md").unwrap(), None);
+        assert_eq!(
+            read_forge_root_file_in(tmp.path(), "AGENTS.md").unwrap(),
+            None
+        );
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -111,7 +111,9 @@ pub(crate) fn search_notes_content_in(
             continue;
         }
 
-        let Ok(raw) = fs::read_to_string(path) else { continue };
+        let Ok(raw) = fs::read_to_string(path) else {
+            continue;
+        };
         // Don't search YAML frontmatter — it would surface "color: red" as a
         // hit when the user searches for "red".
         let content = crate::frontmatter::parse_note(&raw).body;
@@ -138,7 +140,9 @@ pub(crate) fn search_notes_content_in(
             match_count = match_count.saturating_add(occurrences);
         }
 
-        let Some(snippet) = first_snippet else { continue };
+        let Some(snippet) = first_snippet else {
+            continue;
+        };
         let Some((rel_path, is_daily, is_weekly, folder_path)) =
             classify_note_path(notes_dir, path)
         else {
@@ -171,7 +175,10 @@ pub(crate) fn search_notes_content_in(
 /// Case-insensitive substring match. Skips `.md.locked` files and the
 /// internal `.trash` directory. Results are sorted by match count desc.
 #[tauri::command]
-pub(crate) fn search_notes_content(query: String, max_results: u32) -> Result<Vec<ContentMatch>, String> {
+pub(crate) fn search_notes_content(
+    query: String,
+    max_results: u32,
+) -> Result<Vec<ContentMatch>, String> {
     let notes_dir = get_notes_dir();
     let trash_dir = get_trash_dir();
     Ok(search_notes_content_in(

--- a/src-tauri/src/encryption.rs
+++ b/src-tauri/src/encryption.rs
@@ -16,7 +16,7 @@ use aes_gcm::{
 };
 use argon2::{
     password_hash::{PasswordHasher, SaltString},
-    Argon2, Algorithm, Params, Version,
+    Algorithm, Argon2, Params, Version,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use rand::rngs::OsRng;
@@ -40,11 +40,12 @@ const NOTE_AAD_DOMAIN: &[u8] = b"moldavite-note-v2\0";
 /// - Parallelism: 1 - single thread for consistent timing
 fn legacy_argon2() -> Argon2<'static> {
     let params = Params::new(
-        19456,  // m_cost: 19 MiB memory
-        3,      // t_cost: 3 iterations
-        1,      // p_cost: 1 parallel lane
-        Some(32) // output length: 32 bytes for AES-256
-    ).expect("Invalid Argon2 parameters");
+        19456,    // m_cost: 19 MiB memory
+        3,        // t_cost: 3 iterations
+        1,        // p_cost: 1 parallel lane
+        Some(32), // output length: 32 bytes for AES-256
+    )
+    .expect("Invalid Argon2 parameters");
 
     Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
 }
@@ -54,11 +55,12 @@ fn legacy_argon2() -> Argon2<'static> {
 /// locks use these.
 fn hardened_argon2_v3() -> Argon2<'static> {
     let params = Params::new(
-        65536,  // m_cost: 64 MiB memory
-        3,      // t_cost: 3 iterations
-        1,      // p_cost: 1 parallel lane
-        Some(32) // output length: 32 bytes for AES-256
-    ).expect("Invalid Argon2 parameters");
+        65536,    // m_cost: 64 MiB memory
+        3,        // t_cost: 3 iterations
+        1,        // p_cost: 1 parallel lane
+        Some(32), // output length: 32 bytes for AES-256
+    )
+    .expect("Invalid Argon2 parameters");
 
     Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
 }
@@ -82,11 +84,10 @@ fn cipher_from_password(
     }
     let mut key_buffer = [0u8; 32];
     key_buffer.copy_from_slice(&key_bytes[..32]);
-    let cipher = Aes256Gcm::new_from_slice(&key_buffer)
-        .map_err(|e| {
-            key_buffer.zeroize();
-            format!("Failed to create cipher: {}", e)
-        })?;
+    let cipher = Aes256Gcm::new_from_slice(&key_buffer).map_err(|e| {
+        key_buffer.zeroize();
+        format!("Failed to create cipher: {}", e)
+    })?;
     key_buffer.zeroize();
     Ok(cipher)
 }
@@ -125,10 +126,7 @@ fn encrypt_payload(
             "{version}${}${nonce_b64}${ciphertext_b64}",
             salt.as_str()
         )),
-        None => Ok(format!(
-            "{}${nonce_b64}${ciphertext_b64}",
-            salt.as_str()
-        )),
+        None => Ok(format!("{}${nonce_b64}${ciphertext_b64}", salt.as_str())),
     }
 }
 
@@ -147,12 +145,11 @@ fn decrypt_payload(
         .decode(ciphertext_b64)
         .map_err(|e| format!("Failed to decode ciphertext: {}", e))?;
 
-    let salt = SaltString::from_b64(salt_str)
-        .map_err(|e| {
-            nonce_bytes.zeroize();
-            ciphertext.zeroize();
-            format!("Failed to parse salt: {}", e)
-        })?;
+    let salt = SaltString::from_b64(salt_str).map_err(|e| {
+        nonce_bytes.zeroize();
+        ciphertext.zeroize();
+        format!("Failed to parse salt: {}", e)
+    })?;
 
     let cipher = cipher_from_password(password, &salt, argon2).inspect_err(|_| {
         nonce_bytes.zeroize();
@@ -180,11 +177,10 @@ fn decrypt_payload(
         })?;
     nonce_bytes.zeroize();
     ciphertext.zeroize();
-    let result = String::from_utf8(plaintext.clone())
-        .map_err(|e| {
-            plaintext.zeroize();
-            format!("Failed to convert decrypted content to string: {}", e)
-        });
+    let result = String::from_utf8(plaintext.clone()).map_err(|e| {
+        plaintext.zeroize();
+        format!("Failed to convert decrypted content to string: {}", e)
+    });
     plaintext.zeroize();
     result
 }
@@ -209,7 +205,14 @@ pub fn decrypt_content(encrypted: &str, password: &str) -> Result<String, String
     if parts.len() != 3 {
         return Err("Invalid encrypted format".to_string());
     }
-    decrypt_payload(parts[0], parts[1], parts[2], password, &[], &legacy_argon2())
+    decrypt_payload(
+        parts[0],
+        parts[1],
+        parts[2],
+        password,
+        &[],
+        &legacy_argon2(),
+    )
 }
 
 fn note_aad(note_id: &str) -> Vec<u8> {

--- a/src-tauri/src/frontmatter.rs
+++ b/src-tauri/src/frontmatter.rs
@@ -119,7 +119,11 @@ pub fn parse_note(raw: &str) -> ParsedNote {
 /// Serialize a note back to disk format. If `color` is `None` and `extra` is
 /// empty, the frontmatter block is omitted entirely so we don't pollute every
 /// file.
-pub fn serialize_note(color: Option<&str>, extra: &BTreeMap<String, serde_yaml::Value>, body: &str) -> String {
+pub fn serialize_note(
+    color: Option<&str>,
+    extra: &BTreeMap<String, serde_yaml::Value>,
+    body: &str,
+) -> String {
     let has_color = color.is_some_and(|c| !c.is_empty());
     if !has_color && extra.is_empty() {
         return body.to_string();

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -334,8 +334,8 @@ mod tests {
         let root = temp_forge("agent-write-marker");
         let spool = root.with_extension("agent-writes");
         fs::write(root.join("notes/marked.md"), "old body").unwrap();
-        let context = ToolContext::new(root.clone(), true, false)
-            .with_agent_write_spool(spool.clone());
+        let context =
+            ToolContext::new(root.clone(), true, false).with_agent_write_spool(spool.clone());
         let input = request(
             1,
             "initialize",

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -358,18 +358,13 @@ impl ToolContext {
         // Resolve through the permissive existing-note check: a note already on
         // disk may carry a name we would refuse to create today.
         let path = self.checked_existing_note(forge_root, &rel)?;
-        let conflict_copy = save_note_with_conflict_using(
-            &path,
-            base_hash,
-            content,
-            None,
-            |path, serialized| {
+        let conflict_copy =
+            save_note_with_conflict_using(&path, base_hash, content, None, |path, serialized| {
                 self.write_agent_note(forge_root, &rel, serialized, || {
                     write_atomic(path, serialized.as_bytes(), Some(0o600))
                 })
-            },
-        )?
-        .map(|(conflict_name, _)| conflict_name);
+            })?
+            .map(|(conflict_name, _)| conflict_name);
         self.note_changed(forge_root, &rel);
         Ok(json!({ "path": rel, "written": true, "conflictCopy": conflict_copy }))
     }

--- a/src-tauri/src/migration.rs
+++ b/src-tauri/src/migration.rs
@@ -81,7 +81,9 @@ pub fn migrate_legacy_single_forge_to_multi() -> Result<bool, String> {
         fs::read_dir(&legacy_dir).map_err(|e| format!("Failed to read legacy dir: {}", e))?;
     for entry in entries.flatten() {
         let path = entry.path();
-        let Some(name) = path.file_name() else { continue };
+        let Some(name) = path.file_name() else {
+            continue;
+        };
         if name == std::ffi::OsStr::new(DEFAULT_FORGE_NAME) {
             continue;
         }
@@ -189,7 +191,11 @@ pub fn migrate_metadata_to_frontmatter() -> Result<u32, String> {
     let raw = match fs::read_to_string(&metadata_path) {
         Ok(s) => s,
         Err(e) => {
-            log::warn!("[forge migration] could not read {:?}: {}", metadata_path, e);
+            log::warn!(
+                "[forge migration] could not read {:?}: {}",
+                metadata_path,
+                e
+            );
             return Ok(0);
         }
     };
@@ -198,7 +204,10 @@ pub fn migrate_metadata_to_frontmatter() -> Result<u32, String> {
         Err(e) => {
             log::warn!("[forge migration] malformed metadata json: {}", e);
             // Still rename so we don't keep retrying on every boot.
-            let _ = fs::rename(&metadata_path, metadata_path.with_extension("json.migrated"));
+            let _ = fs::rename(
+                &metadata_path,
+                metadata_path.with_extension("json.migrated"),
+            );
             return Ok(0);
         }
     };
@@ -256,10 +265,7 @@ pub fn migrate_metadata_to_frontmatter() -> Result<u32, String> {
     // original payload if something went wrong.
     let renamed = metadata_path.with_extension("json.migrated");
     if let Err(e) = fs::rename(&metadata_path, &renamed) {
-        log::warn!(
-            "[forge migration] could not rename metadata file: {}",
-            e
-        );
+        log::warn!("[forge migration] could not rename metadata file: {}", e);
     }
 
     Ok(migrated)
@@ -334,7 +340,10 @@ mod tests {
         fs::write(root.join("daily/keep.md"), "keep").unwrap();
 
         assert_eq!(adopt_stray_root_layout_at(&root, "Default"), Ok(false));
-        assert_eq!(fs::read_to_string(root.join("daily/keep.md")).unwrap(), "keep");
+        assert_eq!(
+            fs::read_to_string(root.join("daily/keep.md")).unwrap(),
+            "keep"
+        );
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -142,7 +142,8 @@ pub(crate) fn get_metadata_path() -> PathBuf {
 
 pub(crate) fn ensure_trash_dir() -> Result<(), String> {
     let trash_dir = get_trash_dir();
-    fs::create_dir_all(&trash_dir).map_err(|e| format!("Failed to create trash directory: {}", e))?;
+    fs::create_dir_all(&trash_dir)
+        .map_err(|e| format!("Failed to create trash directory: {}", e))?;
     Ok(())
 }
 

--- a/src-tauri/src/persist.rs
+++ b/src-tauri/src/persist.rs
@@ -118,11 +118,7 @@ fn open_atomic_temp(
 }
 
 /// Atomically replace `path` after writing a securely created same-directory temp file.
-pub(crate) fn write_atomic_with<F>(
-    path: &Path,
-    mode: Option<u32>,
-    write: F,
-) -> Result<(), String>
+pub(crate) fn write_atomic_with<F>(path: &Path, mode: Option<u32>, write: F) -> Result<(), String>
 where
     F: FnOnce(&mut fs::File) -> Result<(), String>,
 {
@@ -191,7 +187,8 @@ pub(crate) fn write_config(config: &AppConfig) -> Result<(), String> {
 
     // Ensure config directory exists
     if let Some(parent) = config_path.parent() {
-        fs::create_dir_all(parent).map_err(|e| format!("Failed to create config directory: {}", e))?;
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create config directory: {}", e))?;
     }
 
     let json = serde_json::to_string_pretty(config).map_err(|e| e.to_string())?;
@@ -374,10 +371,9 @@ mod tests {
         let path = tmp.path().join("note.md");
         let outside = tmp.path().join("outside-secret");
         fs::write(&outside, "must survive").unwrap();
-        let predictable = tmp.path().join(format!(
-            ".note.md.{}.0.tmp",
-            std::process::id()
-        ));
+        let predictable = tmp
+            .path()
+            .join(format!(".note.md.{}.0.tmp", std::process::id()));
         symlink(&outside, predictable).unwrap();
 
         write_atomic(&path, b"new note", Some(0o600)).unwrap();

--- a/src-tauri/src/security.rs
+++ b/src-tauri/src/security.rs
@@ -202,7 +202,9 @@ pub fn record_failed_attempt(note_id: &str) -> RateLimitResult {
     // Then update per-note tracker
     let mut tracker = lock(&ATTEMPT_TRACKER);
 
-    let info = tracker.entry(note_id.to_string()).or_insert_with(AttemptInfo::new);
+    let info = tracker
+        .entry(note_id.to_string())
+        .or_insert_with(AttemptInfo::new);
 
     // Reset attempts if it's been a while since last attempt
     if info.last_attempt.elapsed() > Duration::from_secs(ATTEMPT_RESET_SECS) {
@@ -253,7 +255,8 @@ fn cleanup_old_entries(tracker: &mut HashMap<String, AttemptInfo>) {
 
     tracker.retain(|_, info| {
         // Keep entries that are currently locked out or were recently accessed
-        info.locked_until.is_some_and(|until| Instant::now() < until)
+        info.locked_until
+            .is_some_and(|until| Instant::now() < until)
             || info.last_attempt.elapsed() < cleanup_threshold
     });
 }

--- a/src-tauri/src/stress_test.rs
+++ b/src-tauri/src/stress_test.rs
@@ -78,7 +78,11 @@ fn stress_search_over_1000_note_vault() {
     let base = vault.path();
 
     for i in 0..1000 {
-        let dir = if i % 5 == 0 { "notes/Projects" } else { "notes" };
+        let dir = if i % 5 == 0 {
+            "notes/Projects"
+        } else {
+            "notes"
+        };
         let content = lorem_note(i, i % 100 == 0); // 10 notes carry the needle
         fs::write(base.join(dir).join(format!("note-{i}.md")), content).unwrap();
     }
@@ -113,7 +117,10 @@ fn stress_atomic_writes_concurrent_distinct_files() {
             });
         }
     });
-    eprintln!("[stress] 800 concurrent atomic writes took {:?}", started.elapsed());
+    eprintln!(
+        "[stress] 800 concurrent atomic writes took {:?}",
+        started.elapsed()
+    );
 
     let mut count = 0;
     for entry in fs::read_dir(&base).unwrap().flatten() {
@@ -121,7 +128,11 @@ fn stress_atomic_writes_concurrent_distinct_files() {
             continue;
         }
         let content = fs::read_to_string(entry.path()).unwrap();
-        assert!(content.starts_with("thread "), "torn or empty file: {:?}", entry.path());
+        assert!(
+            content.starts_with("thread "),
+            "torn or empty file: {:?}",
+            entry.path()
+        );
         count += 1;
     }
     assert_eq!(count, 800);

--- a/src-tauri/src/wiki.rs
+++ b/src-tauri/src/wiki.rs
@@ -121,7 +121,9 @@ pub(crate) fn rewrite_links_for_rename(
                 None => format!("[[{}]]", new_stem),
             }
         } else {
-            caps.get(0).map(|m| m.as_str().to_string()).unwrap_or_default()
+            caps.get(0)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default()
         }
     });
     if changed {
@@ -153,10 +155,7 @@ fn ceil_char_boundary(s: &str, mut i: usize) -> usize {
 
 pub(crate) fn get_link_context(content: &str, link_text: &str) -> String {
     // Try both with and without pipe syntax
-    let search_patterns = vec![
-        format!("[[{}]]", link_text),
-        format!("[[{}|", link_text),
-    ];
+    let search_patterns = vec![format!("[[{}]]", link_text), format!("[[{}|", link_text)];
 
     for search in search_patterns {
         if let Some(pos) = content.find(&search) {


### PR DESCRIPTION
## Summary

- One-time `cargo fmt` over the 76 files that had drifted from rustfmt defaults. Formatting only.
- New `check-fmt-rust` task in the Linux Rust matrix runs `cargo fmt --check` so it cannot drift again; the toolchain step gains the `rustfmt` component.

## Verification

- `cargo fmt --check`: clean after the pass.
- `cargo test --lib`: 406 passed. `cargo clippy --lib --all-targets -- -D warnings`: clean.
- Large mechanical diff; best merged while no other Rust branches are open, which is the case now.