### PR TITLE
release: 2.5.2 — an installed update stops advertising itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Moldavite are documented here.
 
+## [2.5.2] - 2026-09-04
+
+### Fixed
+
+- **An update you just installed no longer keeps advertising itself.** On Windows the installer takes over and closes Moldavite before the app can note that the update went through, so the new version started with the old "update available" state and pressing Update restarted the app again. A pending version the running app already has is now dropped at launch and before any install; a manual Check for updates was the only way out before.
+
 ## [2.5.1] - 2026-09-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.5.1"
+version = "2.5.2"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
+import { getVersion } from '@tauri-apps/api/app';
 import { registerAutosaveFlush, registerAutosavePendingProbe } from '@/lib/autosaveFlush';
 import {
   INITIAL_UPDATE_CHECK_DELAY_MS,
   UPDATE_CHECK_INTERVAL_MS,
   __resetUpdateStoreForTests,
+  isNewerVersion,
   isUpdateCheckStale,
   selectHasPendingUpdate,
   useUpdateStore,
@@ -19,8 +21,13 @@ vi.mock('@tauri-apps/plugin-process', () => ({
   relaunch: vi.fn(),
 }));
 
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn(),
+}));
+
 const mockCheck = vi.mocked(check);
 const mockRelaunch = vi.mocked(relaunch);
