### PR TITLE
release: 2.6.0 — search answers from an index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [2.6.0] - 2026-09-04
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.5.2"
+version = "2.6.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.5.2"
+version = "2.6.0"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bump Moldavite from `2.5.2` to `2.6.0` across all five release manifests.
- Publish #128, the persistent keyword search index with its Settings block, and turn the Unreleased changelog section into the dated `2.6.0` section used by GitHub Releases and the in-app What's New popup.

## Verification

- `node scripts/bump-version.mjs --check`: all five manifests agree.
- `node scripts/extract-changelog.mjs 2.6.0` returns the section.
- #128 was green on all 17 CI jobs across Linux, Windows and macOS at its final head; this PR's CI is the evidence for the release commit.