### PR TITLE
release: 2.7.1 - Settings text sizing and welcome cursor lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Moldavite are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- Desktop Settings text now follows the S–XL font-size preference, with larger default labels and descriptions. (#130)
+- The welcome screen's asteroid cursor now follows the pointer immediately; only its decorative dots trail behind. (#130)
+
 ## [2.7.0] - 2026-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Moldavite are documented here.
 
-## [Unreleased]
+## [2.7.1] - 2026-09-06
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ and troubleshooting. iOS availability and its full guide will follow separately.
 
 ## What else it does
 
+Settings → Appearance offers S–XL text sizes for the editor and desktop Settings.
+
 Wiki-links with vault-wide rename, backlinks, a graph view, full-text and local
 semantic search, Apple and Google Calendar on a timeline, note locking with
 AES-256-GCM, encrypted export, a one-time Obsidian importer that copies rather

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -33,7 +33,8 @@
 - Pinned notes sit in a bar across the whole app, above the icon rail and index. Four stay on the bar and the rest collapse behind a count; drag or `alt`+arrow reorders them. Pins are the same list the Quick Switcher shows, so a note cannot be pinned in one surface and not the other. Opening a pinned note focuses the tab it is already in rather than opening a second copy.
 
 - The icon-rail monogram is Home: pending edits flush before it closes the active Index / Agenda / Search / Graph / Timeline surface and clears the active note, while every open tab remains available to resume
-- The welcome night sky offers a persisted, default-on asteroid cursor with weighted pointer lag, a three-dot trail, interactive-control feedback, and a single click impact ring. Settings → Layout can disable it; reduced-motion and coarse-pointer media preferences prevent it from mounting or hiding the native cursor
+- The welcome night sky offers a persisted, default-on asteroid cursor that follows the pointer immediately, with a three-dot trail, interactive-control feedback, and a single click impact ring. Settings → Layout can disable it; reduced-motion and coarse-pointer media preferences prevent it from mounting or hiding the native cursor
+- Desktop Settings text follows the S–XL font-size preference in Appearance, including section headings, descriptions, tabs, and controls. The default labels and descriptions are larger.
 
 ### Storage & Data Safety
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moldavite",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moldavite",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "@fontsource/instrument-serif": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moldavite",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A local-first note-taking app for connected thinking. Forged from cosmic impact.",
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "moldavite"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moldavite"
-version = "2.7.0"
+version = "2.7.1"
 description = "A local-first note-taking app for connected thinking"
 authors = ["Mauro Pereira"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Moldavite",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "identifier": "app.moldavite",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/ui/WelcomeScreen.test.tsx
+++ b/src/components/ui/WelcomeScreen.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useFolderStore, useNoteStore, useOverlayStore, useSettingsStore } from '@/stores';
 import { CONSTELLATIONS } from './constellations';
@@ -82,6 +82,25 @@ describe('WelcomeScreen layout settings', () => {
     });
 
     expect(container.querySelector('[data-testid="welcome-meteor"]')).toBeInTheDocument();
+  });
+
+  it('places the cursor at the pointer immediately, without waiting for animation frames', () => {
+    vi.useFakeTimers();
+    const view = render(
+      <WelcomeEmptyState onCreateToday={() => undefined} onCreateNote={() => undefined} />
+    );
+    const cursor = view.getByTestId('welcome-asteroid-cursor');
+
+    // MouseEvent supplies coordinates in jsdom, which has no PointerEvent constructor.
+    fireEvent(document, new MouseEvent('pointermove', { clientX: 120, clientY: 180 }));
+    expect(cursor.style.transform).toBe('translate3d(113px, 173px, 0) scale(1)');
+
+    const button = view.getByRole('button', { name: /new note/i });
+    fireEvent(button, new MouseEvent('pointermove', { bubbles: true, clientX: 400, clientY: 300 }));
+    expect(cursor.style.transform).toBe('translate3d(393px, 293px, 0) scale(1.16)');
+
+    act(() => vi.advanceTimersByTime(100));
+    expect(cursor.style.transform).toBe('translate3d(393px, 293px, 0) scale(1.16)');
   });
 
   it('does not mount the meteor scheduler when reduced motion is preferred', () => {

--- a/src/components/ui/WelcomeScreen.tsx
+++ b/src/components/ui/WelcomeScreen.tsx
@@ -11,7 +11,6 @@ const CONSTELLATION_FIELD = { width: 1200, height: 800 };
 export const BACKGROUND_STAR_COUNT = 180;
 const METEOR_CADENCE_MS = { min: 14_000, max: 22_000 };
 const METEOR_DURATION_MS = { min: 900, max: 1_200 };
-const ASTEROID_LERP = 0.18;
 const ASTEROID_SIZE = 14;
 const ASTEROID_TRAIL = [
   { size: 4, lerp: 0.12, opacity: 0.24 },
@@ -179,11 +178,9 @@ function AsteroidCursor() {
     if (!asteroid || !impact) return;
 
     const target = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-    const position = { ...target };
     const trail = ASTEROID_TRAIL.map(() => ({ ...target }));
     let frame = 0;
     let visible = false;
-    let overInteractive = false;
 
     document.documentElement.classList.add('welcome-asteroid-cursor-active');
 
@@ -229,9 +226,11 @@ function AsteroidCursor() {
     const handlePointerMove = (event: globalThis.PointerEvent) => {
       target.x = event.clientX;
       target.y = event.clientY;
-      overInteractive =
+      const overInteractive =
         event.target instanceof Element &&
         event.target.closest('button, a, [role="button"], [role="link"]') !== null;
+      // Keep the pointer on the click target; only the decorative trail eases behind it.
+      asteroid.style.transform = `translate3d(${target.x - ASTEROID_SIZE / 2}px, ${target.y - ASTEROID_SIZE / 2}px, 0) scale(${overInteractive ? 1.16 : 1})`;
       reveal();
     };
 
@@ -244,12 +243,8 @@ function AsteroidCursor() {
     };
 
     const tick = () => {
-      position.x += (target.x - position.x) * ASTEROID_LERP;
-      position.y += (target.y - position.y) * ASTEROID_LERP;
-      asteroid.style.transform = `translate3d(${position.x - ASTEROID_SIZE / 2}px, ${position.y - ASTEROID_SIZE / 2}px, 0) scale(${overInteractive ? 1.16 : 1})`;
-
       trail.forEach((dot, index) => {
-        const leader = index === 0 ? position : trail[index - 1];
+        const leader = index === 0 ? target : trail[index - 1];
         const spec = ASTEROID_TRAIL[index];
         dot.x += (leader.x - dot.x) * spec.lerp;
         dot.y += (leader.y - dot.y) * spec.lerp;

--- a/src/index.css
+++ b/src/index.css
@@ -1285,6 +1285,34 @@ time,
   box-shadow: none;
 }
 
+/* Desktop Settings follows the existing S–XL preference. Keep the scale
+   local to the dialog; iOS has its own Larger Text and input-size rules. */
+html:not([data-platform='mobile']) .settings-dialog {
+  --text-xs: calc(var(--editor-font-size) * 0.75);
+  --text-sm: calc(var(--editor-font-size) * 0.875);
+  --text-base: var(--editor-font-size);
+  --text-lg: calc(var(--editor-font-size) * 1.125);
+  --text-xl: calc(var(--editor-font-size) * 1.375);
+  --text-2xl: calc(var(--editor-font-size) * 1.5);
+  font-size: var(--text-sm);
+}
+
+html:not([data-platform='mobile']) .settings-dialog .settings-control-label {
+  font-size: var(--text-sm);
+}
+
+html:not([data-platform='mobile'])
+  .settings-dialog
+  :is(.settings-segmented-option, .text-\[10px\]) {
+  font-size: var(--text-xs);
+}
+
+html:not([data-platform='mobile'])
+  .settings-dialog
+  :is(.settings-section-heading, [role='tabpanel'] h3) {
+  font-size: var(--text-xs) !important;
+}
+
 /* The `:not()` arguments are wrapped in `:where()` on purpose: bare `:not(.x)`
    adds a class to the specificity, and at (0,4,0) this blanket reset outranked
    every `.settings-dialog .thing { background: … !important }` exception below


### PR DESCRIPTION
Moldavite 2.7.1 fixes the remaining Settings and cursor complaints from Linux testing. All five version manifests and the changelog are prepared for the patch release.

The follow-up in [#130](https://github.com/mauropereiira/Moldavite/issues/130#issuecomment-5560484240) confirms the RPM and AppImage launch successfully, but Settings text stays small when the font-size preference changes, and the welcome cursor feels sluggish.

Desktop Settings now uses the existing S–XL preference for its text, including headings, descriptions, tabs, controls, and preset/plugin badges. Default descriptions grow from 11px to 12px, and tab labels from 13px to 14px. The scale is scoped to desktop Settings so the mobile Larger Text rules keep their existing behavior.

The asteroid now moves to the pointer coordinates in the pointer event handler. Its three decorative dots still ease behind it. Previously the cursor itself covered only 18% of the remaining distance per animation frame, leaving the visible pointer behind its click target.

## Verification

All 19 checks pass on release commit `65ad431` in [CI run 34048130293](https://github.com/mauropereiira/Moldavite/actions/runs/34048130293), including Windows/Linux installer builds and the Fedora AppImage/RPM launch check.

- Added a cursor regression test and confirmed it fails before the fix and passes afterward. It checks immediate positioning, button hover feedback, and that later animation frames do not move the cursor away from the pointer.
- Version synchronization and changelog extraction for 2.7.1 pass.
- `npm test`: 817 tests pass.
- `cargo test --lib`: 460 tests pass.
- Production build, bundle-size check, token check, and formatting of changed source files pass. Lint passes with the existing 16 warnings.
- Rendered the actual Settings components with WebKitGTK 2.52.5 on Fedora 44 aarch64 under Xvfb, using an isolated fixture with native calls unavailable or stubbed. With the original stylesheet, headings/descriptions/tabs stay at 10/11/13px for every S–XL choice. With this change, they reach 15/15/17.5px at XL and update immediately when the control is clicked. All 13 tabs have no horizontal panel overflow at XL at both 1100×800 and the minimum 900×600 window size. Inspected both rendered Appearance screenshots.

Linux installer packaging is unchanged. This verifies the shared frontend in Fedora's renderer; it does not measure pointer latency on the reporter's hardware or install a new RPM/AppImage. Publish tag `v2.7.1` after this PR merges to deliver the fixes.