+const mockGetVersion = vi.mocked(getVersion);
 
 function mockUpdate(version = '1.8.0') {
   return {
@@ -35,6 +42,7 @@ describe('updateStore', () => {
     __resetUpdateStoreForTests();
     mockCheck.mockReset();
     mockRelaunch.mockReset().mockResolvedValue(undefined);
+    mockGetVersion.mockReset().mockResolvedValue('1.0.0');
   });
 
   afterEach(() => {
@@ -174,6 +182,55 @@ describe('updateStore', () => {
     expect(mockCheck).toHaveBeenCalledTimes(1);
     expect(update.downloadAndInstall).toHaveBeenCalled();
     expect(useUpdateStore.getState().availableVersion).toBeNull();
+  });
+
+  it('compares versions numerically', () => {
+    expect(isNewerVersion('2.5.1', '2.5.0')).toBe(true);
+    expect(isNewerVersion('2.10.0', '2.9.9')).toBe(true);
+    expect(isNewerVersion('2.5.0', '2.5.0')).toBe(false);
+    expect(isNewerVersion('2.4.9', '2.5.0')).toBe(false);
+  });
+
+  it('drops a persisted pending version that the running app already has', async () => {
+    mockGetVersion.mockResolvedValue('2.5.0');
+    useUpdateStore.setState({ availableVersion: '2.5.0', update: null });
+
+    await useUpdateStore.getState().reconcileWithInstalledVersion();
+
+    expect(useUpdateStore.getState().availableVersion).toBeNull();
+  });
+
+  it('keeps a persisted pending version newer than the running app', async () => {
+    mockGetVersion.mockResolvedValue('2.5.0');
+    useUpdateStore.setState({ availableVersion: '2.5.1', update: null });
+
+    await useUpdateStore.getState().reconcileWithInstalledVersion();
+
+    expect(useUpdateStore.getState().availableVersion).toBe('2.5.1');
+  });
+
+  it('refuses to reinstall a pending version the running app already has', async () => {
+    // Windows: the updater exits the process inside downloadAndInstall, so the
+    // post-install clear never ran and the new app rehydrated the old pending
+    // version (#125). Update must not re-check, download, or relaunch.
+    mockGetVersion.mockResolvedValue('2.5.0');
+    useUpdateStore.setState({ availableVersion: '2.5.0', update: null });
+
+    await useUpdateStore.getState().installUpdate();
+
+    expect(mockCheck).not.toHaveBeenCalled();
+    expect(mockRelaunch).not.toHaveBeenCalled();
+    expect(useUpdateStore.getState().availableVersion).toBeNull();
+    expect(useUpdateStore.getState().downloading).toBe(false);
+  });
+
+  it('reconciles the pending version as soon as periodic checks start', async () => {
+    mockGetVersion.mockResolvedValue('2.5.0');
+    useUpdateStore.setState({ availableVersion: '2.5.0', update: null });
+
+    const stop = useUpdateStore.getState().startPeriodicChecks();
+    await vi.waitFor(() => expect(useUpdateStore.getState().availableVersion).toBeNull());
+    stop();
   });
 
   it('checks after 15 seconds and every 24 hours while running', async () => {

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -7,6 +7,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
+import { getVersion } from '@tauri-apps/api/app';
 import { flushPendingAutosave, getPendingAutosaveNoteId } from '@/lib/autosaveFlush';
 
 export const INITIAL_UPDATE_CHECK_DELAY_MS = 15 * 1000;
@@ -28,6 +29,8 @@ export interface UpdateState {
   checkForUpdate: () => Promise<void>;
   checkForUpdateSilently: () => Promise<void>;
   installUpdate: () => Promise<void>;
+  /** Drop a pending version the running app already has; see #125. */
+  reconcileWithInstalledVersion: () => Promise<void>;
   dismiss: () => void;
   setAutoCheck: (autoCheck: boolean) => void;
   startPeriodicChecks: () => () => void;
@@ -53,6 +56,7 @@ const initialUpdateState = {
   | 'checkForUpdate'
   | 'checkForUpdateSilently'
   | 'installUpdate'
+  | 'reconcileWithInstalledVersion'
   | 'dismiss'
   | 'setAutoCheck'
   | 'startPeriodicChecks'
@@ -60,6 +64,23 @@ const initialUpdateState = {
 
 export function isUpdateCheckStale(lastCheckedAt: number | null, now = Date.now()): boolean {
   return lastCheckedAt === null || now - lastCheckedAt >= UPDATE_CHECK_INTERVAL_MS;
+}
+
+/**
+ * True when `candidate` is a newer release than `current`. Dotted numeric
+ * parts compare numerically; anything unparseable counts as newer whenever the
+ * strings differ, so a format surprise can never hide a real update.
+ */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const a = candidate.split('.').map(Number);
+  const b = current.split('.').map(Number);
+  if (a.some(Number.isNaN) || b.some(Number.isNaN)) return candidate !== current;
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x > y;
+  }
+  return false;
 }
 
 export function selectHasPendingUpdate(state: Pick<UpdateState, 'availableVersion'>): boolean {
@@ -126,7 +147,26 @@ export const useUpdateStore = create<UpdateState>()(
 
         checkForUpdateSilently: () => runCheck(true),
 
+        reconcileWithInstalledVersion: async () => {
+          const pending = get().availableVersion;
+          if (!pending) return;
+          let installed: string;
+          try {
+            installed = await getVersion();
+          } catch {
+            return; // Outside Tauri (tests, previews) there is nothing to compare with.
+          }
+          if (!isNewerVersion(pending, installed) && get().availableVersion === pending) {
+            set({ availableVersion: null, update: null, dismissed: false, progress: 0 });
+          }
+        },
+
         installUpdate: async () => {
+          // On Windows the updater exits the process inside downloadAndInstall,
+          // so the clear that follows it below never runs there and the
+          // installed app comes back with the old version still pending
+          // (#125). Never act on a pending version the running app already has.
+          await get().reconcileWithInstalledVersion();
           let update = get().update;
           if (!update && !get().availableVersion) return;
 
@@ -211,6 +251,7 @@ export const useUpdateStore = create<UpdateState>()(
         },
 
         startPeriodicChecks: () => {
+          void get().reconcileWithInstalledVersion();
           const runAutomaticCheck = () => {
             if (!get().autoCheck) return;
             void get().checkForUpdateSilently();


### PR DESCRIPTION
## Summary

- On Windows, `tauri-plugin-updater` launches the installer and calls `std::process::exit(0)` inside `downloadAndInstall`, so the store's clear of the persisted pending version, which sits after that call and before `relaunch()`, never runs there. The installed app rehydrated with the previous version still marked available, and Update restarted it again (#125).
- `updateStore` gains `reconcileWithInstalledVersion`: a pending version that is not newer than `getVersion()` is dropped. It runs when periodic checks start and at the top of `installUpdate`, so a stale banner disappears at launch and Update can never reinstall or relaunch on a version already running. Outside Tauri the reconcile is a no-op.
- `isNewerVersion` compares dotted numeric versions; unparseable strings count as newer when they differ, so a real update is never hidden.
- Bump to `2.5.2` across the five manifests and date the changelog section.

## Verification

- New tests: numeric comparison; a pending version equal to the running one is dropped; a newer one is kept; `installUpdate` on a stale pending version does not check, download or relaunch; the reconcile runs when periodic checks start.
- `npm test`: 737 passed, 97 files. `npx tsc --noEmit`, lint (0 errors, 16 existing), format, tokens, build and size budget: clean. `node scripts/bump-version.mjs --check`: agree.
- Not exercised on Windows; the mechanism is read from the plugin source at `tauri-plugin-updater` 2.10.1, `updater.rs` line 865.

Closes #125